### PR TITLE
Update dkan_sitewide to set the default admin_theme to default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@
 - Upgrade Fieldable Panels Panes to 1.8
 - Added hook_update to remove 'Add Dataset' and 'Datasets' links from main menu. The 'Datasets' link is now added by the dkan_sitewide_search_db feature.
 - Removed 'taxonomy_menu_vocab_parent_dkan_topics' variable from info file to get the 'DKAN Featured Topics' feature back into 'Default' state.
+- Change admin theme setting to use default theme rather than nuboot radix
 
 7.x-1.11 2016-02-01
 --------------------------

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.strongarm.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.strongarm.inc
@@ -14,7 +14,7 @@ function dkan_sitewide_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'admin_theme';
-  $strongarm->value = 'nuboot_radix';
+  $strongarm->value = '0';
   $export['admin_theme'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Issue: NuCivic/dkan#936

## Description
dkan_sitewide feature will display as overridden when using a custom subtheme, the admin theme needs to be the same as the default theme for colorizer to work.

## User story / stories
As a site maintainer I do not want the dkan_sitewide feature to show as overridden when using a custom sub-theme for the admin theme. This value should be set 'Default theme' (0) as this works for both NuBoot Radix and any subtheme. No reason to have it hard coded as nuboot_radix.

## Acceptance criteria
- [ ] View the Appearance list page and confirm that the admin theme is set to 'Default theme'.
- [ ] Visit the colorizer screen and confirm that the settings are configurable.
