### PR TITLE
NuCivic/internal#877: visualization embed

### DIFF
--- a/dkan.info
+++ b/dkan.info
@@ -91,6 +91,7 @@ dependencies[] = views_ui
 dependencies[] = views_bulk_operations
 dependencies[] = visualization_entity
 dependencies[] = visualization_entity_charts
+dependencies[] = visualization_entity_embed
 
 ; Open data
 dependencies[] = entity_rdf

--- a/dkan.profile
+++ b/dkan.profile
@@ -40,6 +40,7 @@ function dkan_additional_setup() {
           array('dkan_colorizer_reset', array()),
           array('dkan_misc_variables_set', array()),
           array('dkan_set_adminrole', array()),
+          array('dkan_enable_visualization_entity_embed', array()),
       ),
   );
 }
@@ -184,4 +185,13 @@ function dkan_misc_variables_set(&$context) {
 function dkan_set_adminrole(&$context) {
   $context['message'] = t('Setting user admin role');
   dkan_sitewide_roles_perms_set_admin_role();
+}
+
+/**
+ * Enable visualization entity embed.
+ * @param $context
+ */
+function dkan_enable_visualization_entity_embed(&$context) {
+  $context['message'] = t('Enabling visualization_entity_embed');
+  module_enable(array('visualization_entity_embed'));
 }

--- a/dkan.profile
+++ b/dkan.profile
@@ -40,7 +40,6 @@ function dkan_additional_setup() {
           array('dkan_colorizer_reset', array()),
           array('dkan_misc_variables_set', array()),
           array('dkan_set_adminrole', array()),
-          array('dkan_enable_visualization_entity_embed', array()),
       ),
   );
 }
@@ -185,13 +184,4 @@ function dkan_misc_variables_set(&$context) {
 function dkan_set_adminrole(&$context) {
   $context['message'] = t('Setting user admin role');
   dkan_sitewide_roles_perms_set_admin_role();
-}
-
-/**
- * Enable visualization entity embed.
- * @param $context
- */
-function dkan_enable_visualization_entity_embed(&$context) {
-  $context['message'] = t('Enabling visualization_entity_embed');
-  module_enable(array('visualization_entity_embed'));
 }

--- a/test/features/vis_entity_embeds.feature
+++ b/test/features/vis_entity_embeds.feature
@@ -1,0 +1,34 @@
+  Feature: Visualization entity embed test.
+
+    @api
+    Scenario: Module visualization entity embed enabled by default
+        Given "dkan_data_story" content:
+            | title                           | author      | status   |
+            | DKAN Data Story Test Story Post | admin       | 0        |
+        And "ve_chart" content:
+            | title                           | author      | status   |
+            | Viz Entity Test Chart           | admin       | 0        |
+        And I am logged in as a user with the "administrator" role
+        When I am on "story/dkan-data-story-test-story-post"
+        And I wait for "Customize this page"
+        And I click "Customize this page"
+        And I wait for "Add new pane"
+        And I click "Add new pane"
+        And I wait for "Please select a category from the left"
+        Then I should see "Visualizations"
+
+    @api
+    Scenario: Use autocomplete field when adding viz_entity to a data story
+        When I click "Visualizations"
+        Then I wait for "Visualization embed"
+        When I click "Visualization embed"
+        Then I should see "Configure new Visualization embed"
+        When I fill in "edit-local-source" with "Viz"
+        And I wait for "2" seconds
+        Then I should see "Viz Entity Test Chart"
+
+    @api
+    Scenario: Embed ve_chart to a data story
+        When I click "Viz Entity Test Chart"
+        And I press "edit-return"
+        Then I should see "Visualization embed"


### PR DESCRIPTION
This responds to the issue https://github.com/NuCivic/internal/issues/877

Acceptance test:
- [x] Module visualization_entity_embed should be enable by default.
- [x] Test passes (for this we need this PR https://github.com/NuCivic/visualization_entity/pull/34 merged because the tests created here depends on that.)