### PR TITLE
Added hook_update to update menu items on main menu.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@
 - Add support to import big files using mysql statement load data infile
 - Added Dkan Workflow module
 - Upgrade Fieldable Panels Panes to 1.8
+- Added hook_update to remove 'Add Dataset' and 'Datasets' links from main menu. The 'Datasets' link is now added by the dkan_sitewide_search_db feature. 
 
 7.x-1.11 2016-02-01
 --------------------------

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
@@ -38,25 +38,6 @@ function dkan_sitewide_menu_update_7101() {
 }
 
 /**
- * Remove unwanted links from main menu
- */
-function dkan_sitewide_menu_update_7101() {
-  // Delete 'Add Dataset' link.
-  menu_link_delete(NULL, 'node/add/dataset');
-  // Delete old 'Datasets' link.
-  // The new 'Datasets' link point to the search page.
-  menu_link_delete(NULL, 'dataset');
-}
-
-function _dkan_sitewide_menu_clear_command_center() {
-  $menu_links = menu_load_links('menu-command-center-menu');
-
-  foreach($menu_links as $menu_link) {
-    menu_link_delete($menu_link['mlid']);
-  }
-}
-
-/**
  * This helper function sets up the admin_menu_source module's configuration.
  * We want the content creator and editor roles to have the "command center"
  * menu rather than the whole admin menu in the top bar. We can't rely on the

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
@@ -21,6 +21,10 @@ function dkan_sitewide_menu_update_7100() {
   _dkan_sitewide_menu_setup_admin_menu_source();
 }
 
+/**
+ * Remove "Add dataset" and "Datasets" menu items from main menu. These links
+ * are now provided from other modules.
+ */
 function dkan_sitewide_menu_update_7101() {
   $main_menu_links = menu_load_links('main-menu');
 
@@ -36,6 +40,19 @@ function dkan_sitewide_menu_update_7101() {
     }
   }
 }
+
+/**
+ * When we upgrade, we need to rebuild the command center menu completely. This
+ * Deletes all the existing menu links.
+ */
+function _dkan_sitewide_menu_clear_command_center() {
+  $menu_links = menu_load_links('menu-command-center-menu');
+
+  foreach($menu_links as $menu_link) {
+    menu_link_delete($menu_link['mlid']);
+  }
+}
+
 
 /**
  * This helper function sets up the admin_menu_source module's configuration.

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
@@ -17,6 +17,14 @@ function dkan_sitewide_menu_update_7100() {
   _dkan_sitewide_menu_setup_admin_menu_source();
 }
 
+function dkan_sitewide_menu_update_7101() {
+  // Delete 'Add Dataset' link.
+  menu_link_delete(NULL, 'node/add/dataset');
+  // Delete old 'Datasets' link.
+  // The new 'Datasets' link point to the search page.
+  menu_link_delete(NULL, 'dataset');
+}
+
 /**
  * This helper function sets up the admin_menu_source module's configuration.
  * We want the content creator and editor roles to have the "command center"

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.install
@@ -13,16 +13,31 @@ function dkan_sitewide_menu_install()  {
   _dkan_sitewide_menu_setup_admin_menu_source();
 }
 
+/**
+ * Configure new lower-level user admin menu
+ */
 function dkan_sitewide_menu_update_7100() {
+  _dkan_sitewide_menu_clear_command_center();
   _dkan_sitewide_menu_setup_admin_menu_source();
 }
 
+/**
+ * Remove unwanted links from main menu
+ */
 function dkan_sitewide_menu_update_7101() {
   // Delete 'Add Dataset' link.
   menu_link_delete(NULL, 'node/add/dataset');
   // Delete old 'Datasets' link.
   // The new 'Datasets' link point to the search page.
   menu_link_delete(NULL, 'dataset');
+}
+
+function _dkan_sitewide_menu_clear_command_center() {
+  $menu_links = menu_load_links('menu-command-center-menu');
+
+  foreach($menu_links as $menu_link) {
+    menu_link_delete($menu_link['mlid']);
+  }
 }
 
 /**


### PR DESCRIPTION
Issue: None.

## Description
A hook_update() function was added on dkan_sitewide_menu in order to remove the 'Add Dataset' and 'Datasets' link. The new 'Datasets' link is added by the dkan_sitewide_search_db feature and it points now to the search page instead of '/dataset'.

## Acceptance criteria
- [ ] An upgrade from 7.x-1.11 should not cause any errors.
- [ ] After upgrade both 'Add Datasets' and 'Datasets' link pointing to '/dataset' should not be present.
- [ ] Confirm that the rest of the menus (ex: command center) did not get affected by the link removal.

Here is a dump of a clean 7.x-1.11 install:
[7-x-1-11.sql.zip](https://github.com/NuCivic/dkan/files/200287/7-x-1-11.sql.zip)


