### PR TITLE
Remove "Sitewide" from DKAN Data Dashboard module name

### DIFF
--- a/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.info
+++ b/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.info
@@ -1,4 +1,4 @@
-name = DKAN Sitewide Data Dashboard
+name = DKAN Data Dashboard
 description = DKAN module for Data Dashboard content type
 core = 7.x
 package = DKAN


### PR DESCRIPTION
Just want to remove the word "Sitewide" from the module name for consistency.