### PR TITLE
Missing ahoy for ahoy dkan mysql-dump command

### DIFF
--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -54,10 +54,10 @@ commands:
     usage: Connect to the default mysql database.
   mysql-import:
     cmd: "docker exec -i $(ahoy docker compose ps -q cli) bash -c 'mysql -u$DB_ENV_MYSQL_USER -p$DB_ENV_MYSQL_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
-    usage: Pipe in a sql file.  `ahoy mysql-import < backups/live.sql`
+    usage: Pipe in a sql file.  `ahoy docker mysql-import < backups/live.sql`
   mysql-dump:
-    cmd: "docker exec -it $(docker-compose -f  ps -q cli) bash -c 'mysqldump -u$DB_ENV_MYSQL_USER -p$DB_ENV_MYSQL_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
-    usage: Dump data out into a file. `ahoy mysql-import > backups/local.sql`
+    cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysqldump -u$DB_ENV_MYSQL_USER -p$DB_ENV_MYSQL_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
+    usage: Dump data out into a file. `ahoy docker mysql-dump > backups/local.sql`
   compose:
     cmd: docker-compose -f dkan/.ahoy/docker-compose.yml -p "${PWD##*/}" {{args}}
     usage: Abstraction for docker-compose


### PR DESCRIPTION
Getting docker-compose output while `ahoy dkan mysql-dump`

```
2016/02/08 12:29:42 ===> AHOY mysql-dump from  : docker exec -it $(docker-compose -f  ps -q cli) bash -c 'mysqldump -u$DB_ENV_MYSQL_USER -p$DB_ENV_MYSQL_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'
Define and run multi-container applications with Docker.

Usage:
  docker-compose [options] [COMMAND] [ARGS...]
  docker-compose -h|--help

Options:
  -f, --file FILE           Specify an alternate compose file (default: docker-compose.yml)
  -p, --project-name NAME   Specify an alternate project name (default: directory name)
  --verbose                 Show more output
  -v, --version             Print version and exit

Commands:
  build              Build or rebuild services
  help               Get help on a command
  kill               Kill containers
  logs               View output from containers
  port               Print the public port for a port binding
  ps                 List containers
  pull               Pulls service images
  restart            Restart services
  rm                 Remove stopped containers
  run                Run a one-off command
  scale              Set number of containers for a service
  start              Start services
  stop               Stop services
  up                 Create and start containers
  migrate-to-labels  Recreate containers to add labels
  version            Show the Docker-Compose version information
Error response from daemon: no such id: bash
```
