### PR TITLE
GH-951 add formating to filesize display

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -113,7 +113,7 @@ function dkan_sitewide_resource_additional_block($nid = '') {
 
     if (($file = $link) || ($file = $upload)) {
       $file_info[] = array(t('mimetype'), $file['filemime']);
-      $file_info[] = array(t('filesize'), $file['filesize']);
+      $file_info[] = array(t('filesize'), format_size($file['filesize']));
       $file_info[] = array(t('resource type'), 'file upload');
       $file_info[] = array(t('timestamp'), date('M d, Y', $file['timestamp']));
       return theme('table',


### PR DESCRIPTION
https://github.com/NuCivic/dkan/issues/951

## Description
file sizes are displayed as just a string of numbers, lets format those to be easier to 'read'

## Acceptance criteria
- [ ] Add a large file to a resource.
- [ ] Confirm that the size is displayed in bytes or MB

![screenshot_5_3_16__4_35_pm](https://cloud.githubusercontent.com/assets/314172/14999262/befb4442-114d-11e6-89b6-859c7dbd2602.png)
