### PR TITLE
Fixed problem with cron bug on colorizer

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -51,7 +51,7 @@ projects[bueditor][patch][1931862] = http://drupal.org/files/dont-render-buedito
 
 projects[colorizer][version] = 1.7
 projects[colorizer][patch][2227651] = https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
-projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/bug_system_cron_delete_current_css.patch
+projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-2.patch
 
 projects[conditional_styles][version] = 2.2
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -51,6 +51,7 @@ projects[bueditor][patch][1931862] = http://drupal.org/files/dont-render-buedito
 
 projects[colorizer][version] = 1.7
 projects[colorizer][patch][2227651] = https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
+projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/bug_system_cron_delete_current_css.patch
 
 projects[conditional_styles][version] = 2.2
 


### PR DESCRIPTION
## Description:
This fixes the bug described here: https://github.com/NuCivic/internal/issues/878.
Every time the cron is executed, then the page styles are broken because of a file not found.

## Steps to reproduce:
- [x] Set cron to 1 ~~hour~~  minute with `drush vset cron_safe_threshold 60`.
- [x] Wait 1 ~~hour~~ minute and see if drupal cron is executed.
- [x] When the cron is run the styles go away (the main navbar doesn't have colors unless you hover it).

## Acceptance criteria:
- [x] Set cron to 1 ~~hour~~  minute with `drush vset cron_safe_threshold 60`.
- [x] Wait 1 ~~hour~~ minute and see if drupal cron is executed.
- [x] Once the cron is run, the styles should continue in the page.