### PR TITLE
Added patch on fontyourface to fix bug when fonts are disabled.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,4 +1,3 @@
-<<<<<<< a5a34f72df75d23ebd7dc2d5adaa8959126562c9
 api: '2'
 core: 7.x
 includes:
@@ -103,6 +102,7 @@ projects:
     version: '2.8'
     patch:
       2550253: 'https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch'
+      2644694: 'https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch'
       1: patches/fontyourface-no-ajax-browse-view.patch
   imagecache_actions:
     download:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,3 +1,4 @@
+<<<<<<< a5a34f72df75d23ebd7dc2d5adaa8959126562c9
 api: '2'
 core: 7.x
 includes:


### PR DESCRIPTION
This PR was created based on: https://github.com/NuCivic/dkan/pull/838

Ref: https://jira.govdelivery.com/browse/CIVIC-512

### Acceptance

1. Go to 'admin/appearance/fontyourface/browse/google_fonts_api'.
2. Enable a font, any font.
3. Go to "Enabled fonts" tab.
4. Choose "Everything (Body)" from the font CSS selector dropdown list.
5. Save.
6. Go to "Browse Fonts" tab and disable the font.
7. Reload the page, drupal default font should be used on the page.