### PR TITLE
Make facets expanded if in use on search page

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
@@ -5,3 +5,32 @@
  */
 
 include_once 'dkan_sitewide_panels.features.inc';
+
+/**
+ * Implements hook_preprocess_panels_style_collapsible().
+ *
+ * Ensures facets are expanded if in use.
+ */
+function dkan_sitewide_panels_preprocess_panels_style_collapsible(&$variables) {
+  // Find out if the pane matches a facet in the query string; un-collapse if so
+  $pane = $variables['pane'];
+  if (substr($pane->type, 0, 8)) {
+    if (is_array($_GET['f'])) {
+      foreach ($_GET['f'] as $param) {
+        // We match the first part of the param to a mapped facet name
+        $param_parts = explode(':', $param, 2);
+        $param_name = $param_parts[0];
+        // The pane subtype will be something like "facetapi-wsVI1ENUXwf4Rz08n9fg2WvfQ0Gs5h2a"
+        $facet_hash = substr($pane->subtype, 9);
+        $facet_delta_map = facetapi_get_delta_map();
+        if (in_array($facet_hash, array_keys($facet_delta_map))) {
+          $mapping_parts = explode(':', $facet_delta_map[$facet_hash]);
+          $facet_name = $mapping_parts[2];
+          if ($facet_name == $param_name) {
+            $variables['collapsed'] = 0;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Acceptance test:

1. Go to /dataset
2. Use a bunch of facets aside from "Type"
3. They should stay open once the page reloads, and dissapear if disabled.