### PR TITLE
Add docker and circle behat config files on update.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -142,5 +142,7 @@ commands:
       git clone 'git@github.com:nucivic/dkan' --depth=1 dkan-ahoy
       cp -r dkan-ahoy/.ahoy dkan/
       cp dkan-ahoy/dkan-init.sh  dkan/
+      cp dkan-ahoy/test/behat.docker.yml dkan/test/
+      cp dkan-ahoy/test/behat.circleci.yml dkan/test/
       rm -fR dkan-ahoy
     hide: true


### PR DESCRIPTION
Ref civic-1510.

`ahoy dkan test` requires that the behat.docker.yml and behat.circleci.yml be
present.  But, current sites do not include these files.  If we add these file
during an `ahoy dkan self-update` Then there is always a simple and automatic
way to keep these files present and current in any of the data_starter type
projects.

Acceptance
==========
- [ ] When run from within a site repo `ahoy dkan self-update` will also update
the docker and circleci behat config files which are required in order to run
`ahoy dkan test` from within a site project.