### PR TITLE
Disable og_extras_members on DKAN install

### DIFF
--- a/dkan.profile
+++ b/dkan.profile
@@ -170,6 +170,7 @@ function dkan_misc_variables_set(&$context) {
       'feeds_log' => TRUE,
       'groups_page' => TRUE,
       'og_extras_groups' => TRUE,
+      'og_extras_members' => TRUE,
       'dataset' => TRUE,
   );
   variable_set('views_defaults', $views_disable);


### PR DESCRIPTION
ref NuCivic/healthdata#466

## Acceptance test
- [x] On a fresh DKAN install, go to node/3/members. The active view should be dkan_og_extras_members, not og_extras_members.