### PR TITLE
Add `ahoy dkan self-update` command.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -132,3 +132,15 @@ commands:
       # Grab the sql string and ignore stdin so it can be used later.
       ahoy cmd-proxy "$(ahoy drush sql-connect < /dev/null)"
 
+  self-update:
+    usage: Update dkan-ahoy
+    cmd: |
+      set -e
+      rm -fR dkan-ahoy
+      rm -fR dkan/.ahoy
+      rm dkan/dkan-init.sh
+      git clone 'git@github.com:nucivic/dkan' --depth=1 dkan-ahoy
+      cp -r dkan-ahoy/.ahoy dkan/
+      cp dkan-ahoy/dkan-init.sh  dkan/
+      rm -fR dkan-ahoy
+    hide: true


### PR DESCRIPTION
This command is a complement of `ahoy site self-update`.  It's a way to conviniently update the ahoy specific components to the latest 7.x-1.x verision of dkan.

The use case is for site remakes to capture latest version of ahoy while not needing to upgrade all of dkan.

Ref civic-1506

Acceptance
=========
- [ ] In initialized version of dkan or data_starter with this component, `ahoy dkan self-update` updates the ahoy component of dkan to whatever is in the 1.7.-1.x branch.