### PR TITLE
Allow users to run `ahoy docker exec` in all cases.

### DIFF
--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -41,14 +41,28 @@ commands:
     usage: Destroy all the docker compose containers. (use before deleting folder)
   exec:
     cmd: |
+      all_args=$(echo {{args}})
+      first_arg=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \).*/\1/')
+      rest_args=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \)//')
+      case $first_arg in
+        *web*|*db*|*memcached*|*cli*|*browser*|*solr*)
+          container=$first_arg
+          args=$rest_args
+          ;;
+        *)
+          container=cli
+          args=$all_args
+          ;;
+      esac
+
       if [ -t 0 ]; then
         # if the input is empty, then use a tty session
-        docker exec -it $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -it $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       else
         # if the input is not empty, then don't use tty
-        docker exec -i $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -i $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       fi
-    usage: run a command in the docker-compose cli service container.
+    usage: run a command in the docker-compose cli or in any other docker service container.
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.


### PR DESCRIPTION
Ref CIVIC-2483.

Acceptance
=========
- [ ] `ahoy docker exec ls -la` works as expected.
- [ ] `ahoy docker exec web ls -la` run command but in web container instead of cli.
- [ ] `ahoy docker exec browser bash` logs you into the browser container.