### PR TITLE
Add text to icon links for 508 compliance

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -185,7 +185,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/nuboot_radix.git'
-      branch: 7.x-1.x
+      branch: civic-2199-front-page
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -185,7 +185,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/nuboot_radix.git'
-      branch: civic-2199-front-page
+      branch: 7.x-1.x
     type: theme
   radix:
     type: theme

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -123,12 +123,9 @@ function dkan_topics_views_pre_render(&$view) {
           if(!empty($row->field_field_topic_icon_color[0]['raw']['rgb'])) {
             $new_prefix .= ' style="color:' . $row->field_field_topic_icon_color[0]['raw']['rgb'] . '"';
           }
-          else {
-            $new_prefix .= '';
-          }
           $new_prefix .= $prefix_clipped;
           $row->field_field_topic_icon[0]['rendered']['#prefix'] = $new_prefix;
-          $row->field_field_topic_icon[0]['rendered']['#suffix'] = '</a>';
+          $row->field_field_topic_icon[0]['rendered']['#suffix'] = '<span class="screenreader">icon</span></a>';
         }
       }
     }
@@ -194,7 +191,7 @@ function dkan_topics_field_formatter_view($entity_type, $entity, $field, $instan
           'name' => array(
             '#type' => 'markup',
             '#markup' => check_plain($term->name),
-            '#prefix' => '<a class="name" href="' . $url . '">',
+            '#prefix' => '<a href="' . $url . '">',
             '#suffix' => '</a>',
             ),
           );

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -191,7 +191,7 @@ function dkan_topics_field_formatter_view($entity_type, $entity, $field, $instan
           'name' => array(
             '#type' => 'markup',
             '#markup' => check_plain($term->name),
-            '#prefix' => '<a href="' . $url . '">',
+            '#prefix' => '<a class="name" href="' . $url . '">',
             '#suffix' => '</a>',
             ),
           );


### PR DESCRIPTION
Issue: civic 2580
https://github.com/NuCivic/dkan/issues/1088

## Description
508 fail: Front Page
Topics view contains empty links (icons)
![screenshot_4_25_16__1_26_pm](https://cloud.githubusercontent.com/assets/314172/14794514/260b200e-0aea-11e6-87c2-44ea9f8b123a.png)

## Acceptance criteria
- [ ] When viewing the front page with the WAVE compliance tool you should not see any red flags.

![screenshot_5_24_16__4_41_pm](https://cloud.githubusercontent.com/assets/314172/15520935/778784b8-21ce-11e6-94d6-3f3d413a1876.png)


## PR Dependency
https://github.com/NuCivic/nuboot_radix/pull/85

Update drupal-org.make file to reset the nuboot_radix branch back to 7.x-1.x before merge.
