### PR TITLE
Helper to build docker mysql url

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -4,7 +4,12 @@ commands:
   drupal-rebuild:
     usage: 'Builds a drupal site in ./docroot. Requires database url.'
     cmd: |
-      if [[ "{{args}}" != mysql* ]]; then
+      if [ "$AHOY_CMD_PROXY" != "DOCKER" ]; then
+        ARGS="{{args}}"
+      else
+        ARGS=`ahoy docker mysql-url`
+      fi
+      if [[ "$ARGS" != mysql* ]]; then
           echo "You need to specify the drupal db url to use in the form mysql://root:root@localhost/db as an argument."
           exit 1
       fi
@@ -16,7 +21,7 @@ commands:
       fi
       ahoy drush make --prepare-install dkan/drupal-org-core.make docroot --yes
       ln -s ../../dkan docroot/profiles/dkan &&
-      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module=\"'array\(FALSE,FALSE\)'\""
+      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url=$ARGS install_configure_form.update_status_module='''''array\(FALSE,FALSE\)'''''"
 
   remake:
     usage: Rebuild all the dkan projects from the drupal-org.make file using drush make.
@@ -41,7 +46,13 @@ commands:
         ahoy dkan sqlc <  backups/last_install.sql && \
         echo "Installed dkan from backup"
       else
-        ahoy drush "si dkan --verbose --account-pass='admin' --site-name='DKAN' install_configure_form.update_status_module=\"\'array\(FALSE,FALSE\)\'\" --yes" && \
+        if [ "$AHOY_CMD_PROXY" == "DOCKER" ]; then
+          MYSQL=`ahoy docker mysql-url`
+          MYSQL="--db-url=$MYSQL"
+        else
+          MYSQL=''
+        fi
+        ahoy drush "si dkan --verbose --account-pass='admin' $MYSQL --site-name='DKAN' install_configure_form.update_status_module='''''array\(FALSE,FALSE\)''''' --yes" && \
         ahoy drush sql-dump > backups/last_install.sql.tmp && \
         mv backups/last_install.sql.tmp backups/last_install.sql && \
         echo "Installed DKAN and created a new backup at backups/last_install.sql"

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -66,7 +66,9 @@ commands:
     usage: run a command in the docker-compose cli service container.
   mysql-url:
     cmd: |
-      docker exec -it $(ahoy docker compose ps -q cli) bash -c 'echo "mysql://$DB_1_ENV_MYSQL_USER:$DB_1_ENV_MYSQL_PASSWORD@$DB_1_PORT_3306_TCP_ADDR/$DB_1_ENV_MYSQL_DATABASE"'
+      MYSQL=`docker exec -it $(ahoy docker compose ps -q cli) bash -c 'echo "mysql://$DB_1_ENV_MYSQL_USER:$DB_1_ENV_MYSQL_PASSWORD@$DB_1_PORT_3306_TCP_ADDR/$DB_1_ENV_MYSQL_DATABASE"'`
+      MYSQL="$(echo -e "${MYSQL}" | tr -d '[[:space:]]')"
+      echo "$MYSQL"
     usage: Outputs a mysql-url
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -63,8 +63,11 @@ commands:
         # if the input is not empty, then don't use tty
         docker exec -i $id bash -c "$command $args"
       fi
-    usage: run a command in the docker-compose cli or in any other docker service container.
-
+    usage: run a command in the docker-compose cli service container.
+  mysql-url:
+    cmd: |
+      docker exec -it $(ahoy docker compose ps -q cli) bash -c 'echo "mysql://$DB_1_ENV_MYSQL_USER:$DB_1_ENV_MYSQL_PASSWORD@$DB_1_PORT_3306_TCP_ADDR/$DB_1_ENV_MYSQL_DATABASE"'
+    usage: Outputs a mysql-url
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.


### PR DESCRIPTION
## Description
If you are using docker, this helps with the construction for the `mysql://` uri

## User story

As a developer, i need a quick way to set up the drupal database settings within the docker environment.

## Acceptance criteria
- [x] Set `AHOY_CMD_PROXY="DOCKER"` for the environment
- [x] Run `ahoy dkan drupal-rebuild` without passing arguments and it should rebuild and do the minimal install
- [x] Run `ahoy dkan reinstall` without any argument and it should reinstall dkan with the appropriate db settings #