### PR TITLE
NuCivic/internal#703 Add Dkan Workflow to DKAN.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ modules/contrib
 modules/nucivic
 modules/dkan/dkan_dataset
 modules/dkan/dkan_datastore
+modules/dkan/dkan_workflow
 themes/contrib
 webroot
 test/vendor

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -17,6 +17,14 @@ projects[dkan_datastore][download][type] = git
 projects[dkan_datastore][download][url] = https://github.com/NuCivic/dkan_datastore.git
 projects[dkan_datastore][download][branch] = 7.x-1.x
 
+; dkan_workflow not (yet?) in DO. Specify project type.
+projects[dkan_workflow][type] = module
+projects[dkan_workflow][subdir] = dkan
+projects[dkan_workflow][download][type] = git
+projects[dkan_workflow][download][url] = https://github.com/NuCivic/dkan_workflow.git
+projects[dkan_workflow][download][branch] = 7.x-1.x
+includes[dkan_workflow_make] = https://raw.githubusercontent.com/NuCivic/dkan_workflow/7.x-1.x/dkan_workflow.make
+
 ; NuCivic Visualization tools
 
 projects[visualization_entity][download][type] = git


### PR DESCRIPTION
Ref NuCivic/internal#703

Add Dkan Workflow to DKAN as optional dependency.

Just enable the dkan_workflow from Structure > Features and use the workflow_* roles to get access to the workflow functionality.

This is for testing purposes and not meant to be merged before the new release.