### PR TITLE
NuCivic/dkan#652: added patch in restws to fix resource format extensions.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -117,6 +117,7 @@ projects[r4032login][version] = 1.7
 projects[rules][version] = 2.3
 
 projects[restws][version] = 2.3
+projects[restws][patch][2484829] = https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch
 
 projects[schema][version] = 1.2
 


### PR DESCRIPTION
Change in drupal-org.make to add a patch to restws and fix the drupal upgrade issue about specifying the resource format via URL.