### PR TITLE
Fixed regex used to rewrite font file paths on Dkan Topics.

### DIFF
--- a/modules/dkan/dkan_featured_topics/dkan_featured_topics.module
+++ b/modules/dkan/dkan_featured_topics/dkan_featured_topics.module
@@ -106,10 +106,10 @@ function dkan_featured_topics_views_pre_render(&$view) {
  * Rewrite font file paths to work on install.
  */
 function dkan_featured_topics_file_url_alter(&$uri) {
-  $re = "/public\\:\\/\\/dkantopics.(eot|woff|ttf|svg)/";  
-  preg_match_all($re, $uri, $matches);
+  $re = "/public:\\/\\/[^\\/]*\\/?dkan-topics.*\\.(eot|woff|ttf|svg)$/";
+  $match = preg_match($re, $uri);
 
-  if(!empty($matches)) {
+  if ($match) {
     $uri = str_replace('public://', '/sites/default/files/', $uri);
   }
 }


### PR DESCRIPTION
Issues: https://github.com/NuCivic/dkan/issues/1062

## Description
Data.json validation was failing because of the 'downloadURL' field not being a full path. 

## User story / stories
- [ ] As a user I should be able to get the full path of each resource file on the 'downloadURL' field.

## Acceptance criteria
- [ ] Go to /data.json and check that the 'downloadURL'  is correct.
- [ ] Go to admin/config/services/odsm/validate/pod and confirm there are no validation errors.
- [ ] The issue was caused because of a renaming on the font files for Topics so we should also check that the fonts on Topics are still working OK.
- [ ] Automatic tests should pass.

## PR dependencies
None.