### PR TITLE
Fix ahoy dkan test command.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -145,7 +145,6 @@ commands:
         echo "$BEHAT_ENV"
         echo "Using behat.yml .."
       fi
-      echo "The behat folder: $BEHAT_FOLDER"
       ahoy cmd-proxy "cd $BEHAT_FOLDER \&\& bin/behat $CONFIG ${ARGS[@]}"
 
   dkanextension-update:

--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -127,7 +127,7 @@ commands:
       SKIP_COMPOSER_FLAG="--skip-composer"
       if [[ ! "${ARGS[@]}" == *"$SKIP_COMPOSER_FLAG"* ]]; then
         echo "Installing behat dependencies.."
-        ahoy cmd-proxy "cd $BEHAT_FOLDER && composer install --prefer-source --no-interaction"
+        ahoy cmd-proxy "cd $BEHAT_FOLDER \&\& composer install --prefer-source --no-interaction"
       else
         echo "Skipping composer install.."
         ARGS=( "${ARGS[@]/$SKIP_COMPOSER_FLAG}" )
@@ -145,11 +145,12 @@ commands:
         echo "$BEHAT_ENV"
         echo "Using behat.yml .."
       fi
-      ahoy cmd-proxy "cd $BEHAT_FOLDER && bin/behat $CONFIG ${ARGS[@]}"
+      echo "The behat folder: $BEHAT_FOLDER"
+      ahoy cmd-proxy "cd $BEHAT_FOLDER \&\& bin/behat $CONFIG ${ARGS[@]}"
 
   dkanextension-update:
     usage: Update the nucivic/dkanextension composer package.
-    cmd: ahoy cmd-proxy 'cd dkan/test && composer update nucivic/dkanextension'
+    cmd: ahoy cmd-proxy 'cd dkan/test \&\& composer update nucivic/dkanextension'
 
   sqlc:
     usage: Abstracted way to connect to the mysql database.


### PR DESCRIPTION
Ref CIVIC-2718

`ahoy dkan test` is failling locally do to ahoy exec/cmd-proxy requiring a new abstraction step.  Some characters now require to be escaped in order to work properly.

AC
==
- [ ] `ahoy dkan test` runs locally.