### PR TITLE
Increase the amount of time allowed for a test to run.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,6 +59,9 @@ dependencies:
         background: true
   post:
      - sudo apt-get install -y x11vnc
+       # warm up cache
+     - curl http://127.0.0.1:8888
+     - curl http://127.0.0.1:8888/afghan-dashboard
      - x11vnc -forever -nopw:
         background: true
 

--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,7 @@ dependencies:
 test:
   override:
     - ruby dkan/.ahoy/.scripts/circle-behat.rb docroot/profiles/dkan/test/features:
+        timeout: 900
         parallel: true
   post:
     - echo $CIRCLE_ARTIFACTS; cp -av dkan/test/assets $CIRCLE_ARTIFACTS:


### PR DESCRIPTION
Ref civic-1920.

Increases the allowed time with no output per test command to 15 minutes.

Acceptance
=========
- [ ] Less timeouts occur.