### PR TITLE
Downgrade selenium to 2.49.1 from 2.50.0

### DIFF
--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -88,7 +88,7 @@ memcached:
 # Uncomment the service definition section below and the link in the web service above to start using selenium2 driver for Behat tests requiring JS support.
 browser:
   hostname: browser
-  image: selenium/standalone-chrome-debug:2.50.0
+  image: selenium/standalone-chrome-debug:2.49.1
   # This helps keep selenium-chrome from crashing because it uses shared memory.
   volumes:
     - /dev/shm:/dev/shm

--- a/circle.yml
+++ b/circle.yml
@@ -54,8 +54,8 @@ dependencies:
     #- sh -e /etc/init.d/xvfb start
     #- sleep 3
 
-    - wget http://selenium-release.storage.googleapis.com/2.50/selenium-server-standalone-2.50.0.jar
-    - java -jar selenium-server-standalone-2.50.0.jar -quiet -p 4444 -log shut_up_selenium :
+    - wget http://selenium-release.storage.googleapis.com/2.49/selenium-server-standalone-2.49.1.jar
+    - java -jar selenium-server-standalone-2.49.1.jar -p 4444 :
         background: true
   post:
      - sudo apt-get install -y x11vnc


### PR DESCRIPTION
- There is a known 2.50.0 timeout issue, that was just fixed in 2.50.1, but no docker image just yet. See https://github.com/SeleniumHQ/selenium/blob/master/java/CHANGELOG
- Remove the shutup of selenium, so at least we might be able to debug things better in the future.