### PR TITLE
Allow `ahoy docker exec` on all containers.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -16,7 +16,7 @@ commands:
       fi
       ahoy drush make --prepare-install dkan/drupal-org-core.make docroot --yes
       ln -s ../../dkan docroot/profiles/dkan &&
-      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module='''''array\(FALSE,FALSE\)'''''"
+      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module=\"'array\(FALSE,FALSE\)'\""
 
   remake:
     usage: Rebuild all the dkan projects from the drupal-org.make file using drush make.
@@ -40,7 +40,7 @@ commands:
         ahoy dkan sqlc <  backups/last_install.sql && \
         echo "Installed dkan from backup"
       else
-        ahoy drush "si dkan --verbose --account-pass='admin' --site-name='DKAN' install_configure_form.update_status_module='''''array\(FALSE,FALSE\)''''' --yes" && \
+        ahoy drush "si dkan --verbose --account-pass='admin' --site-name='DKAN' install_configure_form.update_status_module=\"\'array\(FALSE,FALSE\)\'\" --yes" && \
         ahoy drush sql-dump > backups/last_install.sql.tmp && \
         mv backups/last_install.sql.tmp backups/last_install.sql && \
         echo "Installed DKAN and created a new backup at backups/last_install.sql"

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -47,22 +47,24 @@ commands:
       case $first_arg in
         *web*|*db*|*memcached*|*cli*|*browser*|*solr*)
           container=$first_arg
-          args=$rest_args
+          args=" $rest_args"
           ;;
         *)
           container=cli
-          args=$all_args
+          args=" $all_args"
           ;;
       esac
 
+      id=$(ahoy docker compose ps -q $container)
       if [ -t 0 ]; then
         # if the input is empty, then use a tty session
-        docker exec -it $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
+        docker exec -it $id bash -c $command "$args"
       else
         # if the input is not empty, then don't use tty
-        docker exec -i $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
+        docker exec -i $id bash -c $command "$args"
       fi
     usage: run a command in the docker-compose cli or in any other docker service container.
+
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -41,14 +41,28 @@ commands:
     usage: Destroy all the docker compose containers. (use before deleting folder)
   exec:
     cmd: |
+      all_args=$(echo {{args}})
+      first_arg=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \).*/\1/')
+      rest_args=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \)//')
+      case $first_arg in
+        *web*|*db*|*memcached*|*cli*|*browser*|*solr*)
+          container=$first_arg
+          args=$rest_args
+          ;;
+        *)
+          container=cli
+          args=$all_args
+          ;;
+      esac
+
       if [ -t 0 ]; then
         # if the input is empty, then use a tty session
-        docker exec -it $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -it $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       else
         # if the input is not empty, then don't use tty
-        docker exec -i $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -i $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       fi
-    usage: run a command in the docker-compose cli service container.
+    usage: run a command in the docker-compose cli or in any other docker service container.
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.


### PR DESCRIPTION
Ref CIVIC-2593 CIVIC-2483 CIVIC-2392

This implementation also fixes `ahoy dkan reinstall` which broke when the new `ahoy docker exec` was implemented.

Accetance
========
- [ ] `ahoy docker exec ls -la` works as expected.
- [ ] `ahoy docker exec web ls -la` works too.
- [ ] `ahoy dkan reinstall` is not broken.