### PR TITLE
Fixed issue: font is still used after being disabled (CIVIC-512).

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -72,6 +72,8 @@ projects[fieldable_panels_panes][version] = 1.7
 projects[honeypot][version] = 1.17
 
 projects[fontyourface][version] = 2.8
+projects[fontyourface][patch][2644694] = https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch
+
 
 projects[imagecache_actions][download][type] = git
 projects[imagecache_actions][download][url] = "http://git.drupal.org/project/imagecache_actions.git"


### PR DESCRIPTION
NOTE: Continued here: https://github.com/NuCivic/dkan/pull/865

ref https://jira.govdelivery.com/browse/CIVIC-512
### Acceptance
1. Go to 'admin/appearance/fontyourface/browse/google_fonts_api'.
2. Enable a font, any font.
3. Go to "Enabled fonts" tab.
4. Choose "Everything (Body)" from the font CSS selector dropdown list.
5. Save.
6. Go to "Browse Fonts" tab and disable the font.
7. Reload the page, drupal default font should be used on the page.
