### PR TITLE
Update the readme dkan install instructions.

### DIFF
--- a/.ahoy/README.md
+++ b/.ahoy/README.md
@@ -1,0 +1,24 @@
+Ahoy
+====
+
+[Ahoy]:[ahoy] is an open source build tool written in Go that we use to abstract
+out the build steps for the project.  If you are familiar with gnu `make`, then
+the basic use of this tool is the same. The main advantage of `ahoy` over `make`
+is that ahoy has a simple yaml format that is familiar to the modern developer
+and also it is easier to organize commands into logical sets.
+
+Ahoy is not required to develop with DKAN, and at this point we are not
+recommending contributing developers to adopt it.  For further details please
+read the ahoy documentation on the ahoy site. The contents of this README are
+merely 
+
+## Why we use Ahoy:
+* Standardize workflow steps so that everyone is doing things exactly the same way
+* Abstract more complex workflow steps and scripts behind higher level commands, which:
+  *  Makes it easier for developers, as they can see a list of commands available along with descriptions of each
+  * Makes it easier for the devops team to improve the processes without having to retrain developers or change documentation
+* Reuse abstracted commands in scripts like CircleCI, or even other ahoy commands.
+* Make it easier for anyone to add or tweak the commands without knowledge of bash, php, etc
+* Allow projects (or users) to have their own custom commands in addition to the defaults.
+
+[ahoy]:https://github.com/devinci-code/ahoy

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Create a full version with drush make:
 ```bash
 git clone --branch 7.x-1.x https://github.com/NuCivic/dkan.git
 cd dkan
-drush make --prepare-install build-dkan.make webroot
-cd webroot
+drush make --prepare-install drupal-org-core.make docroot --yes
+cd docroot
 drush site-install dkan --db-url="mysql://DBUSER:DBPASS@localhost/DBNAME"
 ```
 


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-1891

## Description
The drush makefile referred to in the README has been removed.
Also, there is no description of the .ahoy folder.

## User story / stories
- [ ] As a user I want relevant install instructions as to not waste my time.
- [ ] As a developer I want to know what `.ahoy` folder is about in the dkan repo root.

## Acceptance criteria
- [ ] Instructions refer to an existing drush make file.
- [ ] Add README section for .ahoy folder.

## PR dependencies
None.