### PR TITLE
Update the drupal-org.make and drupal-org-core.make to use the new ya…

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -4,5 +4,6 @@ projects:
   drupal:
     type: core
     version: '7.41'
+    # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,9 +1,8 @@
-api = 2
-core = 7.x
-
-projects[drupal][type] = core
-projects[drupal][version] = "7.41"
-
-; Use vocabulary machine name for permissions
-; http://drupal.org/node/995156
-projects[drupal][patch][995156] = http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch
+api: '2'
+core: 7.x
+projects:
+  drupal:
+    type: core
+    version: '7.41'
+    patch:
+      995156: 'http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,181 +1,208 @@
-core = 7.x
-api = 2
-
-; Set the default subdirectory for projects.
-defaults[projects][subdir] = contrib
-
-; DKAN core modules
-
-;Moved featured groups view
-projects[dkan_dataset][subdir] = dkan
-projects[dkan_dataset][download][type] = git
-projects[dkan_dataset][download][url] = https://github.com/NuCivic/dkan_dataset.git
-projects[dkan_dataset][download][branch] = 7.x-1.x
-
-
-projects[dkan_datastore][subdir] = dkan
-projects[dkan_datastore][download][type] = git
-projects[dkan_datastore][download][url] = https://github.com/NuCivic/dkan_datastore.git
-projects[dkan_datastore][download][branch] = 7.x-1.x
-
-; NuCivic Visualization tools
-
-projects[visualization_entity][download][type] = git
-projects[visualization_entity][download][url] = https://github.com/NuCivic/visualization_entity.git
-projects[visualization_entity][download][branch] = master
-projects[visualization_entity][type] = module
-
-projects[visualization_entity_charts][download][type] = git
-projects[visualization_entity_charts][download][url] = https://github.com/NuCivic/visualization_entity_charts.git
-projects[visualization_entity_charts][download][branch] = master
-projects[visualization_entity_charts][type] = module
-
-; Includes, since we're doing non-recusive
-
-includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/7.x-1.x/dkan_dataset.make
-includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
-
-includes[visualization_entity_make] = https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make
-includes[visualization_entity_charts_make] = https://raw.githubusercontent.com/NuCivic/visualization_entity_charts/master/visualization_entity_charts.make
-
-includes[dkan_data_story_make] = modules/dkan/dkan_data_story/dkan_data_story.make
-
-; Patches to other modules
-
-projects[file_entity][patch][2308737] = https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9509141.patch
-
-; Contrib Modules
-projects[admin_menu][version] = 3.0-rc5
-
-projects[bueditor][version] = 1.8
-projects[bueditor][patch][1931862] = http://drupal.org/files/dont-render-bueditor-for-plain-text-textareas.patch
-
-projects[colorizer][version] = 1.8
-projects[colorizer][patch][2227651] = https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
-projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch
-
-projects[conditional_styles][version] = 2.2
-
-projects[conditional_styles][version] = 2.2
-
-projects[diff][version] = 3.2
-
-projects[draggableviews][version] = 2.1
-
-projects[entityreference_filter][version] = 1.5
-
-;; Required by dkan_permissions.
-projects[features_roles_permissions][version] = 1.2
-projects[features_roles_permissions][subdir] = contrib
-
-projects[fieldable_panels_panes][version] = 1.7
-
-projects[honeypot][version] = 1.17
-
-projects[fontyourface][version] = 2.8
-projects[fontyourface][patch][2550253] = https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch
-projects[fontyourface][patch][] = patches/fontyourface-no-ajax-browse-view.patch
-
-projects[imagecache_actions][download][type] = git
-projects[imagecache_actions][download][url] = "http://git.drupal.org/project/imagecache_actions.git"
-projects[imagecache_actions][download][branch] = 7.x-1.x
-projects[imagecache_actions][download][revision] = cd19d2a
-projects[imagecache_actions][type] = module
-
-projects[markdown][version] = 1.2
-
-projects[markdowneditor][version] = 1.4
-projects[markdowneditor][patch][2045225] = http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch
-
-projects[module_filter][version] = 2.0
-
-projects[og_moderation][version] = 2.3
-
-projects[defaultconfig][version] = 1.0-alpha11
-
-projects[panelizer][version] = 3.1
-
-projects[views_autocomplete_filters][version] = 1.2
-projects[views_autocomplete_filters][patch][2374709] = http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch
-projects[views_autocomplete_filters][patch][2317351] = http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch
-
-
-projects[panopoly_widgets][version] = 1.25
-includes[panopoly_widgets_make] = http://cgit.drupalcode.org/panopoly_widgets/plain/panopoly_widgets.make
-projects[panopoly_widgets][patch][1] = patches/panopoly_widgets_overrides.patch
-projects[panopoly_widgets][patch][2] = patches/panopoly_widgets_add_jquery_ui_tabs.patch
-
-
-projects[panopoly_images][version] = 1.27
-includes[panopoly_images_make] = http://cgit.drupalcode.org/panopoly_images/plain/panopoly_images.make
-
-projects[panels][version] = 3.5
-
-projects[panels_style_collapsible][version] = 1.3
-projects[panels_style_collapsible][subdir] = contrib
-
-projects[path_breadcrumbs][version] = 3.3
-
-projects[pathauto][version] = 1.2
-
-projects[radix_layouts][version] = 3.4
-
-projects[r4032login][version] = 1.8
-
-projects[rules][version] = 2.3
-
-projects[restws][version] = 2.3
-projects[restws][patch][2484829] = https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch
-
-projects[schema][version] = 1.2
-
-projects[adminrole][version] = 1.1
-
-projects[admin_menu_source][version] = 1.0
-projects[admin_menu_source][subdir] = contrib
-
-projects[menu_token][version] = 1.0-beta5
-projects[menu_token][subdir] = contrib
-
-; Deprecated
-projects[delta][version] = 3.0-beta11
-
-; Themes
-projects[omega][version] = 3.1
-projects[omega][patch][1828552] = http://drupal.org/files/1828552-omega-hook_views_mini_pager.patch
-projects[omega][type] = theme
-
-;projects[bootstrap][download][version] = 3.x
-;projects[bootstrap][download][type] = git
-;projects[bootstrap][download][revision] = "0390173732439fd60e898c7086219ab8c99c2f3d"
-
-;projects[nuboot][download][type] = git
-;projects[nuboot][download][url] = https://github.com/NuCivic/nuboot.git
-;projects[nuboot][download][revision] = "fbd7ea2c2f1fa45a5f5a10b4215950940335879e"
-;projects[nuboot][download][branch] = 7.x-1.x
-
-projects[nuboot_radix][download][type] = git
-projects[nuboot_radix][download][url] = https://github.com/NuCivic/nuboot_radix.git
-projects[nuboot_radix][download][branch] = 7.x-1.x
-projects[nuboot_radix][type] = theme
-
-projects[radix][type] = theme
-projects[radix][version] = 3.0-rc4
-projects[radix][patch][2557385] = https://www.drupal.org/files/issues/radix-undefined-theme-2557385-9.patch
-
-projects[field_reference_delete][download][version] = 7.x-1.0-beta1
-
-projects[facetapi][patch][1] = patches/cross-site-scripting-facets-156778.patch
-
-; Libraries
-libraries[font_awesome][type] = libraries
-libraries[font_awesome][download][type] = git
-libraries[font_awesome][download][url] = "https://github.com/FortAwesome/Font-Awesome.git"
-libraries[font_awesome][directory_name] = font_awesome
-libraries[font_awesome][download][revision] = "13d5dd373cbf3f2bddd8ac2ee8df3a1966a62d09"
-
-libraries[spyc][download][type] = "get"
-libraries[spyc][download][url] = "https://raw.github.com/mustangostang/spyc/79f61969f63ee77e0d9460bc254a27a671b445f3/spyc.php"
-libraries[spyc][filename] = "../spyc.php"
-libraries[spyc][directory_name] = "lib"
-libraries[spyc][destination] = "modules/contrib/services/servers/rest_server"
+api: '2'
+core: 7.x
+includes:
+    # DKAN Dataset
+  - "https://raw.githubusercontent.com/NuCivic/dkan_dataset/7.x-1.x/dkan_dataset.make"
+    # DKAN Datastore
+  - "https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make"
+    # Visualization Entity
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make"
+    # Visualization Entity Charts
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity_charts/master/visualization_entity_charts.make"
+    #DKAN Data Story
+  - "modules/dkan/dkan_data_story/dkan_data_story.make"
+projects:
+  manualcrop:
+    version: 1.x-dev
+    download:
+      type: git
+      revision: d6c449d
+      branch: 7.x-1.x
+  tablefield:
+    version: '2.4'
+  simple_gmap:
+    version: '1.2'
+  menu_block:
+    version: '2.7'
+  file_entity:
+    version: 2.0-beta2
+    patch:
+      2308737: 'https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9509141.patch'
+  media:
+    version: 2.0-beta1
+    patch:
+      2126697: 'https://www.drupal.org/files/issues/media_wysiwyg_2126697-53.patch'
+      2308487: 'https://www.drupal.org/files/issues/media-alt-title-double-encoded-2308487-2.patch'
+      2084287: 'http://www.drupal.org/files/issues/media-file-name-focus-2084287-2.patch'
+      2534724: 'https://www.drupal.org/files/issues/media-browser_opens_twice-2534724-53.patch'
+  media_youtube:
+    version: '3.0'
+  media_vimeo:
+    version: '2.1'
+    patch:
+      2446199: 'https://www.drupal.org/files/issues/no_exception_handling-2446199-1.patch'
+  dkan_dataset:
+    subdir: dkan
+    download:
+      type: git
+      url: 'https://github.com/NuCivic/dkan_dataset.git'
+      branch: 7.x-1.x
+  dkan_datastore:
+    subdir: dkan
+    download:
+      type: git
+      url: 'https://github.com/NuCivic/dkan_datastore.git'
+      branch: 7.x-1.x
+  visualization_entity:
+    download:
+      type: git
+      url: 'https://github.com/NuCivic/visualization_entity.git'
+      branch: master
+    type: module
+  visualization_entity_charts:
+    download:
+      type: git
+      url: 'https://github.com/NuCivic/visualization_entity_charts.git'
+      branch: master
+    type: module
+  admin_menu:
+    version: 3.0-rc5
+  bueditor:
+    version: '1.8'
+    patch:
+      1931862: 'http://drupal.org/files/dont-render-bueditor-for-plain-text-textareas.patch'
+  colorizer:
+    version: '1.8'
+    patch:
+      2227651: 'https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch'
+      2599298: 'https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch'
+  conditional_styles:
+    version: '2.2'
+  diff:
+    version: '3.2'
+  draggableviews:
+    version: '2.1'
+  entityreference_filter:
+    version: '1.5'
+  features_roles_permissions:
+    version: '1.2'
+  fieldable_panels_panes:
+    version: '1.7'
+  honeypot:
+    version: '1.17'
+  fontyourface:
+    version: '2.8'
+    patch:
+      2550253: 'https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch'
+      1: patches/fontyourface-no-ajax-browse-view.patch
+  imagecache_actions:
+    download:
+      type: git
+      url: 'http://git.drupal.org/project/imagecache_actions.git'
+      branch: 7.x-1.x
+      revision: cd19d2a
+    type: module
+  markdown:
+    version: '1.2'
+  markdowneditor:
+    version: '1.4'
+    patch:
+      2045225: 'http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch'
+  module_filter:
+    version: '2.0'
+  og_moderation:
+    version: '2.3'
+  defaultconfig:
+    version: 1.0-alpha11
+  panelizer:
+    version: '3.1'
+  views_autocomplete_filters:
+    version: '1.2'
+    patch:
+      2374709: 'http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch'
+      2317351: 'http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch'
+  panopoly_widgets:
+    version: '1.25'
+    patch:
+      1: patches/panopoly_widgets_overrides.patch
+      2: patches/panopoly_widgets_add_jquery_ui_tabs.patch
+  panopoly_images:
+    version: '1.27'
+  panels:
+    version: '3.5'
+  panels_style_collapsible:
+    version: '1.3'
+  path_breadcrumbs:
+    version: '3.3'
+  pathauto:
+    version: '1.2'
+  radix_layouts:
+    version: '3.4'
+  r4032login:
+    version: '1.8'
+  rules:
+    version: '2.3'
+  restws:
+    version: '2.3'
+    patch:
+      2484829: 'https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch'
+  schema:
+    version: '1.2'
+  adminrole:
+    version: '1.1'
+  admin_menu_source:
+    version: '1.0'
+  menu_token:
+    version: 1.0-beta5
+  delta:
+    version: 3.0-beta11
+  omega:
+    version: '3.1'
+    patch:
+      1828552: 'http://drupal.org/files/1828552-omega-hook_views_mini_pager.patch'
+    type: theme
+  nuboot_radix:
+    download:
+      type: git
+      url: 'https://github.com/NuCivic/nuboot_radix.git'
+      branch: 7.x-1.x
+    type: theme
+  radix:
+    type: theme
+    version: 3.0-rc4
+    patch:
+      2557385: 'https://www.drupal.org/files/issues/radix-undefined-theme-2557385-9.patch'
+  field_reference_delete:
+    download:
+      version: 7.x-1.0-beta1
+  facetapi:
+    patch:
+      1: patches/cross-site-scripting-facets-156778.patch
+libraries:
+  jquery.imagesloaded:
+    download:
+      type: file
+      url: 'https://github.com/desandro/imagesloaded/archive/v2.1.2.tar.gz'
+      subtree: imagesloaded-2.1.2
+  jquery.imgareaselect:
+    download:
+      type: file
+      url: 'https://github.com/odyniec/imgareaselect/archive/v0.9.11-rc.1.tar.gz'
+      subtree: imgareaselect-0.9.11-rc.1
+  font_awesome:
+    type: libraries
+    download:
+      type: git
+      url: 'https://github.com/FortAwesome/Font-Awesome.git'
+      revision: 13d5dd373cbf3f2bddd8ac2ee8df3a1966a62d09
+    directory_name: font_awesome
+  spyc:
+    download:
+      type: get
+      url: 'https://raw.github.com/mustangostang/spyc/79f61969f63ee77e0d9460bc254a27a671b445f3/spyc.php'
+    filename: ../spyc.php
+    directory_name: lib
+    destination: modules/contrib/services/servers/rest_server
+defaults:
+  projects:
+    subdir: contrib


### PR DESCRIPTION
…ml spec starting in drush 7.0.0.

Listing of all dkan files and their md5 is in this gist (before, after, and diff) https://gist.github.com/frankcarey/1ec6b0e6afdffe628ca7

.. It's really long, so you really just want to see the diff..
https://gist.githubusercontent.com/frankcarey/1ec6b0e6afdffe628ca7/raw/011ed7cbccf5f103001d83cf203446a690a0c1d9/module-listing.diff

Command to create the md5 files is:
`find . -not -path "*.git*" -type f -exec md5 {} + > module-listing-before.txt`