### PR TITLE
Update Drupal Extension (DE) to version 3.x on DKAN #697

### DIFF
--- a/test/behat.yml
+++ b/test/behat.yml
@@ -1,4 +1,6 @@
 default:
+  filters:
+    tags: ~@fixme
   extensions:
     Behat\MinkExtension\Extension:
       goutte: ~

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -1,21 +1,28 @@
 default:
-  filters:
-    tags: ~@fixme
+  suites:
+     default:
+        contexts:
+          - FeatureContext
+          - Drupal\DrupalExtension\Context\DrupalContext
+          - Drupal\DrupalExtension\Context\MinkContext
+          - Drupal\DrupalExtension\Context\MessageContext
+          - Drupal\DrupalExtension\Context\DrushContext
+  gherkin:
+    filters:
+      tags: ~@fixme
+  formatters:
+    pretty: true
   extensions:
-    Behat\MinkExtension\Extension:
-      goutte: ~
+    Behat\MinkExtension:
       selenium2: ~
-      base_url: http://127.0.0.1:8888
-      default_session: 'goutte'
-      javascript_session: 'selenium2'
-      files_path: "files"
-    Drupal\DrupalExtension\Extension:
-      blackbox: ~
+      goutte: ~
+    Drupal\DrupalExtension:
       drupal:
         drupal_root: 'drupal'
       drush:
         root: "drupal"
-      api_driver: "drupal"
+      api_driver: 'drupal'
+      # @todo fixup these regions for use with new theme. Updated navigation only
       region_map:
         content: ".region-content"
         toolbar: ".tabs--primary"
@@ -26,17 +33,28 @@ default:
         right header: "#header-right"
         right sidebar: "#column-right"
         dashboards: ".view-data-dashboards table tbody"
+        navigation: '.navigation-wrapper'
+        breadcrumb: '.breadcrumb'
+        left_sidebar: '.panel-col-first'
+        search_area: '.panel-col-last'
+        dropdown_links: '.comment-main .links.inline.dropdown-menu'
+        comment: '.comment-main'
       text:
         log_out: "Log out"
         log_in: "Log in"
-local:
+      selectors:
+        message_selector: '.alert'
+        error_message_selector: '.alert.alert-error'
+        success_message_selector: '.alert.alert-success'
+
+local-vm:
   extensions:
-    Behat\MinkExtension\Extension:
-      base_url: http://dkan.local
+    Behat\MinkExtension:
+      base_url: http://dkan_test.localhost
       selenium2:
         wd_host: http://127.0.0.1:4444/wd/hub
-    Drupal\DrupalExtension\Extension:
-      drupal:
-        drupal_root: '/var/www/dkan/webroot'
-      drush:
-        root: '/var/www/dkan/webroot'
+
+jenkins:
+  extensions:
+    Behat\MinkExtension:
+      base_url: http://dkan.local

--- a/test/composer.json
+++ b/test/composer.json
@@ -1,8 +1,8 @@
 {
-  "require": {
-    "drupal/drupal-extension": "1.0.2"
-  },
-  "config": {
-    "bin-dir": "bin/"
-  }
+    "require": {
+        "drupal/drupal-extension": "~3.0"
+    },
+    "config": {
+        "bin-dir": "bin/"
+    }
 }

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -255,6 +255,42 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
+   * Use xpath to find 'admin-menu' top bar.
+   * @todo maybe rewrite with simpler way then xpath?
+   *
+   * @Then I should see the administration menu
+   */
+  public function iShouldSeeTheAdministrationMenu()
+  {
+    $session = $this->getSession();
+    $page = $session->getPage();
+    $xpath = "//div[@id='admin-menu']";
+    // grab the element
+    $element = $page->find('xpath', $xpath);
+    if(!isset($element)){
+      throw new Exception(sprintf("Admin menu not found in this page."));
+    }
+  }
+
+  /**
+   * Use xpath to find format option.
+   * @todo maybe rewrite with simpler way then xpath?
+   *
+   * @Then I should have an :option text format option
+   */
+  public function iShouldHaveAnTextFormatOption($option)
+  {
+    $session = $this->getSession();
+    $page = $session->getPage();
+    $xpath = "//select[@name='body[und][0][format]']//option[@value='" . $option . "']";
+    // grab the element
+    $element = $page->find('xpath', $xpath);
+    if(!isset($element)){
+      throw new Exception(sprintf("Admin menu not found in this page."));
+    }
+  }
+
+  /**
    * @When I attach the drupal file :arg1 to :arg2
    *
    * Overrides attachFileToField() in Mink context to fix but with relative

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -1,48 +1,47 @@
 <?php
 
-use Drupal\DrupalExtension\Context\DrupalContext;
-use Behat\Behat\Context\BehatContext;
-use Behat\Behat\Context\Step\Given;
-use Behat\Behat\Context\Step\Then;
-use Symfony\Component\Process\Process;
+use Behat\Behat\Context\Context;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Behat\MinkExtension\Context\MinkContext;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use WebDriver\Key;
 
-require 'vendor/autoload.php';
-
-class FeatureContext extends DrupalContext
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
 {
-  // Keep track of created data dashboards so they can be cleaned up.
-  protected $data_dashboards = array();
 
   /**
    * @Given /^I scroll to the top$/
    */
-  public function iScrollToTheTop()
-  {
+  public function iScrollToTheTop() {
     $driver = $this->getSession()->getDriver();
     // Wait two seconds for admin menu if using js.
     if ($driver instanceof Selenium2Driver) {
-      $element = $driver . findElement(By . id("header"));
+      $element = $driver.findElement(By.id("header"));
       $actions = new Actions($driver);
-      $actions . moveToElement($element);
+      $actions.moveToElement($element);
       // actions.click();
-      $actions . perform();
+      $actions.perform();
     }
   }
 
   /**
    * @When /^I switch to the frame "([^"]*)"$/
    */
-  public function iSwitchToTheFrame($frame)
-  {
+  public function iSwitchToTheFrame($frame) {
     $this->getSession()->switchToIFrame($frame);
   }
 
   /**
    * @Then /^I should see the "([^"]*)" element in the "([^"]*)" region$/
    */
-  public function assertRegionElement($tag, $region)
-  {
+  public function assertRegionElement($tag, $region) {
     $regionObj = $this->getMainContext()->getRegion($region);
     $elements = $regionObj->findAll('css', $tag);
     if (!empty($elements)) {
@@ -54,8 +53,7 @@ class FeatureContext extends DrupalContext
   /**
    * @Given /^I switch out of all frames$/
    */
-  public function iSwitchOutOfAllFrames()
-  {
+  public function iSwitchOutOfAllFrames() {
     $this->getSession()->switchToIFrame();
   }
 
@@ -65,6 +63,16 @@ class FeatureContext extends DrupalContext
   public function iWaitForTheDialogBoxToAppear()
   {
     $this->getSession()->wait(2000, "jQuery('#user-login-dialog').children().length > 0");
+  }
+
+  /**
+   * @Then the Dataset search updates behind the scenes
+   */
+  public function theDatasetSearchUpdatesBehindTheScenes()
+  {
+    $index = search_api_index_load('datasets');
+    $items =  search_api_get_items_to_index($index);
+    search_api_index_specific_items($index, $items);
   }
 
   /**
@@ -85,19 +93,20 @@ class FeatureContext extends DrupalContext
   /**
    * @Given /^I am a "([^"]*)" of the group "([^"]*)"$/
    */
-  public function iAmAMemberOfTheGroup($role, $group_name)
-  {
-    $this->assertDrushCommandWithArgument('php-eval', "\"return db_query('SELECT nid FROM node WHERE title = \'$group_name\'')->fetchField();\"");
-    $option = $this->readDrushOutput();
-    $gid = trim(str_replace(array("'"), "", $option));
-    $user = $this->user;
-    $this->assertDrushCommandWithArgument('php-eval', "\"return db_query('SELECT uid FROM users WHERE name = \'$user->name\'')->fetchField();\"");
-    $option = $this->readDrushOutput();
-    $user_id = trim(str_replace(array("'"), "", $option));
-    $this->assertDrushCommandWithArgument('php-eval', "\"return db_query('SELECT rid FROM og_role WHERE name = \'$role\'')->fetchField();\"");
-    $option = $this->readDrushOutput();
-    $rid = trim(str_replace(array("'"), "", $option));
-    $this->assertDrushCommandWithArgument('og-add-user', "node $gid $rid $user_id");
+  public function iAmAMemberOfTheGroup($role, $group_name) {
+    $nid = db_query('SELECT nid FROM node WHERE title = :group_name', array(':group_name' =>  $group_name))->fetchField();
+
+    if ($account = $this->getCurrentUser()) {
+      og_group('node', $nid, array(
+        "entity type" => "user",
+        "entity" => $account,
+        "membership type" => OG_MEMBERSHIP_TYPE_DEFAULT,
+      ));
+    }
+    else {
+      throw new \InvalidArgumentException(sprintf('Could not find current user'));
+    }
+
   }
 
   /**
@@ -106,8 +115,7 @@ class FeatureContext extends DrupalContext
    *
    * @Given /^I fill in the chosen field "([^"]*)" with "([^"]*)"$/
    */
-  public function iFillInTheChosenFieldWith($field, $value)
-  {
+  public function iFillInTheChosenFieldWith($field, $value) {
     $session = $this->getSession();
     $page = $session->getPage();
     $xpath = $page->find('xpath', '//input[@value="' . $field . '"]');
@@ -130,8 +138,7 @@ class FeatureContext extends DrupalContext
   /**
    * @Given /^I click the chosen field "([^"]*)" and enter "([^"]*)"$/
    */
-  public function iClickTheChosenFieldAndEnter($field, $value)
-  {
+  public function iClickTheChosenFieldAndEnter($field, $value) {
     $session = $this->getSession();
     $page = $session->getPage();
     $field = $this->fixStepArgument($field);
@@ -153,19 +160,17 @@ class FeatureContext extends DrupalContext
     $title->click();
   }
 
-
   /**
    * Click some text.
    *
    * @When /^I click on the text "([^"]*)"$/
    */
-  public function iClickOnTheText($text)
-  {
+  public function iClickOnTheText($text) {
     $session = $this->getSession();
     $element = $session->getPage()->find(
       'xpath',
       $session->getSelectorsHandler()->selectorToXpath('xpath',
-        '//*[contains(text(), "' . $text . '")]')
+      '//*[contains(text(), "' . $text . '")]')
     );
     if (NULL === $element) {
       throw new \InvalidArgumentException(sprintf('Cannot find text: "%s"', $text));
@@ -178,8 +183,7 @@ class FeatureContext extends DrupalContext
    *
    * @Given /^I click map icon number "([^"]*)"$/
    */
-  public function iClickMapIcon($num)
-  {
+  public function iClickMapIcon($num) {
     $session = $this->getSession();
     $element = $session->getPage()->find(
       'xpath',
@@ -203,8 +207,7 @@ class FeatureContext extends DrupalContext
    *
    * @Given /^I fill in the autocomplete field "([^"]*)" with "([^"]*)"$/
    */
-  public function iFillInTheAutoFieldWith($field, $value)
-  {
+  public function iFillInTheAutoFieldWith($field, $value) {
     $session = $this->getSession();
     $field = $this->fixStepArgument($field);
     $value = $this->fixStepArgument($value);
@@ -228,8 +231,7 @@ class FeatureContext extends DrupalContext
   /**
    * @Given /^I empty the field "([^"]*)"$/
    */
-  public function iEmptyTheField($locator)
-  {
+  public function iEmptyTheField($locator) {
     $session = $this->getSession();
     $page = $session->getPage();
     $field = $page->findField($locator);
@@ -244,150 +246,50 @@ class FeatureContext extends DrupalContext
   }
 
   /**
-   * Determine if the a user is already logged in.
-   */
-  public function loggedIn()
-  {
-    $session = $this->getSession();
-    $session->visit($this->locatePath('/'));
-    $driver = $this->getSession()->getDriver();
-    // Wait two seconds for admin menu if using js.
-    if ($driver instanceof Selenium2Driver) {
-      $session->wait(2000);
-    }
-    // If a logout link is found, we are logged in. While not perfect, this is
-    // how Drupal SimpleTests currently work as well.
-    $element = $session->getPage();
-    return $element->findLink($this->getDrupalText('log_out'));
-  }
-
-  /**
-   * @Given /^groups memberships:$/
-   */
-  public function groupsMemberships(TableNode $table)
-  {
-    $memberships = $table->getHash();
-    foreach ($memberships as $membership) {
-      // Find group node.
-      $group_node = $membership['group'];
-      foreach ($this->nodes as $node) {
-        if ($node->type == 'group' && $node->title == $group_node) {
-          $group_node = $node;
-        }
-      }
-
-      // Subscribe nodes and users to group.
-      if (isset($membership['members'])) {
-        $members = explode(",", $membership['members']);
-        foreach ($this->users as $user) {
-          if (in_array($user->name, $members)) {
-            og_group(
-              'node',
-              $group_node->nid,
-              array(
-                'entity' => $user,
-                'entity_type' => 'user',
-                "membership type" => OG_MEMBERSHIP_TYPE_DEFAULT,
-              )
-            );
-            // Patch till i figure out why rules are not firing.
-            if ($user->name == 'editor') {
-              og_role_grant('node', $group_node->nid, $user->uid, 4);
-            }
-          }
-        }
-      }
-
-      if (isset($membership['nodes'])) {
-        $content = explode(",", $membership['nodes']);
-        foreach ($this->nodes as $node) {
-          if ($node->type != 'group' && in_array($node->title, $content)) {
-            og_group(
-              'node',
-              $group_node->nid,
-              array(
-                'entity' => $node,
-                'entity_type' => 'node',
-                'state' => OG_STATE_ACTIVE,
-              )
-            );
-          }
-        }
-      }
-    }
-  }
-
-  /**
+   * Wait for the given number of seconds. ONLY USE FOR DEBUGGING!
+   *
    * @Given /^I wait for "([^"]*)" seconds$/
    */
-  public function iWaitForSeconds($seconds)
-  {
-    $session = $this->getSession();
-    $session->wait($seconds * 1000);
+  public function iWaitForSeconds($arg1) {
+    sleep($arg1);
   }
 
   /**
-   * @Then /^I should see the administration menu$/
-   */
-  public function iShouldSeeTheAdministrationMenu()
-  {
-    $xpath = "//div[@id='admin-menu']";
-    // grab the element
-    $element = $this->getXPathElement($xpath);
-  }
-
-  /**
-   * @Then /^I should have an "([^"]*)" text format option$/
-   */
-  public function iShouldHaveAnTextFormatOption($option)
-  {
-    $xpath = "//select[@name='body[und][0][format]']//option[@value='" . $option . "']";
-    // grab the element
-    $element = $this->getXPathElement($xpath);
-  }
-
-  /**
-   * Returns an element from an xpath string
-   * @param  string $xpath
-   *   String representing the xpath
-   * @return object
-   *   A mink html element
-   */
-  protected function getXPathElement($xpath)
-  {
-    // get the mink session
-    $session = $this->getSession();
-    // runs the actual query and returns the element
-    $element = $session->getPage()->find(
-      'xpath',
-      $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath)
-    );
-    // errors must not pass silently
-    if (null === $element) {
-      throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $xpath));
-    }
-    return $element;
-  }
-
-  /**
-   * Take screenshot when step fails.
-   * Works only with Selenium2Driver.
+   * @When I attach the drupal file :arg1 to :arg2
    *
-   * @AfterStep
+   * Overrides attachFileToField() in Mink context to fix but with relative
+   * path.
    */
-  public function takeScreenshotAfterStep($event)
+  public function iAttachTheDrupalFileTo($path, $field)
   {
-    if (4 === $event->getResult()) {
-      $driver = $this->getSession()->getDriver();
-      if (!($driver instanceof Selenium2Driver)) {
-        // throw new UnsupportedDriverActionException('Taking screenshots is not supported by %s, use Selenium2Driver instead.', $driver);
-        return;
-      }
-      $screenshot = $driver->getScreenshot();
-      $file = 'screens/' . time() . ' ' . $event->getLogicalParent()->getTitle();
-      $file = $file . '.png';
-      file_put_contents($file, $screenshot);
+    $field = $this->fixStepArgument($field);
+
+    // Relative paths stopped working after selenium 2.44.
+    $offset = 'features/bootstrap/FeatureContext.php';
+    $dir =  __file__;
+    $test_dir = str_replace($offset, "", $dir);
+
+    $path = $test_dir . "files/" . $path;
+
+    $this->getSession()->getPage()->attachFileToField($field, $path);
+  }
+
+  /**
+   * Check toolbar if this->user isn't working.
+   */
+  public function getCurrentUser() {
+    if ($this->user) {
+      return $this->user;
     }
+    $session = $this->getSession();
+    $page = $session->getPage();
+    $xpath = $page->find('xpath', "//div[@class='content']/span[@class='links']/a[1]");
+    $userName = $xpath->getText();
+    $uid = db_query('SELECT uid FROM users WHERE name = :user_name', array(':user_name' =>  $userName))->fetchField();
+    if ($uid && $user = user_load($uid)) {
+      return $user;
+    }
+    return FALSE;
   }
 
   /************************************/
@@ -395,10 +297,9 @@ class FeatureContext extends DrupalContext
   /************************************/
 
   /**
-   * @Given data_dashboards:
+   * @Given Data Dashboard:
    */
-  public function addDataDashboard(TableNode $data_dashboards_table)
-  {
+  public function addDataDashboard(TableNode $data_dashboards_table) {
 
     // Map readable field names to drupal field names.
     $field_map = array(
@@ -410,12 +311,13 @@ class FeatureContext extends DrupalContext
       $node = new stdClass();
       $node->type = 'data_dashboard';
 
-      foreach ($data_dashboards_hash as $field => $value) {
+      foreach($data_dashboards_hash as $field => $value) {
 
-        if (isset($field_map[$field])) {
+        if(isset($field_map[$field])) {
           $drupal_field = $field_map[$field];
           $node->$drupal_field = $value;
-        } else {
+        }
+        else {
           throw new Exception(sprintf("Data Dashboard field %s doesn't exist, or hasn't been mapped. See FeatureContext::addDataDashboard for mappings.", $field));
         }
       }
@@ -427,16 +329,26 @@ class FeatureContext extends DrupalContext
 
   /**
    * Clean up generated content.
+   *
+   * @AfterScenario
    */
-  public function afterScenario($event)
-  {
-
-    parent::afterScenario($event);
-
+  public function afterScenario() {
     if (!empty($this->data_dashboards)) {
       foreach ($this->data_dashboards as $data_dashboard_id => $data_dashboard) {
         $this->getDriver()->nodeDelete($data_dashboard);
       }
     }
+  }
+
+  /**
+   * Returns fixed step argument (with \\" replaced back to ").
+   *
+   * @param string $argument
+   *
+   * @return string
+   */
+  public function fixStepArgument($argument)
+  {
+    return str_replace('\\"', '"', $argument);
   }
 }

--- a/test/features/data_dashboard.feature
+++ b/test/features/data_dashboard.feature
@@ -1,7 +1,7 @@
 Feature: Data Dashboard
 
   Background:
-    Given data_dashboards:
+    Given Data Dashboard:
       | title        |
       | Dashboard 01 |
       | Dashboard 02 |
@@ -11,38 +11,38 @@ Feature: Data Dashboard
     Given I am logged in as a user with the "administrator" role
     When I am on "admin/dkan/data-dashboards"
     Then I should see the text "Dashboard 01" in the "dashboards" region
-      And I should see the text "Dashboard 02" in the "dashboards" region
+    And I should see the text "Dashboard 02" in the "dashboards" region
 
   @api
   Scenario: Creation of data dashboard
     Given I am logged in as a user with the "administrator" role
-      And I am on "admin/dkan/data-dashboards"
-      And I click "Create Dashboard"
-      Then I should see "Create Data Dashboard"
+    And I am on "admin/dkan/data-dashboards"
+    And I click "Create Dashboard"
+    Then I should see "Create Data Dashboard"
     When I fill in "title" with "My new dashboard"
-      And I select the radio button "Radix Boxton" with the id "edit-layout-radix-boxton"
-      And I press "Save"
+    And I select the radio button "Radix Boxton" with the id "edit-layout-radix-boxton"
+    And I press "Save"
     Then I should see "Your Data Dashboard 'My new dashboard' has been created"
-      And I should see "Start adding content by clicking on the + sign on each panel"
+    And I should see "Start adding content by clicking on the + sign on each panel"
 
   @api
   Scenario: Edition of data dashboard
     Given I am logged in as a user with the "administrator" role
-      And I am on "/dashboard-01"
+    And I am on "/dashboard-01"
     When I click "Edit"
-      And I fill in "title" with "Edited Dashboard"
-      And I press "Save"
+    And I fill in "title" with "Edited Dashboard"
+    And I press "Save"
     Then I should see "Data Dashboard Edited Dashboard has been updated"
     When I am on "admin/dkan/data-dashboards"
     Then I should see the text "Edited Dashboard" in the "dashboards" region
-      And I should not see the text "Dashboard 01" in the "dashboards" region
+    And I should not see the text "Dashboard 01" in the "dashboards" region
 
   @api
   Scenario: Deletion of data dashboard
     Given I am logged in as a user with the "administrator" role
-      And I am on "/dashboard-01"
+    And I am on "/dashboard-01"
     When I click "Edit"
-      And I press "Delete"
+    And I press "Delete"
     Then I should see "Are you sure you want to delete Dashboard 01?"
     When I press "Delete"
     Then I should see "Data Dashboard Dashboard 01 has been deleted"

--- a/test/features/dataset.feature
+++ b/test/features/dataset.feature
@@ -1,16 +1,17 @@
-Feature: Datasets 
+Feature: Datasets
 
-  Scenario: Sharing the Dataset on Facebook 
+  @api
+  Scenario: Sharing the Dataset on Facebook
     Given I am on "/dataset/wisconsin-polling-places"
     When I click "Facebook"
     Then I should see "Facebook"
 
-  Scenario: Sharing the Dataset on Twitter 
+  Scenario: Sharing the Dataset on Twitter
     Given I am on "/dataset/wisconsin-polling-places"
     When I click "Twitter"
     Then I should see "Share a link with your followers"
 
-  Scenario: Seeing the License 
+  Scenario: Seeing the License
     Given I am on "/dataset/wisconsin-polling-places"
     When I click "Creative Commons Attribution"
     Then I should see "The Creative Commons Attribution license allows re-distribution and re-use of a licensed work"
@@ -18,59 +19,59 @@ Feature: Datasets
 
   Scenario: See Users datasets
 
-  @javascript
-  Scenario: Viewing the Dataset 
+    @javascript
+  Scenario: Viewing the Dataset
     Given I am on "/dataset/wisconsin-polling-places"
     Then I should see "Polling places in the state of Wisconsin"
-      And I should see "Explore Data"
-      And I should see "Dataset Info"
-      And I should see "Modified Date"
-      And I should see "Identifier"
+    And I should see "Explore Data"
+    And I should see "Dataset Info"
+    And I should see "Modified Date"
+    And I should see "Identifier"
     When I click "Madison Polling Places"
     Then I should see "This is a list and map of polling places in Madison, WI."
-      And I should see "Polling_Places_Madison.csv"
-      And I wait for "5" seconds
-      And I should see "Door Creek Church"
+    And I should see "Polling_Places_Madison.csv"
+    And I wait for "5" seconds
+    And I should see "Door Creek Church"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Create a dataset with a group as an authenticated user
     Given I am logged in as a user with the "authenticated user" role
-      And I am on "/node/add/group"
+    And I am on "/node/add/group"
     Then I should see "Create Group"
     When I fill in "title" with "Test Group"
-      And I press "Save"
+    And I press "Save"
     Then I should see "Test Group has been created"
     Given I am on "/node/add/dataset"
-      Then I should see "Create Dataset"
+    Then I should see "Create Dataset"
     When I fill in "title" with "Test Dataset"
-      And I fill in "body[und][0][value]" with "Test description"
-      And I click the chosen field "License Not Specified" and enter "Creative Commons Attribution"    
-      And I fill in the chosen field "Choose some options" with "Test Group"
-      And I press "Next: Add data"
+    And I fill in "body[und][0][value]" with "Test description"
+    And I click the chosen field "License Not Specified" and enter "Creative Commons Attribution"
+    And I fill in the chosen field "Choose some options" with "Test Group"
+    And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I fill in "title" with "Test Resource Link File"
-      And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/district_centerpoints_0.csv"
-      And I press "edit-another"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/district_centerpoints_0.csv"
+    And I press "edit-another"
     Then I should see "Test Resource Link File has been created"
-      And I should see "Add content"
+    And I should see "Add content"
     When I fill in "title" with "Test Resource Upload"
-      And I click "Upload a file"
-      And I attach the file "Polling_Places_Madison.csv" to "files[field_upload_und_0]" 
-      And I check "field_upload[und][0][view][grid]"
-      And I press "edit-submit"
-      And I wait for "5" seconds
+    And I click "Upload a file"
+    And I attach the file "Polling_Places_Madison.csv" to "files[field_upload_und_0]"
+    And I check "field_upload[und][0][view][grid]"
+    And I press "edit-submit"
+    And I wait for "5" seconds
     Then I should see "Test Resource Upload has been created"
-      And I should see "Glendale Elementary School"
+    And I should see "Glendale Elementary School"
     When I click "Test Dataset"
     Then I should see "Test Resource"
-      And I should see "Test Group"
-      And I should see "Creative Commons Attribution"
+    And I should see "Test Group"
+    And I should see "Creative Commons Attribution"
     When I click "Test Resource Link File"
-      And I wait for "1" seconds
+    And I wait for "1" seconds
     Then I should see "Farah"
     When I am on "dataset/test-dataset"
     Then I should see "Edit"
-      And I should see "Add Resource"
+    And I should see "Add Resource"
     When I am on "/dataset/wisconsin-polling-places"
-      Then I should not see "Edit"
-      And I should see "Add Resource"
+    Then I should not see "Edit"
+    And I should see "Add Resource"

--- a/test/features/dataset.feature
+++ b/test/features/dataset.feature
@@ -33,7 +33,7 @@ Feature: Datasets
     And I wait for "5" seconds
     And I should see "Door Creek Church"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Create a dataset with a group as an authenticated user
     Given I am logged in as a user with the "authenticated user" role
     And I am on "/node/add/group"

--- a/test/features/editor.feature
+++ b/test/features/editor.feature
@@ -1,6 +1,6 @@
 Feature: Datasets
 
-  @api @fixme
+  @api
   Scenario: Edit any group content
     Given I am logged in as a user with the "editor" role
       And I am on "/group/data-explorer-examples"

--- a/test/features/editor.feature
+++ b/test/features/editor.feature
@@ -1,7 +1,7 @@
 Feature: Datasets 
 
-  @api
-  Scenario: Edit any group content 
+  @api @fixme
+  Scenario: Edit any group content
     Given I am logged in as a user with the "editor" role
       And I am on "/group/data-explorer-examples"
     Then I should see "US National Foreclosure Statistics January 2012"

--- a/test/features/editor.feature
+++ b/test/features/editor.feature
@@ -1,4 +1,4 @@
-Feature: Datasets 
+Feature: Datasets
 
   @api @fixme
   Scenario: Edit any group content
@@ -11,7 +11,7 @@ Feature: Datasets
     Then I should see "Edit Data Explorer Examples"
 
   @api
-  Scenario: Edit any page content 
+  Scenario: Edit any page content
     Given I am logged in as a user with the "editor" role
       And I am on "/about"
     Then I should see "DKAN is the Drupal-based version of CKAN"
@@ -19,7 +19,7 @@ Feature: Datasets
     Then I should see "Edit About"
 
   @api
-  Scenario: Edit any dataset content 
+  Scenario: Edit any dataset content
     Given I am logged in as a user with the "editor" role
       And I am on "/dataset/us-national-foreclosure-statistics-january-2012"
     Then I should see "Add Resource"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -18,11 +18,11 @@ Feature: Groups
    Scenario: Request to join a group as an Auth User
     Given I am logged in as a user with the "authenticated user" role
     When I visit "group/geospatial-data-explorer-examples"
-      And I click "Request group membership"
-      Then I should see "Are you sure you want to join the group Geospatial Data Explorer Examples?"
-    
-  @api @javascript
-  Scenario: View Groups 
+    And I click "Request group membership"
+    Then I should see "Are you sure you want to join the group Geospatial Data Explorer Examples?"
+
+  @api @javascript @fixme
+  Scenario: View Groups
     Given I am on "/group/geospatial-data-explorer-examples"
       Then I should see "Wisconsin Polling Places"
       And I should see "Afghanistan Election Districts"
@@ -33,8 +33,8 @@ Feature: Groups
       Then I should see "Afghanistan Election Districts"
       And I should see "Wisconsin Polling Places"
 
-  @api @javascript
-  Scenario: Manage a group as an Editor 
+  @api @javascript @fixme
+  Scenario: Manage a group as an Editor
     Given I am logged in as a user with the "editor" role
       And I am on "/group/data-explorer-examples"
     Given users:

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -1,5 +1,5 @@
-Feature: Groups 
-  In order to know the groups are working 
+Feature: Groups
+  In order to know the groups are working
   As a website user
   I need to be able to view the group pages
 
@@ -24,14 +24,14 @@ Feature: Groups
   @api @javascript @fixme
   Scenario: View Groups
     Given I am on "/group/geospatial-data-explorer-examples"
-      Then I should see "Wisconsin Polling Places"
-      And I should see "Afghanistan Election Districts"
+    Then I should see "Wisconsin Polling Places"
+    And I should see "Afghanistan Election Districts"
     When I click "country-afghanistan (1)"
-      Then I should see "Afghanistan Election Districts"
-      And I should not see "Wisconsin Polling Places"
+    Then I should see "Afghanistan Election Districts"
+    And I should not see "Wisconsin Polling Places"
     When I click "country-afghanistan"
-      Then I should see "Afghanistan Election Districts"
-      And I should see "Wisconsin Polling Places"
+    Then I should see "Afghanistan Election Districts"
+    And I should see "Wisconsin Polling Places"
 
   @api @javascript @fixme
   Scenario: Manage a group as an Editor

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -14,14 +14,14 @@ Feature: Groups
     When I visit "dataset/wisconsin-polling-places"
     Then I should see "edit"
 
-   @api @javascript
-   Scenario: Request to join a group as an Auth User
+  @api @javascript
+  Scenario: Request to join a group as an Auth User
     Given I am logged in as a user with the "authenticated user" role
     When I visit "group/geospatial-data-explorer-examples"
     And I click "Request group membership"
     Then I should see "Are you sure you want to join the group Geospatial Data Explorer Examples?"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: View Groups
     Given I am on "/group/geospatial-data-explorer-examples"
     Then I should see "Wisconsin Polling Places"
@@ -36,7 +36,7 @@ Feature: Groups
   @api @javascript @fixme
   Scenario: Manage a group as an Editor
     Given I am logged in as a user with the "editor" role
-      And I am on "/group/data-explorer-examples"
+    And I am on "/group/data-explorer-examples"
     Given users:
       | name     | mail            | status |
       | teo      | teo@rocks.com   | 1      |
@@ -44,47 +44,47 @@ Feature: Groups
     When I click "Group" in the "toolbar" region
     Then I should see "Add group members."
     When I click "Add people"
-      And I wait for "3" seconds
+    And I wait for "3" seconds
     Then I should see "ADD A GROUP MEMBER TO DATA EXPLORER EXAMPLES"
     When I fill in "name" with "teo"
-      And I wait for "3" seconds
-      And I press "edit-submit"
-      And I wait for "3" seconds
-    Then I should see "teo has been added to the group Data Explorer Examples."
+    And I wait for "3" seconds
+    And I press "edit-submit"
+    And I wait for "3" seconds
+    Then I should see the success message "teo has been added to the group Data Explorer Examples."
     When I am on "/group/data-explorer-examples"
     Then I should see "Members"
     When I click "Members"
     Then I should see "teo"
     When I click "Group" in the "toolbar" region
-      And I wait for "1" seconds
-      And I click "People"
+    And I wait for "1" seconds
+    And I click "People"
     Then I should see "teo"
     When I check "edit-views-bulk-operations-1"
-      And I select "action::og_membership_delete_action" from "edit-operation"
-      And I press "edit-submit--2"
+    And I select "action::og_membership_delete_action" from "edit-operation"
+    And I press "edit-submit--2"
     Then I should see "Are you sure you want to perform Remove from group on the selected items?"
     When I press "edit-submit"
-      And I wait for "1" seconds
-    Then I should see "Performed Remove from group"
+    And I wait for "1" seconds
+    Then I should see the success message "Performed Remove from group"
     Given I am logged in as a user with the "authenticated user" role
-      And I am on "/node/add/group"
+    And I am on "/node/add/group"
     Then I should see "Create Group"
     When I fill in "title" with "Test Group"
-      And I press "Save"
+    And I press "Save"
     Then I should see "Test Group has been created"
     Given I am on "/node/add/dataset"
-      Then I should see "Create Dataset"
+    Then I should see "Create Dataset"
     When I fill in "title" with "Test Dataset"
-      And I fill in "body[und][0][value]" with "Test description"
-      And I click the chosen field "License Not Specified" and enter "Creative Commons Attribution"
-      And I fill in the chosen field "Choose some options" with "Test Group"
-      And I press "Next: Add data"
+    And I fill in "body[und][0][value]" with "Test description"
+    And I click the chosen field "License Not Specified" and enter "Creative Commons Attribution"
+    And I fill in the chosen field "Choose some options" with "Test Group"
+    And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I fill in "title" with "Test Resource Link File"
-      And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/district_centerpoints_0.csv"
-      And I press "edit-another"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/district_centerpoints_0.csv"
+    And I press "edit-another"
     Then I should see "Test Resource Link File has been created"
-      And I should see "Add resource"
+    And I should see "Add resource"
     When I fill in "title" with "Test Resource Upload"
-      And I press "edit-submit"
+    And I press "edit-submit"
     Then I should see "Test Resource Upload has been created"

--- a/test/features/panels.feature
+++ b/test/features/panels.feature
@@ -1,6 +1,6 @@
 Feature: Panels
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Custom Item" block to home page using panels ipe editor
     Given I am logged in as a user with the "administrator" role
       And I am on the homepage

--- a/test/features/profile.feature
+++ b/test/features/profile.feature
@@ -1,8 +1,8 @@
 # features/profile.feature
 Feature: Profile
-  To check a user profile
-  As a authenticated user
+  Check a user profile as an authenticated user.
 
+  @api @fixme
   Scenario: Check profile menu
     Given I am logged in as a user with the "authenticated user" role
     And I am on "/user"

--- a/test/features/role_storyteller.feature
+++ b/test/features/role_storyteller.feature
@@ -3,108 +3,108 @@ Feature: Testing storyteller role and permissions
   @api
   Scenario: Can see the administration menu
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And I am logged in as "storyteller"
     When I am on the homepage
     Then I should see the administration menu
 
   @api
   Scenario: Can see administration pages
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And I am logged in as "storyteller"
     When I am on "/admin"
     Then I should see "Content"
 
   @api
   Scenario: Access content overview
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And I am logged in as "storyteller"
     When I am on "/admin/content"
     Then I should see "About"
 
   @api
   Scenario: Create Story Content
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And I am logged in as "storyteller"
     When I am on "/node/add/dkan-data-story"
-      And I fill in "edit-title" with "DKAN Data Story Test Story Post"
-      And I fill in "body[und][0][value]" with "Test description"
-      And I press "Save"
+    And I fill in "edit-title" with "DKAN Data Story Test Story Post"
+    And I fill in "body[und][0][value]" with "Test description"
+    And I press "Save"
     Then I should see "Your DKAN Data Story 'DKAN Data Story Test Story Post' has been created"
 
   @api
   Scenario: Delete own story content
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And "dkan_data_story" nodes:
-        | title                           | author      | status   |
-        | DKAN Data Story Test Story Post | storyteller | 1        |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And "dkan_data_story" content:
+      | title                           | author      | status   |
+      | DKAN Data Story Test Story Post | storyteller | 1        |
+    And I am logged in as "storyteller"
     When I am on "admin/content"
-      And I click "delete"
-      And I press "Delete"
+    And I click "delete"
+    And I press "Delete"
     Then I should see "DKAN Data Story Test Story Post has been deleted"
 
   @api
   Scenario: Edit own story content
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And "dkan_data_story" nodes:
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And "dkan_data_story" content:
       | title                           | author      | status   |
       | DKAN Data Story Test Story Post | storyteller | 0        |
-      And I am logged in as "storyteller"
+    And I am logged in as "storyteller"
     When I am on "story/dkan-data-story-test-story-post"
-      When I click "Edit"
+    When I click "Edit"
     And I fill in "body[und][0][value]" with "Test description Update"
     And I press "Save"
     Then I should see "DKAN Data Story Test Story Post has been updated"
 
-#  @api @javascript
-#  Scenario: Add widget to my story
-#    Given users:
-#      | name         | mail                  | status     | roles     |
-#      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-#    And "dkan_data_story" nodes:
-#      | title                           | author      | status   |
-#      | DKAN Data Story Test Story Post | storyteller | 0        |
-#    And I am logged in as "storyteller"
-#      When I am on "story/dkan-data-story-test-story-post"
-#      And I click "Customize this page"
-#      And I click "Add new pane"
-#      Then I should see "Please select a category from the left"
-#    When I click on the text " Add map"
-#      And I fill in "field_map_address[und][0][value]" with "175th St, Jamaica, NY 11433, USA"
-#      And I fill in "field_map_information[und][0][value]" with "map example"
-#      And I press "Finish"
-#      And I press "Save"
-#      Then I should see "map example"
+    #  @api @javascript
+    #  Scenario: Add widget to my story
+    #    Given users:
+    #      | name         | mail                  | status     | roles     |
+    #      | storyteller  | storyteller@test.com  | 1          | storyteller |
+    #    And "dkan_data_story" content:
+    #      | title                           | author      | status   |
+    #      | DKAN Data Story Test Story Post | storyteller | 0        |
+    #    And I am logged in as "storyteller"
+    #      When I am on "story/dkan-data-story-test-story-post"
+    #      And I click "Customize this page"
+    #      And I click "Add new pane"
+    #      Then I should see "Please select a category from the left"
+    #    When I click on the text " Add map"
+    #      And I fill in "field_map_address[und][0][value]" with "175th St, Jamaica, NY 11433, USA"
+    #      And I fill in "field_map_information[und][0][value]" with "map example"
+    #      And I press "Finish"
+    #      And I press "Save"
+    #      Then I should see "map example"
 
   @api @javascript
   Scenario: Use text format filtered_html
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And I am logged in as "storyteller"
     When I am on "/node/add/dkan-data-story"
     Then I should have an "html" text format option 
 
   @api
   Scenario: View own unpublished content
     Given users:
-      | name         | mail                  | status     | roles     |
-      | storyteller  | storyteller@test.com  | 1          | 132006037 |
-      And "dkan_data_story" nodes:
-        | title          | author      | status   |
-        | test Story Post | storyteller | 0        |
-      And I am logged in as "storyteller"
+      | name        | mail                 | status | roles       |
+      | storyteller | storyteller@test.com | 1      | storyteller |
+    And "dkan_data_story" content:
+      | title           | author      | status |
+      | test Story Post | storyteller | 0      |
+    And I am logged in as "storyteller"
     When I am on "/admin/content"
     Then I should see "test Story Post"

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -20,6 +20,7 @@ Feature: Search
     When I click "politics"
     Then I should not see "Wisconsin Polling Places"
 
+    @fixme
   Scenario: Filter by facet group
     Given I am on "/dataset"
     When I click "Data Explorer Examples"

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -3,7 +3,7 @@ Feature: Widgets
   Background:
     Given I am logged in as a user with the "administrator" role
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Link Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -17,7 +17,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "Link example"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New File Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -30,7 +30,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "actionplan.pdf"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Image Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -44,7 +44,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "dkan logo image test"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Text Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -57,7 +57,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "text example"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Map Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -71,7 +71,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "map example"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Table Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -116,7 +116,7 @@ Feature: Widgets
     #   And I press "Save"
     # Then I should see "Testing video"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Spotlight Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -131,7 +131,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "First spot" in the "content"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Submenu Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -143,7 +143,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "About" in the "content"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Content List Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -159,7 +159,7 @@ Feature: Widgets
     Then I should see "Afghanistan Election Districts"
       And I should see "Posted by admin"
 
-  @api @javascript
+  @api @javascript @fixme
   Scenario: Adds "New Content Item Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -3,7 +3,7 @@ Feature: Widgets
   Background:
     Given I am logged in as a user with the "administrator" role
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Link Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -30,7 +30,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "actionplan.pdf"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Image Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -44,7 +44,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "dkan logo image test"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Text Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -57,7 +57,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "text example"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Map Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -71,7 +71,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "map example"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Table Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -131,7 +131,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "First spot" in the "content"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Submenu Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -143,7 +143,7 @@ Feature: Widgets
       And I press "Save"
       Then I should see "About" in the "content"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Content List Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"
@@ -159,7 +159,7 @@ Feature: Widgets
     Then I should see "Afghanistan Election Districts"
       And I should see "Posted by admin"
 
-  @api @javascript @fixme
+  @api @javascript
   Scenario: Adds "New Content Item Widget" block to home page using panels ipe editor
     Given I am on the homepage
       Then I should see "Customize this page"


### PR DESCRIPTION
@acouch here we go:

Work done for NuCivic/internal#697
Based on NuCivic/dkan#545. New branch to avoid merge conflicts.
[test/behat.yml](https://github.com/NuCivic/dkan/compare/NuCivic:7.x-1.x...rhabbachi:697_update_drupal_extensions?expand=1#diff-6f8a1f9f8525608ada3742a01569046d) is based on data_starter

**Tests failing before starting the upgrade**
Tagged with the "fixme" tag in behat.yml to skip.

* Feature: Groups
	a. Scenario: Manage a group as an Editor

* Feature: Panels
	a. Scenario: Adds "New Custom Item" block to home page using panels ipe editor

* Feature: Profile
	a. Scenario: Check profile menu

* Feature: Search
	a. Scenario: Filter by facet group

* Feature: Widgets
	a. Scenario: Adds "New File Widget" block to home page using panels ipe editor
	b. Scenario: Adds "New Spotlight Widget" block to home page using panels ipe editor

**Notes**
1. Couple of small fixes for some custom steps were needed. I tried to stick to the testing methods used and just do a 1 to 1 port. Generally some custom steps can be worked on to match the testing techniques we are using in data_starter. I think as a general direction we want to have dkan and data_starter Behat tests and code to be similar if not unified. 

2. Some tests (especially in widgets.feature) all required to add a waiting step (ie. "I wait for 4 seconds") when an jQuery related action (animation/UI loading) was involved. Maybe my machine is a bit slow? Or the DE upgrade bring some performances enhancements that break some assumptions? I did not commit those "waiting" steps and wanted to check with you first.

3. Also went ahead as well and made some small formatting changes to match the one we are using on data_starter.