### PR TITLE
Ahoy command to create a sanitized db out of the working docker db

### DIFF
--- a/.ahoy/.mysqlscripts/sanitize.sql
+++ b/.ahoy/.mysqlscripts/sanitize.sql
@@ -1,0 +1,72 @@
+-- 
+-- Scrub important information from a Drupal database.
+-- 
+
+-- Remove all email addresses.
+UPDATE users SET mail=CONCAT('user', uid, '@example.com'), init=CONCAT('user', uid, '@example.com') WHERE uid != 0;
+
+-- Example: Disable a module by setting its system.status value to 0.
+-- UPDATE system SET status = 0 WHERE name = 'securepages';
+
+-- Example: Update or delete variables via the variable table.
+-- DELETE FROM variable WHERE name='secret_key';
+-- Note that to update variables the value must be a properly serialized php array.
+-- UPDATE variable SET value='s:24:"http://test.gateway.com/";' WHERE name='payment_gateway';
+
+-- IMPORTANT: If you change the variable table, clear the variables cache.
+-- DELETE FROM cache WHERE cid = 'variables';
+
+-- Scrub url aliases for non-admins since these also reveal names
+-- Add the IGNORE keyword, since a user may have multiple aliases, and without
+-- this keyword the attempt to store duplicate dst values causes the query to fail.
+-- UPDATE IGNORE url_alias SET dst = CONCAT('users/', REPLACE(src,'/', '')) WHERE src IN (SELECT CONCAT('user/', u.uid) FROM users u WHERE u.uid NOT IN (SELECT uid FROM users_roles WHERE rid=3) AND u.uid > 0);
+
+-- don't leave e-mail addresses, etc in comments table.
+-- UPDATE comments SET name='Anonymous', mail='', homepage='http://example.com' WHERE uid=0;
+
+-- Scrub webform submissions.
+-- UPDATE webform_submitted_data set data='*scrubbed*';
+
+-- remove sensitive customer data from custom module
+-- TRUNCATE custom_customer_lead_data;
+
+-- USER PASSWORDS
+-- These statements assume you want to preserve real passwords for developers. Change 'rid=3' to the 
+-- developer or test role you want to preserve.
+
+-- DRUPAL 6
+-- Remove passwords unless users have 'developer role'
+UPDATE users SET pass=md5('devpassword') WHERE uid IN (SELECT uid FROM users_roles WHERE rid=3) AND uid > 0;
+
+-- Admin user should not be same but not really well known
+UPDATE users SET pass = MD5('supersecret!') WHERE uid = 1;
+
+-- DRUPAL 7
+-- Drupal 7 requires sites to generate a hashed password specific to their site. A script in the 
+-- docroot/scripts directory is provided for doing this. From your docroot run the following:
+--      
+--    scripts/password-hash.sh password
+--
+-- this will generate a hash for the password "password". In the following statements replace
+-- $REPLACE THIS$ with your generated hash.
+
+-- Remove passwords unless users have 'developer role'
+UPDATE users SET pass='123' WHERE uid IN (SELECT uid FROM users_roles WHERE rid=3) AND uid > 0;
+
+-- Admin user should not be same but not really well known
+UPDATE users SET pass='1235' WHERE uid = 1;
+
+TRUNCATE flood;
+TRUNCATE history;
+TRUNCATE sessions;
+TRUNCATE watchdog;
+
+SELECT concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE 'access%';
+
+SELECT concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE 'devel_%';
+
+SELECT concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE 'cache%';
+
+SELECT concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE 'migrate_%';
+
+SELECT concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE 'search_%';

--- a/.ahoy/site.ahoy.yml
+++ b/.ahoy/site.ahoy.yml
@@ -77,9 +77,9 @@ commands:
       mv docroot_new docroot
       # No recursive prevents dkan build to happen. Run it now from dkan remake.
       ahoy dkan remake
-      ahoy site post_build
+      ahoy site post-build
 
-  post_build:
+  post-build:
     usage: Runs (what used to be buildmanager) post build commands.
     cmd: |
       # Setup a folder for contrib modules and themes.
@@ -163,5 +163,15 @@ commands:
       git add . -A
       git commit -m "Updates build-dkan.make from $tag_old $version_old to $tag_new $version_new"
       ahoy site remake
+      command -v hub >/dev/null 2>&1 || { echo >&2 "Hub not installed, please push code and create PR manually."; exit 1; }
       git push origin "$pr_branch";
-      hub pull-request 
+      hub pull-request
+
+  mysql-dump-sanitized:
+    usage: Creates a dump of a sanitazed version of the site db
+    cmd: |
+      ahoy drush sql-dump > backups/unsanitized.sql
+      ahoy drush sql-cli < dkan/.ahoy/.mysqlscripts/sanitize.sql
+      ahoy drush sql-dump > backups/sanitized.sql
+      ahoy drush -y sql-drop
+      ahoy drush sql-cli < backups/unsanitized.sql


### PR DESCRIPTION
Issue #CIVIC-940

### Usage

```
ahoy site mysql-dump-sanitized
```

+ Creates `backup/unsanitized.sql` file from working db
+ Creates a `backup/sanitized.sql` file out of the working db after running `dkan/.ahoy/.mysqlscripts/sanitize.sql`.
+ Restores `backup/unsanitized.sql`