### PR TITLE
Make probo admin password admin.

### DIFF
--- a/.probo.yml
+++ b/.probo.yml
@@ -4,5 +4,6 @@ steps:
     makeFile: 'build-dkan.make'
     profileName: 'dkan'
     runInstall: true
+    installArgs: "--account-pass='admin'"
   - name: Fix Files Folder Permissions
     command: 'chmod -R 777 /var/www/html/sites/default/files && drush cc all'


### PR DESCRIPTION
As a QAer I don't want to have to look up the password of a QA site.

Acceptance:
==========

- [ ] Log in to QA site using admin/admin credentials: https://37695544-66a0-41e4-a344-549ec2708c08.probo.build/.