### PR TITLE
NuCivic/dkan#382 - Show notices only on available updates report.

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -104,7 +104,29 @@ function dkan_sitewide_restws_resource_info_alter(&$info) {
  * are checking github.
  */
 function dkan_sitewide_update_status_alter(&$projects) {
-    $project = 'dkan';
+  
+  // Remove update notices.
+  $up_to_date_projects = array('gravatar', 'link_iframe_formatter', 'og_extras');
+  foreach ( $up_to_date_projects as $up_to_date_project ) {
+    
+    if ( isset($projects[$up_to_date_project]) ) {
+      
+      $projects[$up_to_date_project]['status'] = UPDATE_CURRENT; 
+
+      if ( isset($projects[$up_to_date_project]['title']) &&
+           isset($projects[$up_to_date_project]['existing_version']) ) {
+        
+        $project_name = $projects[$up_to_date_project]['title'];
+        $project_revision = $projects[$up_to_date_project]['existing_version'];
+
+        if (current_path() == 'admin/reports/updates') {
+          drupal_set_message( $project_name . ' is up to date. We are using ' . $project_revision . ' revision.' );
+        }
+      }
+    }
+  } 
+  
+  $project = 'dkan';
   $org = 'nucivic';
 
   $tags = drupal_http_request('https://api.github.com/repos/NuCivic/' . $project . '/tags');
@@ -164,17 +186,4 @@ function dkan_sitewide_update_status_alter(&$projects) {
   if (preg_match("/.*?(\d+)$/", $projects[$project]['existing_version'])) {
     $projects[$project]['recommended'] = $dkan_tag;
   }
-  
-  // Remove update notices.
-  $up_to_date_projects = array('gravatar', 'link_iframe_formatter', 'og_extras');
-  foreach ( $up_to_date_projects as $up_to_date_project ) {
-    
-    $projects[$up_to_date_project]['status'] = UPDATE_CURRENT; 
-    $project_name = $projects[$up_to_date_project]['title'];
-    $project_revision = $projects[$up_to_date_project]['existing_version'];
-    
-    if ( !drupal_installation_attempted() ) {
-      drupal_set_message( $project_name . ' is up to date. We are using ' . $project_revision . ' revision.' );
-    }
-  }  
 }


### PR DESCRIPTION
See: https://github.com/NuCivic/dkan/issues/382

### Acceptance test
- [x] Git pull
- [x] Rebuild a dkan instance.
- [x] Login 
- [x] Go through admin pages.
- [x] The messages about the 3 modules being up to date should only appear on /admin/reports/updates