### PR TITLE
Fix typo in add data story link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+- Fixes typo in "add data story" link in command center menu
 - Add topic icons to the drop down menu
 
 7.x-1.12 2016-04-20

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.features.menu_links.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_menu/dkan_sitewide_menu.features.menu_links.inc
@@ -279,17 +279,17 @@ function dkan_sitewide_menu_menu_default_menu_links() {
     'customized' => 1,
     'parent_identifier' => 'menu-command-center-menu_site-configuration:admin/config',
   );
-  // Exported menu link: menu-command-center-menu_data-story:node/add/asdas
-  $menu_links['menu-command-center-menu_data-story:node/add/asdas'] = array(
+  // Exported menu link: menu-command-center-menu_data-story:node/add/dkan-data-story
+  $menu_links['menu-command-center-menu_data-story:node/add/dkan-data-story'] = array(
     'menu_name' => 'menu-command-center-menu',
-    'link_path' => 'node/add/asdas',
+    'link_path' => 'node/add/dkan-data-story',
     'router_path' => 'node/add',
     'link_title' => 'Data Story',
     'options' => array(
       'attributes' => array(
         'title' => '',
       ),
-      'identifier' => 'menu-command-center-menu_data-story:node/add/asdas',
+      'identifier' => 'menu-command-center-menu_data-story:node/add/dkan-data-story',
     ),
     'module' => 'menu',
     'hidden' => 0,


### PR DESCRIPTION
## Description
When logged in as an editor or site manager, the admin menu link for adding a data story is incorrect.

## Acceptance criteria
- [ ] When I am logged in as a site manager, I should end up on the Create DKAN Data Story form when clicking on _Content > Add Content > DKAN Data Story_ from the admin menu.


