### PR TITLE
570 jquery vbo update

### DIFF
--- a/build-dkan.make
+++ b/build-dkan.make
@@ -8,4 +8,4 @@ includes[core] = drupal-org-core.make
 projects[dkan][type] = profile
 projects[dkan][download][type] = git
 projects[dkan][download][url] = https://github.com/NuCivic/dkan.git
-projects[dkan][download][branch] = 7.x-1.x
+projects[dkan][download][branch] = 570_jquery_vbo_update

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -15,7 +15,7 @@ projects[dkan_datastore][download][type] = git
 projects[dkan_datastore][download][url] = https://github.com/NuCivic/dkan_datastore.git
 projects[dkan_datastore][download][branch] = 7.x-1.x
 
-includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/7.x-1.x/dkan_dataset.make
+includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/570_jquery_vbo_update/dkan_dataset.make
 includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
 
 projects[file_entity][patch][2308737] = https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9509141.patch


### PR DESCRIPTION
This should update jquery_update and views_bulk_operations to latest and secure releases.

This updates two lines of code in an unmade version of DKAN: https://github.com/NuCivic/dkan_dataset/commit/c95184e7df2d0300aff9f6a8834b9f76d2094f69