### PR TITLE
QA Only. Updates in license block and facet rendering

### DIFF
--- a/dkan.info
+++ b/dkan.info
@@ -39,6 +39,7 @@ dependencies[] = entityreference
 dependencies[] = feeds
 dependencies[] = facetapi
 dependencies[] = facetapi_pretty_paths
+dependencies[] = facetapi_bonus
 dependencies[] = features
 dependencies[] = field_group_table
 dependencies[] = field_group

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -168,37 +168,26 @@ function dkan_sitewide_license_block() {
   else {
     if (isset($node->field_license) && $node->field_license) {
       $key = (isset($node->field_license[$node->language][0])) ? $node->field_license[$node->language][0] : $node->field_license[LANGUAGE_NONE][0];
-      $field = field_info_instance('node', 'field_license', 'dataset');
-      $raw_options = $field['widget']['settings']['available_options'];
-
-      foreach (explode("\n", $raw_options) as $option) {
-        $option = explode("|", $option);
-        $options[$option[0]] = $option[1];
-      }
-
       $key = $key['value'];
-      $label = $options[$key];
-
-      if (!$label) {
-        $output = $key;
+      $subscribed_values = dkan_dataset_content_types_license_subscribed_values();
+      if (isset($subscribed_values[$key])) {
+        $license = $subscribed_values[$key];
+        // dpm($subscribed_values);
+        if (isset($license['uri'])) {
+          $output = l($license['label'], $license['uri']) . '<br/>';
+          $output .= l(
+            '<img class="open-data" src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="[Open Data]">',
+            $license['uri'],
+            array('html' => TRUE)
+          );
+        }
+        else {
+          $output = $license['label'];
+        }
+        return $output;
       }
-      else if (strpos($key,'other') !== false) {
-        $output = $label;
-      }
-      else {
-        $output = l($label, 'http://opendefinition.org/licenses/' . $key) . '<br/>';
-        $output .= l(
-          '<img class="open-data" src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="[Open Data]">',
-          'http://opendefinition.org/licenses/' . $key,
-          array('html' => TRUE)
-        );
-      }
-
-      return $output;
     }
-    else {
-      return t('License not specified');
-    }
+    return t('License not specified');
   }
 }
 

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.facetapi_defaults.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.facetapi_defaults.inc
@@ -89,7 +89,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -109,6 +134,10 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'exclude' => '',
+    'regex' => 0,
+    'show_minimum_items' => 2,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:field_license'] = $facet;
 


### PR DESCRIPTION
# IMPORTANT
>
> DO NOT GET THIS IN AS IT IS. THE CODE HERE IS ADAPTED TO BRING UP A 
> QA SITE TO EVALUATE CHANGES IN THREE DIFFERENT COMPONENTS (REPOSITORIES).
> 

#447

### Acceptance Test

- [x] Wait for QA Site to get created
- [x] Do all the Testing bellow **(Using new options for license field, Services, etc)**
- [x] Ping me (@drkloc) if everything is working properly so i can remove all the hardcoding in the make files.

#### Using new options for license field

- [x] Edit a dataset node
- [x] There should be an ```Attribution NonCommercial NoDerivatives 4.0 International``` option for the license field
- [x] Set that license
- [x] Save the node
- [x] Both the block displaying the license option and the field should render a link to a page in the creative commons domain

#### Services

- [x] Go to data.json 
- [x] The link under the `license` field for the dataset above should be rendered using the creative commons domain
- [x] Go to the package_show implementation for the node above
- [x] The link under the `license_title` field should be should be rendered using the creative commons domain

#### Render licenses options that don't have a uri associated with them

- [x] Edit any dataset
- [x] Choose `Other`
- [x] Save and go to dataset page
- [x] Neither the license block or the license row in the table should be render as a link to anything

#### Using old options

- [x] Apply the same criteria as the ```Using new options for license field``` block for this acceptance test but pick a license under the open definition domain.

#### License Facet

- [x] go to /dataset/
- [x] The links within the block for the license facet should be rendered using the label options for the license instead of the key (```Creative Commons Non-Commercial (Any)``` instead of ```cc-nc``)
- [x] License facet should work as before

# IMPORTANT

>
> DO NOT GET THIS IN AS IT IS. THE CODE HERE IS ADAPTED TO BRING UP A 
> QA SITE TO EVALUATE CHANGES IN THREE DIFFERENT COMPONENTS (REPOSITORIES).
>
