### PR TITLE
Update make to point to add-line-plus-bar-chart

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -73,7 +73,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/visualization_entity_charts.git'
-      branch: master
+      branch: add-line-plus-bar-chart
     type: module
   admin_menu:
     version: 3.0-rc5


### PR DESCRIPTION
https://jira.govdelivery.com/browse/CIVIC-727
https://jira.govdelivery.com/browse/CIVIC-1323

## Description
• Includes new chart type linePlusBar
• Includes update for tooltip disable

## User story / stories
User should be able to create a line plus bar type of chart and it works.
User should be able to disable tooltips in their chart visualizations.

## Acceptance criteria
[-] Line plus bar chart can be instantiated (you need to add two data series)
[-] Line plus bar chart Y axes formatters, range and step fields work
[-] User can switch which y axis is represented as a bar chart
[-] User can disable tooltips for all chart types
[-] Other functionality is still sane and not broken

## PR dependencies
https://github.com/NuCivic/recline.view.nvd3.js/pull/25
https://github.com/NuCivic/visualization_entity_charts/pull/27
