### PR TITLE
fix recline test

### DIFF
--- a/test/features/recline.feature
+++ b/test/features/recline.feature
@@ -87,6 +87,7 @@ Feature: Recline
     And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv"
     And I press "edit-submit"
     Then I should see "Polling_Places_Madison_0.csv"
+    Then I wait for "3" seconds
     Given I click "»"
     Then I wait for "Our"
     Then I wait for "1" seconds

--- a/test/features/recline.feature
+++ b/test/features/recline.feature
@@ -87,12 +87,11 @@ Feature: Recline
     And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv"
     And I press "edit-submit"
     Then I should see "Polling_Places_Madison_0.csv"
-    Then I wait for "3" seconds
+    Then I wait for "»"
     Given I click "»"
     Then I wait for "Our"
-    Then I wait for "1" seconds
+    Then I wait for "«"
     Given I click "«"
-    Then I wait for "1" seconds
     Then I wait for "East"
     Given I fill in "q" with "Glendale"
     When I press "Go"


### PR DESCRIPTION
## Description
The recline test started failing after the wait 3 seconds was removed, so adding it back.

<img width="1206" alt="nucivic_dkan__2224_-_circleci" src="https://cloud.githubusercontent.com/assets/314172/16138592/b7923ed4-3404-11e6-9ff2-8754f25c1779.png">


## Acceptance criteria
- [ ] Tests pass
