### PR TITLE
Update drupal-org.make

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -82,10 +82,9 @@ projects:
     patch:
       1931862: 'http://drupal.org/files/dont-render-bueditor-for-plain-text-textareas.patch'
   colorizer:
-    version: '1.8'
+    version: '1.10'
     patch:
       2227651: 'https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch'
-      2599298: 'https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch'
   conditional_styles:
     version: '2.2'
   diff:


### PR DESCRIPTION
Issue: #1089

## Description
Colorizer is two versions behind.

## Acceptance criteria
- [ ] tests pass
- [ ] Code from https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch applies cleanly
