### PR TITLE
Enable proboci QA site builds.

### DIFF
--- a/.probo.yml
+++ b/.probo.yml
@@ -1,0 +1,7 @@
+steps:
+  - name: Site Setup
+    plugin: Drupal
+    makeFile: 'build-dkan.make'
+    profileName: 'dkan'
+    runInstall: true
+    clearCaches: true

--- a/.probo.yml
+++ b/.probo.yml
@@ -4,4 +4,5 @@ steps:
     makeFile: 'build-dkan.make'
     profileName: 'dkan'
     runInstall: true
-    clearCaches: true
+  - name: Fix Files Folder Permissions
+    command: 'chmod -R 777 /var/www/html/sites/default/files && drush cc all'


### PR DESCRIPTION
Enables QA site builds.

Ref: NuCivic/pluto#116.

### Acceptance
- [ ] PRs get a QA site on the probo servers on PR and on pushes to the PR branch.