### PR TITLE
Update s3 files url.

### DIFF
--- a/.ahoy/site.ahoy.yml
+++ b/.ahoy/site.ahoy.yml
@@ -212,8 +212,8 @@ commands:
     cmd: |
       ahoy cmd-proxy exec mkdir -p backups
       site=$(ahoy site name)
-      asset="https://s3.amazonaws.com/nucivic-data-backups/$site.prod.files.gz"
-      wget -O backups/$site.prod.files.gz $asset
+      asset="https://s3.amazonaws.com/nucivic-data-backups/$site.prod.files.tar.gz"
+      wget -O backups/$site.prod.files.tar.gz $asset
     hide: true
 
   asset-upload:

--- a/.ahoy/site.ahoy.yml
+++ b/.ahoy/site.ahoy.yml
@@ -214,6 +214,10 @@ commands:
       site=$(ahoy site name)
       asset="https://s3.amazonaws.com/nucivic-data-backups/$site.prod.files.tar.gz"
       wget -O backups/$site.prod.files.tar.gz $asset
+      echo ""
+      echo "Unpacking the files asset."
+      echo ""
+      ahoy cmd-proxy tar xvzf backups/$site.prod.files.tar.gz
     hide: true
 
   asset-upload:


### PR DESCRIPTION
Fixes 403 errors on files download.
Also unpacks files when retrieved.

Ref civic-1352.

Acceptance:
==========
- [ ] ahoy site asset-files-download works as expected.
- [ ] files get automatically unpacked.