### PR TITLE
Allow pass extra params to ahoy tests proxied through circle_behat

### DIFF
--- a/test/circle-behat.sh
+++ b/test/circle-behat.sh
@@ -14,20 +14,27 @@ echo "\$CIRCLE_NODE_INDEX = $CIRCLE_NODE_INDEX"
 error=0
 pwd=$(pwd)
 declare -a files
+declare -a params
 # Fetch all of the feature files for each parameter (directories)
-for search_dir in "$@"; do
-    echo "Seaching $search_dir for feature files..."
-    while read -r path; do
-       echo "-- found $path"
-       files=(${files[@]} "$path")
-    # Bash wizardry so we can update the array (otherwise it's a subprocess)
-    done < <(find $search_dir | grep "\.feature$")
+for param in "$@"; do
+    echo "Seaching $param for feature files..."
+    if [ -d "$param" ]; then
+      while read -r entry; do
+        echo "-- found $entry"
+        files=(${files[@]} "$entry")
+        # Bash wizardry so we can update the array (otherwise it's a subprocess)
+      done < <(find $param | grep "\.feature$")
+    else
+      # Fetch all the params to be passed later to behat
+      echo "Fetch param $param"
+      params=(${params[@]} "$param")
+    fi
 done
 
 for i in "${!files[@]}"; do
     if [ $(($i % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX ]; then
-      echo "Running ahoy dkan test --format=pretty --out=std --format=junit --out=$CIRCLE_ARTIFACTS/junit `pwd`/${files[$i]}"
-      time ahoy dkan test --format=pretty --out=std --format=junit --out=$CIRCLE_ARTIFACTS/junit `pwd`/${files[$i]}
+      echo "Running ahoy dkan test --format=pretty --out=std --format=junit --out=$CIRCLE_ARTIFACTS/junit ${params} `pwd`/${files[$i]}"
+      time ahoy dkan test --format=pretty --out=std --format=junit --out=$CIRCLE_ARTIFACTS/junit ${params} `pwd`/${files[$i]}
     fi
     # Mark the entire script as a failure if any of the iterations fail.
     if [ ! $? -eq 0 ]


### PR DESCRIPTION
In order to override some behat params we need to allow circle_behat.sh to 
receive behat parameter and pass them to the ahoy test function. In this way
each project can specify things like tags to exclude or include.