### PR TITLE
Use nuams/drupal-cli container.

### DIFF
--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -43,7 +43,7 @@ db:
 # Used for all console commands and tools.
 cli:
   hostname: cli
-  image: devinci/drupal-cli
+  image: nuams/drupal-cli
   environment:
     - XDEBUG_CONFIG=idekey=cli
     - PHP_IDE_CONFIG=serverName=dkan.docker


### PR DESCRIPTION
The nuams/drupal-cli container now has `drush rr` out of the box.

Ref Civi-2385


Acceptance
==========
- [x] `ahoy docker up && ahoy drush rr --help` works as expected.