### PR TITLE
Bug counting dataset on view groups

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -10,7 +10,7 @@ defaults[projects][subdir] = contrib
 projects[dkan_dataset][subdir] = dkan
 projects[dkan_dataset][download][type] = git
 projects[dkan_dataset][download][url] = https://github.com/NuCivic/dkan_dataset.git
-projects[dkan_dataset][download][branch] = 7.x-1.x
+projects[dkan_dataset][download][branch] = problem_counting_dataset_groups_777
 
 projects[dkan_datastore][subdir] = dkan
 projects[dkan_datastore][download][type] = git


### PR DESCRIPTION
## Description
If we add a dataset to 2 groups or more to the field EVA (using og_count) show a incorrect value. For example:
We have 2 groups and we add a dataset linked with both groups. Then on the section groups we will see 2 dataset instead 1.


## Steps to Reproduce

Create a dataset and associate with 2 groups. On the groups section the total dataset count is a bad value.

## Acceptance Criteria

Create a dataset and associate with 2 groups. On the groups section the total datasets should be fine.

Related with #777 and CIVIC-161