### PR TITLE
Fix ahoy site mysql-dump-sanitize.

### DIFF
--- a/.ahoy/site.ahoy.yml
+++ b/.ahoy/site.ahoy.yml
@@ -170,6 +170,7 @@ commands:
   mysql-dump-sanitized:
     usage: Creates a dump of a sanitazed version of the site db
     cmd: |
+      ahoy cmd-proxy exec mkdir -p backups
       ahoy drush sql-dump > backups/unsanitized.sql
       ahoy drush sql-cli < dkan/.ahoy/.mysqlscripts/sanitize.sql
       ahoy drush sql-dump > backups/sanitized.sql


### PR DESCRIPTION
Ref civic-1396

Acceptance:
==========
- [x] backups folder is created if it does not exist when trying to sanitize local db.