### PR TITLE
Fix colorizer fix throwing errors during installation process

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -51,7 +51,7 @@ projects[bueditor][patch][1931862] = http://drupal.org/files/dont-render-buedito
 
 projects[colorizer][version] = 1.7
 projects[colorizer][patch][2227651] = https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
-projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-2.patch
+projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-3.patch
 
 projects[conditional_styles][version] = 2.2
 


### PR DESCRIPTION
The colorizer fix we introduce is throwing some warnings during the installation process. I've reviewed how the colorizer fix works and I've created another patch following the colorizer creator suggestions.

Acceptance test
---------------------
- [ ] Install dkan using this branch
- [ ] colorizer warnings shouldn't appear
- [ ] Run: drush -y vset cron_safe_threshold 0
- [ ] Go to the homepage
- [ ] Colorizer effects should be working as expected (menu bar background in blue and hero image overlay)

Drupal thread is here https://www.drupal.org/node/2599298#comment-10654038