### PR TITLE
NuCivic/dkan#365 - Removed notices for 'Gravatar integration', 'OG Extra...

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -164,4 +164,17 @@ function dkan_sitewide_update_status_alter(&$projects) {
   if (preg_match("/.*?(\d+)$/", $projects[$project]['existing_version'])) {
     $projects[$project]['recommended'] = $dkan_tag;
   }
+  
+  // Remove update notices.
+  $up_to_date_projects = array('gravatar', 'link_iframe_formatter', 'og_extras');
+  foreach ( $up_to_date_projects as $up_to_date_project ) {
+    
+    $projects[$up_to_date_project]['status'] = UPDATE_CURRENT; 
+    $project_name = $projects[$up_to_date_project]['title'];
+    $project_revision = $projects[$up_to_date_project]['existing_version'];
+    
+    if ( !drupal_installation_attempted() ) {
+      drupal_set_message( $project_name . ' is up to date. We are using ' . $project_revision . ' revision.' );
+    }
+  }  
 }


### PR DESCRIPTION
...s' and 'Link iframe formatter'.

See: https://github.com/NuCivic/dkan/issues/365

### Acceptance test
- [x] Login
- [x] Clear cache
- [x] Go to /admin/modules/update
- [x] There should be no update notices for the modules 'Gravatar integration', 'OG Extras' and 'Link iframe formatter'.
- [x] A Drupal message should be shown for each module saying: "X Module is up to date. We are using X revision (git hash)."