### PR TITLE
QA Only! Data API Button

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -10,10 +10,10 @@ projects[dkan_dataset][download][branch] = 7.x-1.x
 projects[dkan_datastore][subdir] = dkan
 projects[dkan_datastore][download][type] = git
 projects[dkan_datastore][download][url] = https://github.com/NuCivic/dkan_datastore.git
-projects[dkan_datastore][download][branch] = 7.x-1.x
+projects[dkan_datastore][download][branch] = make_data_api_button_smarter
 
 includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/7.x-1.x/dkan_dataset.make
-includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
+includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/make_data_api_button_smarter/dkan_datastore.make
 
 ; Contrib Modules
 projects[admin_menu][version] = 3.0-rc5


### PR DESCRIPTION
## QA Procedure

- [x] A user that's not logged in or does not have permissions to manage the datastore shouldn't see the DATA Api button
- [x] If the resource is added to the datastore any user should see the `DATA api button`
- [x] If a resource can be added to the datastore clicking the `DATA api button` will redirect the user to the `manage datastore` page
- [x] If a resource can't be added to the datastore then the button is hidden.
- [x] Delete this PR and branch when it's done and merge NuCivic/dkan_datastore#39
