### PR TITLE
Remove insert a definition list button from bueditor toolbar

### DIFF
--- a/dkan.profile
+++ b/dkan.profile
@@ -295,6 +295,11 @@ function dkan_delete_markdown_buttons(&$context) {
     ->condition('eid', $eid)
     ->execute();
 
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert a definition list')
+    ->condition('eid', $eid)
+    ->execute();
+
   // Update markdown linebreak button with html.
   db_update('bueditor_buttons')
     ->fields(array('content' => '<br>'))

--- a/test/features/markdown_editor.feature
+++ b/test/features/markdown_editor.feature
@@ -29,7 +29,6 @@ Feature: Markdown Editor
     And I should see the button "Make selected text into a block quote (Alt + Q)" in the "dataset edit body"
     And I should see the button "Make selected text into an ordered list (numbered) (Alt + O)" in the "dataset edit body"
     And I should see the button "Make selected text into an unordered list (bullets) (Alt + N)" in the "dataset edit body"
-    And I should see the button "Insert a definition list" in the "dataset edit body"
     And I should see the button "Make text into an autolink (turns URLs in links, turns words into section identifiers for navigating the document) (Alt + A)" in the "dataset edit body"
     And I should see the button "Make text into a link (turns text into a link with more options) (Alt + L)" in the "dataset edit body"
     And I should see the button "Insert an image (Alt + M)" in the "dataset edit body"
@@ -41,6 +40,7 @@ Feature: Markdown Editor
     And I should not see the button "Insert a footnote" in the "dataset edit body"
     And I should not see the button "Insert a horizontal ruler (horizontal line)" in the "dataset edit body"
     And I should not see the button "Teaser break" in the "dataset edit body"
+    And I should not see the button "Insert a definition list" in the "dataset edit body"
 
   Scenario: Seeing 'Markdown' text format and toolbar as an Editor
     Given I am logged in as "Jaz"

--- a/test/features/recline.feature
+++ b/test/features/recline.feature
@@ -87,6 +87,7 @@ Feature: Recline
     And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv"
     And I press "edit-submit"
     Then I should see "Polling_Places_Madison_0.csv"
+    Then I wait for "3" seconds
     Given I click "»"
     Then I wait for "Our"
     Then I wait for "1" seconds


### PR DESCRIPTION
Issue: civic-2961

## Description
Users should only be presented with mark up options that are allowed by the html filter. Definition lists are not allowed, the button to insert a definition list should be removed.

## Acceptance criteria
When logged in as a site manager, editor, or content creator, I should not see the Insert a Definition List button when using the html markdown text format.

