### PR TITLE
Update dkan_groups view to display 12 items per page rather than 10

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.views_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.views_default.inc
@@ -332,7 +332,7 @@ function dkan_sitewide_panels_views_default_views() {
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '12';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['pager']['options']['id'] = '1';
   $handler->display->display_options['pager']['options']['quantity'] = '9';


### PR DESCRIPTION
The dkan groups view is a 3 column display, displaying 10 items on a page leaves one orphaned group on the last row by itself.

![screenshot_12_7_15__2_35_pm](https://cloud.githubusercontent.com/assets/314172/12192340/54fe558a-b5a3-11e5-98be-09a7ca61796b.png)
