### PR TITLE
Viz perms release

### DIFF
--- a/modules/dkan/dkan_permissions/dkan_permissions.features.roles_permissions.inc
+++ b/modules/dkan/dkan_permissions/dkan_permissions.features.roles_permissions.inc
@@ -175,6 +175,7 @@ function dkan_permissions_default_roles_permissions() {
       'eck delete visualization ve_chart entities' => TRUE,
       'eck edit entities' => TRUE,
       'eck edit visualization ve_chart entities' => TRUE,
+      'eck list bundles' => TRUE,
       'eck list entities' => TRUE,
       'eck list visualization ve_chart entities' => TRUE,
       'eck view entities' => TRUE,


### PR DESCRIPTION
Brings in editor permissions for ECK, solving problem of editors not being able to use viz entity admin menu items.

# Acceptance test

- [ ] Editor should have "View Bundle Lists" permission
- [ ] Editor should see "visualizations" in the admin menu