### PR TITLE
Smarter module-link ahoy dkan command

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -74,11 +74,18 @@ commands:
         echo "No dkan folder found at ./docroot/profiles/dkan/modules/dkan. Consider running 'ahoy dkan drupal-rebuild'."
         exit 1
       fi
-      if [ -d "docroot/profiles/dkan/modules/dkan/$MODULE" ]; then
-        echo "Module already exists at 'docroot/profiles/dkan/modules/dkan/$MODULE', removing it to make room..."
-        rm -rf "docroot/profiles/dkan/modules/dkan/$MODULE";
+      if [ ! -d docroot/profiles/dkan/modules/contrib ]; then
+        echo "No contrib folder found at ./docroot/profiles/dkan/modules/contrib. Consider running 'ahoy dkan drupal-rebuild'."
+        exit 1
       fi
-      ln -s ../../../$MODULE docroot/profiles/dkan/modules/dkan && echo "Symlink created for $MODULE.. "
+      MODULE_PATH=`find dkan -type d -name 'recline' | grep -e 'modules'`
+      if [ -d "$MODULE_PATH" ]; then
+        echo "Module already exists at '$MODULE_PATH', removing it to make room..."
+        rm -rf $MODULE_PATH
+      else
+        exit 0;
+      fi
+      ln -s ../../../$MODULE docroot/profiles/$MODULE_PATH && echo "Symlink created for $MODULE.. "
 
   module-make:
     usage: Run drush make for a module in dkan/modules/dkan/.


### PR DESCRIPTION
This attemps to allow module linking for other modules other than the ones located at `dkan/modules/dkan`
