### PR TITLE
547 resource redirect

### DIFF
--- a/test/features/dataset.feature
+++ b/test/features/dataset.feature
@@ -59,7 +59,7 @@ Feature: Datasets
       And I check "field_upload[und][0][view][grid]"
       And I press "edit-submit"
       Then I should see "Test Dataset"
-    When I click on "Test Resource Upload"
+    When I click "Test Resource Upload"
       And I wait for "5" seconds
     Then I should see "Test Resource Upload has been created"
       And I should see "Glendale Elementary School"

--- a/test/features/dataset.feature
+++ b/test/features/dataset.feature
@@ -58,6 +58,8 @@ Feature: Datasets
       And I attach the file "Polling_Places_Madison.csv" to "files[field_upload_und_0]" 
       And I check "field_upload[und][0][view][grid]"
       And I press "edit-submit"
+      Then I should see "Test Dataset"
+    When I click on "Test Resource Upload"
       And I wait for "5" seconds
     Then I should see "Test Resource Upload has been created"
       And I should see "Glendale Elementary School"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -87,4 +87,4 @@ Feature: Groups
       And I should see "Add resource"
     When I fill in "title" with "Test Resource Upload"
       And I press "edit-submit"
-    Then I should see "Test Resource Upload has been created"
+    Then I should see "Test Dataset"


### PR DESCRIPTION
Issue #547 

This is for tests and QA only.

The following is added to `dkan_dataset.module`

```
 /**
+ * Implements hook_node_insert().
+ */
+function dkan_dataset_node_insert($node) {
+  switch ($node->type) {
+    case 'resource':
+      if (isset($node->field_dataset_ref['und'][0]) && $node->op == 'Save') {
+        $dataset_nid = $node->field_dataset_ref['und'][0]['target_id'];
+        $dataset_node = node_load($dataset_nid);
+        $dataset_wrapper = entity_metadata_wrapper('node', $dataset_node);
+        // Save resource on dataset before redirect.
+        $dataset_wrapper->field_resources->set(array($node->nid));
+        $dataset_wrapper->save();
+        // Redirect to the dataset after saving the last node in the form.
+        drupal_goto('node/' . $dataset_nid);
+      }
+    break;
+  }
+}
```

It checks for the `op` parameter so does not redirect on non-form saves.
