### PR TITLE
Removed unused variable from topics info file.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
 - Add support to import big files using mysql statement load data infile
 - Added Dkan Workflow module
 - Upgrade Fieldable Panels Panes to 1.8
+- Removed 'taxonomy_menu_vocab_parent_dkan_topics' variable from info file to get the 'DKAN Featured Topics' feature back into 'Default' state. 
 
 7.x-1.11 2016-02-01
 --------------------------

--- a/modules/dkan/dkan_featured_topics/dkan_featured_topics.info
+++ b/modules/dkan/dkan_featured_topics/dkan_featured_topics.info
@@ -55,7 +55,6 @@ features[variable][] = taxonomy_menu_voc_item_description_dkan_topics
 features[variable][] = taxonomy_menu_voc_item_dkan_topics
 features[variable][] = taxonomy_menu_voc_name_dkan_topics
 features[variable][] = taxonomy_menu_vocab_menu_dkan_topics
-features[variable][] = taxonomy_menu_vocab_parent_dkan_topics
 features[views_view][] = dkan_topics_featured
 features_exclude[dependencies][ctools] = ctools
 features_exclude[dependencies][dkan_dataset_groups] = dkan_dataset_groups


### PR DESCRIPTION
Issue: None

## Description
The variable 'taxonomy_menu_vocab_parent_dkan_topics' was present on the .info and since its not being exported it was causing the 'Topics' feature to be marked as Overriden.

## User story / stories
- [ ] As a developer I should see the 'Topics' feature on 'Default' state.

## Acceptance criteria
- [ ] Wait for the tests to pass.
- [ ] Log in on the QA site and confirm that the 'Topics' feature is on 'Default' state.

## PR dependencies
None.

