### PR TITLE
Add patch to remove radix warning in forms

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -152,6 +152,7 @@ projects[nuboot_radix][type] = theme
 
 projects[radix][type] = theme
 projects[radix][version] = 3.0-rc4
+projects[radix][patch][2557385] = https://www.drupal.org/files/issues/radix-undefined-theme-2557385-9.patch
 
 projects[field_reference_delete][download][version] = 7.x-1.0-beta1
 


### PR DESCRIPTION
This removes an annoying warning in some drupal forms. 

<img width="903" alt="screen shot 2015-12-09 at 7 28 06 pm" src="https://cloud.githubusercontent.com/assets/381224/11701373/ea4237a4-9ead-11e5-85c4-a8f24a283736.png">

Acceptance test
-----------------------
- [x] Install dkan using this branch
- [x] Go to /user/1/edit
- [x] Error shouldn't be displayed