### PR TITLE
CIVIC-906 Update the circleCI and docker selenium versions

### DIFF
--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -88,7 +88,8 @@ memcached:
 # Uncomment the service definition section below and the link in the web service above to start using selenium2 driver for Behat tests requiring JS support.
 browser:
   hostname: browser
-  image: selenium/standalone-chrome-debug:2.48.2
+  image: selenium/standalone-chrome-debug:2.50.0
+  # This helps keep selenium-chrome from crashing because it uses shared memory.
   volumes:
     - /dev/shm:/dev/shm
   links:

--- a/circle.yml
+++ b/circle.yml
@@ -54,8 +54,8 @@ dependencies:
     #- sh -e /etc/init.d/xvfb start
     #- sleep 3
 
-    - wget http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar
-    - java -jar selenium-server-standalone-2.48.2.jar -quiet -p 4444 -log shut_up_selenium :
+    - wget http://selenium-release.storage.googleapis.com/2.50/selenium-server-standalone-2.50.0.jar
+    - java -jar selenium-server-standalone-2.50.0.jar -quiet -p 4444 -log shut_up_selenium :
         background: true
   post:
      - sudo apt-get install -y x11vnc


### PR DESCRIPTION
 from 2.48.2 to 2.50.0 in the hope that chrome will stop crashing.