### PR TITLE
Fix `ahoy compare` default not working.

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -32,11 +32,12 @@ commands:
   reinstall:
     usage: Reinstall the dkan install profile (db only).
     cmd: |
+      set -e
       if [ ! -d backups ]; then
         mkdir backups
       fi
       if [ -f backups/last_install.sql ] && ahoy confirm "An existing installation backup exists at backups/last_install.sql, do you want to use that instead of reinstalling from scratch?"; then
-        ahoy drush sql-drop -y &&
+        ahoy drush sql-drop -y && \
         ahoy dkan sqlc <  backups/last_install.sql && \
         echo "Installed dkan from backup"
       else

--- a/.ahoy/starter.ahoy.yml
+++ b/.ahoy/starter.ahoy.yml
@@ -12,7 +12,7 @@ commands:
 
 # Utility / Experimental commands that are currently hidden
   confirm:
-    cmd: ahoy -f dkan/.ahoy/utils.ahoy.yml confirm {{args}}
+    cmd: ahoy -f dkan/.ahoy/utils.ahoy.yml confirm "{{args}}"
     hide: true
 
   docker:

--- a/.ahoy/utils.ahoy.yml
+++ b/.ahoy/utils.ahoy.yml
@@ -4,7 +4,7 @@ commands:
     confirm:
       cmd: |
         read -r -p "{{args}} [y/N] " response
-        if [ $response = y ]
+        if [ "$response" = y ] || [ "$response" = Y ];
         then
           true
         else


### PR DESCRIPTION
There may be an issue with DB backup not getting created on `ahoy dkan reinstall`.
However, this is likely an underlying issue with `ahoy compare` not able to
handle the default behavior without throwing an error.

This commit fixes that issue and by proxy the other issue.

Ref civic-2918

AC
==
- [x]  `ahoy dkan reinstall` creates a backup db in <root>/backups/
- [x] `ahoy dkan reinstall` does not throw error if user presses enter without confirming.