### PR TITLE
NuCivic/dkan#436: Removed duplicated message.

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.info
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.info
@@ -44,4 +44,4 @@ features[variable][] = path_breadcrumbs_truncate_title_length
 features[variable][] = path_breadcrumbs_url_cleaning_method
 features[views_view][] = dkan_datasets
 features[views_view][] = dkan_groups
-mtime = 1419797634
+mtime = 1432688483

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
@@ -451,21 +451,23 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $display->content = array();
   $display->panels = array();
     $pane = new stdClass();
-    $pane->pid = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+    $pane->pid = 'new-93b93af5-e162-416f-813d-06e7be118cb7';
     $pane->panel = 'contentmain';
-    $pane->type = 'node';
-    $pane->subtype = 'node';
+    $pane->type = 'node_content';
+    $pane->subtype = 'node_content';
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'nid' => '%1',
       'links' => 1,
-      'leave_node_title' => 0,
-      'identifier' => '',
-      'build_mode' => 'full',
-      'link_node_title' => 0,
+      'no_extras' => 1,
       'override_title' => 0,
       'override_title_text' => '',
+      'identifier' => '',
+      'link' => 0,
+      'leave_node_title' => 0,
+      'build_mode' => 'full',
+      'context' => 'argument_entity_id:node_1',
+      'override_title_heading' => 'h2',
     );
     $pane->cache = array();
     $pane->style = array(
@@ -475,11 +477,11 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();
-    $pane->uuid = '5771913e-f897-497d-9d56-f76f6b207b18';
-    $display->content['new-5771913e-f897-497d-9d56-f76f6b207b18'] = $pane;
-    $display->panels['contentmain'][0] = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+    $pane->uuid = '93b93af5-e162-416f-813d-06e7be118cb7';
+    $display->content['new-93b93af5-e162-416f-813d-06e7be118cb7'] = $pane;
+    $display->panels['contentmain'][0] = 'new-93b93af5-e162-416f-813d-06e7be118cb7';
   $display->hide_title = PANELS_TITLE_PANE;
-  $display->title_pane = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+  $display->title_pane = '0';
   $handler->conf['display'] = $display;
   $export['node_view_panel_context_2'] = $handler;
 


### PR DESCRIPTION
The panel content for 'Resource' content type was modified. A "node being viewed" block was added instead of "Node loaded from %1".

### Acceptance test:
- [x] Pull branch and generate a Dkan instance based on the branch.
- [x] Open a resource page.
- [x] The 'Your file for this resource is not added to the datastore. Click "Manage Datastore" to import file into the datastore.' message should be shown only once and the resource should be rendered as expected.