### PR TITLE
Use nuams/web container.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -16,7 +16,7 @@ commands:
       fi
       ahoy drush make --prepare-install dkan/drupal-org-core.make docroot --yes
       ln -s ../../dkan docroot/profiles/dkan &&
-      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module='''''array\(FALSE,FALSE\)'''''"
+      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module=\"'array\(FALSE,FALSE\)'\""
 
   remake:
     usage: Rebuild all the dkan projects from the drupal-org.make file using drush make.
@@ -40,7 +40,7 @@ commands:
         ahoy dkan sqlc <  backups/last_install.sql && \
         echo "Installed dkan from backup"
       else
-        ahoy drush "si dkan --verbose --account-pass='admin' --site-name='DKAN' install_configure_form.update_status_module='''''array\(FALSE,FALSE\)''''' --yes" && \
+        ahoy drush "si dkan --verbose --account-pass='admin' --site-name='DKAN' install_configure_form.update_status_module=\"\'array\(FALSE,FALSE\)\'\" --yes" && \
         ahoy drush sql-dump > backups/last_install.sql.tmp && \
         mv backups/last_install.sql.tmp backups/last_install.sql && \
         echo "Installed DKAN and created a new backup at backups/last_install.sql"

--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -4,7 +4,7 @@
 # Web node
 web:
   hostname: web
-  image: blinkreaction/drupal-apache-php:2.2-5.5
+  image: nuams/drupal-apache-php:1.0-5.5
   environment:
     - VIRTUAL_HOST=dkan.docker
     #- VIRTUAL_PROTO=https

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -47,22 +47,24 @@ commands:
       case $first_arg in
         *web*|*db*|*memcached*|*cli*|*browser*|*solr*)
           container=$first_arg
-          args=$rest_args
+          args=" $rest_args"
           ;;
         *)
           container=cli
-          args=$all_args
+          args=" $all_args"
           ;;
       esac
 
+      id=$(ahoy docker compose ps -q $container)
       if [ -t 0 ]; then
         # if the input is empty, then use a tty session
-        docker exec -it $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
+        docker exec -it $id bash -c $command "$args"
       else
         # if the input is not empty, then don't use tty
-        docker exec -i $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
+        docker exec -i $id bash -c $command "$args"
       fi
     usage: run a command in the docker-compose cli or in any other docker service container.
+
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -41,14 +41,28 @@ commands:
     usage: Destroy all the docker compose containers. (use before deleting folder)
   exec:
     cmd: |
+      all_args=$(echo {{args}})
+      first_arg=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \).*/\1/')
+      rest_args=$(echo {{args}} | sed  's/\([[:alnum:]]*\ \)//')
+      case $first_arg in
+        *web*|*db*|*memcached*|*cli*|*browser*|*solr*)
+          container=$first_arg
+          args=$rest_args
+          ;;
+        *)
+          container=cli
+          args=$all_args
+          ;;
+      esac
+
       if [ -t 0 ]; then
         # if the input is empty, then use a tty session
-        docker exec -it $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -it $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       else
         # if the input is not empty, then don't use tty
-        docker exec -i $(ahoy docker compose ps -q cli) bash -c '{{args}}'
+        docker exec -i $(ahoy docker compose ps -q $container) bash -c " ${args[@]}"
       fi
-    usage: run a command in the docker-compose cli service container.
+    usage: run a command in the docker-compose cli or in any other docker service container.
   mysql:
     cmd: "docker exec -it $(ahoy docker compose ps -q cli) bash -c 'mysql -uroot -p$DB_ENV_MYSQL_ROOT_PASSWORD -h$DB_PORT_3306_TCP_ADDR $DB_ENV_MYSQL_DATABASE'"
     usage: Connect to the default mysql database as the root user.

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -104,3 +104,42 @@ commands:
         docker rmi $DANGLING
       fi
       docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes
+
+  log:
+    usage: Target spcific logs using tail -f.  targets the error log by default.
+    cmd: |
+      args=$(echo {{args}})
+      case $args in
+        access)
+          ahoy docker exec web tail -f /var/log/apache2/access.log
+          ;;
+        error)
+          ahoy docker exec web tail -f /var/log/apache2/error.log
+          ;;
+        *)
+          ahoy docker exec web tail -f /var/log/apache2/error.log
+          ;;
+      esac
+
+  apache:
+    usage: Interact with the docker apache service Accepts start, stop, restart.
+    cmd: ahoy docker exec web service apache2 {{args}}
+
+  xdebug:
+    usage: Enable or disable xdebug configuration. Accepts stop or start
+    cmd: |
+      args=$(echo {{args}})
+      case $args in
+        start)
+        ahoy docker exec web cp -f /etc/php5/xdebug.ini /etc/php5/mods-available
+        ahoy docker apache restart
+          ;;
+        stop)
+        ahoy docker exec web rm -f /etc/php5/mods-available/xdebug.ini
+        ahoy docker apache restart
+          ;;
+        *)
+          echo "Accepted arguments are 'sart' or 'stop'".
+          exit 1
+          ;;
+      esac


### PR DESCRIPTION
Ref CIVIC-2392

The new container adds does not have xdebug configured. Some new helper
commands have been added.

`ahoy docker apache start|stop|restart`
`ahoy docker xdebug start|stop`
`ahoy docker log (access|error)`

Acceptance
=========
- [x] Local errors are logged when xdebug does not get in the way.
- [x] `ahoy docker apache restart` restarts apache
- [x] `ahoy docker log` tails the error log.