### PR TITLE
NuCivic/nucivic-internal#325 - Flushed image styles on install.

### DIFF
--- a/dkan.profile
+++ b/dkan.profile
@@ -49,4 +49,9 @@ function dkan_additional_setup() {
   unset($_SESSION['messages']['warning']);
   cache_clear_all();
 
+  // Flush image styles.
+  $image_styles = image_styles();
+  foreach ( $image_styles as $image_style ) {
+    image_style_flush($image_style);
+  }  
 }


### PR DESCRIPTION
Issue: https://github.com/NuCivic/nucivic-internal/issues/325

Note: The error messages were fixed in another commit. A flush of the image styles was added in order to make the image appear since in some cases a refresh was needed in order for the images to be shown.

### Acceptance test
- [ ] Git pull
- [ ] Install Dkan ( don't use drush ).
- [ ] No errors should be shown after install.
- [ ] Go to the Homepage.
- [ ] All images should be shown.