### PR TITLE
Copy drush alias.

### DIFF
--- a/.ahoy/site.ahoy.yml
+++ b/.ahoy/site.ahoy.yml
@@ -8,6 +8,9 @@ commands:
       ARGS=( {{args}} )
       rm -f assets/sites/default/settings.docker.php
       rm -f assets/sites/default/settings.local.php
+      if [ -f assets/drush/aliases.local.php ]; then
+        ahoy cmd-proxy 'mkdir -p ~/.drush && cp assets/drush/aliases.local.php ~/.drush/'
+      fi
       if [ "$AHOY_CMD_PROXY" == "DOCKER" ]; then
         cp assets/sites/default/settings.docker.demo.php assets/sites/default/settings.docker.php
         ahoy docker up


### PR DESCRIPTION
As a site developer I want to take advantage of Acquia deployment scripts in my QA build and testing processing.  This change adds an alias to the docker instance if available so that calls to drush @local or whatever works.

Acceptance
==========
- [x] `ahoy site setup` - adds an alias file to container ~/.drush folder.

This will help in cases where we are taking advantage of a deployment script
that requires an alias passes to it.