### PR TITLE
Update make file to point to add-line-plus-bar-chart repos

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -10,7 +10,7 @@ includes:
     # Visualization Entity
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make"
     # Visualization Entity Charts
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity_charts/master/visualization_entity_charts.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity_charts/add-line-plus-bar-chart/visualization_entity_charts.make"
     #DKAN Data Story
   - "modules/dkan/dkan_data_story/dkan_data_story.make"
     #DKAN Featured Topics
@@ -73,7 +73,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/visualization_entity_charts.git'
-      branch: master
+      branch: add-line-plus-bar-chart
     type: module
   admin_menu:
     version: 3.0-rc5


### PR DESCRIPTION
Issue: 
https://jira.govdelivery.com/browse/CIVIC-727
https://jira.govdelivery.com/browse/CIVIC-1323

## Description
Line plus bar chart was not implemented in recline view nvd3. Also fix colorpicker dependency.

## User story / stories
• The user should be able to generate a line plus bar chart where one Y axis (y1) is represented as a bar chart, and the additional Y axes are represented as line graphs. 
• The controls for the line plus bar chart should allow for the y1 and y2 axes to be formatted using the existing formatters, and the tick values (range and step) should be user-configurable as per existing y axis values for other charts. 
• User should be able to disable tooltips for all chart types

## Acceptance criteria
* Create a chart with multiple y series using the line-plus-bar-chart graph type. Ensure that all controls and functionality (as per user story above) work. 
* Additionally, help QA other visualization enetity chart functionality and chart types to ensure that refactoring did not break existing functionality.
• User can disable tooltips using chart UI for all chart types

## PR dependencies
https://github.com/NuCivic/recline.view.nvd3.js/pull/25
https://github.com/NuCivic/visualization_entity_charts/pull/27

