### PR TITLE
Update to 7.39

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = core
-projects[drupal][version] = "7.38"
+projects[drupal][version] = "7.39"
 
 ; Use vocabulary machine name for permissions
 ; http://drupal.org/node/995156


### PR DESCRIPTION
This updates to Drupal core version 7.39.

We should merge if tests pass.