### PR TITLE
Fix Data Extent Map

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -134,12 +134,8 @@ function dkan_sitewide_data_extent_block() {
        $geojson = drupal_json_encode(leaflet_widget_geojson_feature_collection($features));
        $output = "var dataExtent = " . $geojson;
        $output .= "; var map = L.map('map');
-        L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
-        maxZoom: 7,
-        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors, ' +
-        '<a href=\"http://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA</a>, ' +
-        'Imagery © <a href=\"http://mapbox.com\">Mapbox</a>',
-        id: 'examples.map-20v6611k'
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a>'
         }).addTo(map);
 
         var geojson = L.geoJson(dataExtent).addTo(map);


### PR DESCRIPTION
Mapbox changed their example tile so the data extent map doesn't work. This fixes it.
<img width="300" alt="screen shot 2015-08-14 at 3 22 52 am" src="https://cloud.githubusercontent.com/assets/512243/9270007/d9e5a5e8-4233-11e5-81db-883b9517fae1.png">