### PR TITLE
Add roleassign module, update permissions, add tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.4 2016-07-12
 --------------------------
 - Update permissions in DKAN Permissions module to allow anonymous users to access RDF endpoints for individual datasets.
+- Add RoleAssign module, update DKAN Permissions to give site managers permission to assign roles.
 
 7.x-1.12.3 2016-06-30
 --------------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,13 +1,17 @@
+7.x-1.12.x
+--------------------------
+- Theme updates back ported from dev branch, including topics icons in topics drop-down menu
+- Add RoleAssign module, update DKAN Permissions to give site managers permission to assign roles.
+
 7.x-1.12.5 2016-07-13
 --------------------------
 - Update restws to 7.x-2.6 (critical security update)
 - Update to latest version of recline.js to fix map tiles (Mapquest discontinued open access)
-- Upgrade Drupal core to 7.50 
+- Upgrade Drupal core to 7.50
 
 7.x-1.12.4 2016-07-12
 --------------------------
 - Update permissions in DKAN Permissions module to allow anonymous users to access RDF endpoints for individual datasets.
-- Add RoleAssign module, update DKAN Permissions to give site managers permission to assign roles.
 
 7.x-1.12.3 2016-06-30
 --------------------------

--- a/dkan.info
+++ b/dkan.info
@@ -74,7 +74,6 @@ dependencies[] = path_breadcrumbs
 dependencies[] = path_breadcrumbs_ui
 dependencies[] = pathauto
 dependencies[] = radix_layouts
-dependencies[] = roleassign
 dependencies[] = rules
 dependencies[] = rules_admin
 dependencies[] = select_or_other

--- a/dkan.info
+++ b/dkan.info
@@ -74,6 +74,7 @@ dependencies[] = path_breadcrumbs
 dependencies[] = path_breadcrumbs_ui
 dependencies[] = pathauto
 dependencies[] = radix_layouts
+dependencies[] = roleassign
 dependencies[] = rules
 dependencies[] = rules_admin
 dependencies[] = select_or_other

--- a/dkan.profile
+++ b/dkan.profile
@@ -44,8 +44,14 @@ function dkan_additional_setup() {
       array('dkan_group_link_delete', array()),
       array('dkan_install_default_content', array()),
       array('dkan_set_adminrole', array()),
+      array('dkan_set_roleassign_roles', array()),
     ),
   );
+}
+
+function dkan_set_roleassign_roles(&$context) {
+  $roles = array('editor' => 'editor', 'site manager' => 'site manager', 'content creator' => 'content creator', 'administrator' => 0);
+  variable_set('roleassign_roles', $roles);
 }
 
 function dkan_theme_config(&$context) {

--- a/dkan.profile
+++ b/dkan.profile
@@ -49,10 +49,6 @@ function dkan_additional_setup() {
   );
 }
 
-function dkan_set_roleassign_roles(&$context) {
-  $roles = array('editor' => 'editor', 'site manager' => 'site manager', 'content creator' => 'content creator', 'administrator' => 0);
-  variable_set('roleassign_roles', $roles);
-}
 
 function dkan_theme_config(&$context) {
   $context['message'] = t('Setting theme options.');
@@ -399,4 +395,19 @@ function dkan_delete_markdown_buttons(&$context) {
 function dkan_group_link_delete(&$context) {
   $context['message'] = t('Removing og_extra groups link');
   db_query('DELETE FROM {menu_links} WHERE link_path = :link_path LIMIT 1', array(':link_path' => 'groups'));
+}
+
+/**
+ * Set up the roles that sitemanagers are allowed to assign via role assign
+ * module. Should be everything except admin.
+ */
+function dkan_set_roleassign_roles(&$context) {
+  $context['message'] = t('Configuring Role Assign module');
+  $roles_rids = array_flip(user_roles());
+  $roleassign_roles = array($roles_rids['administrator'] => 0);
+  $allowed_roles = array('editor', 'site manager', 'content creator');
+  foreach($allowed_roles as $role) {
+    $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
+  }
+  variable_set('roleassign_roles', $roleassign_roles);
 }

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -138,6 +138,8 @@ projects:
     version: '2.9'
   restws:
     version: '2.5'
+  roleassign:
+    version: '1.1'
   schema:
     version: '1.2'
   adminrole:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,7 +4,7 @@ core: 7.x
 includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
-- https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
+- https://raw.githubusercontent.com/NuCivic/dkan_workflow/civic-2811-assign-roles/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
@@ -55,7 +55,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_workflow.git
-      branch: release-1-12
+      branch: civic-2811-assign-roles
   visualization_entity:
     download:
       type: git

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -140,6 +140,9 @@ projects:
     version: '2.5'
   roleassign:
     version: '1.1'
+    # Features export fix
+    patch:
+      2189541: https://www.drupal.org/files/issues/roleassign-features-export-2189541-1.patch
   schema:
     version: '1.2'
   adminrole:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,7 +4,7 @@ core: 7.x
 includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
-- https://raw.githubusercontent.com/NuCivic/dkan_workflow/civic-2811-assign-roles/dkan_workflow.make
+- https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
@@ -55,7 +55,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_workflow.git
-      branch: civic-2811-assign-roles
+      branch: release-1-12
   visualization_entity:
     download:
       type: git
@@ -140,9 +140,6 @@ projects:
     version: '2.6'
   roleassign:
     version: '1.1'
-    # Features export fix
-    patch:
-      2189541: https://www.drupal.org/files/issues/roleassign-features-export-2189541-1.patch
   schema:
     version: '1.2'
   adminrole:

--- a/modules/dkan/dkan_permissions/dkan_permissions.features.roles_permissions.inc
+++ b/modules/dkan/dkan_permissions/dkan_permissions.features.roles_permissions.inc
@@ -265,6 +265,7 @@ function dkan_permissions_default_roles_permissions() {
       'administer taxonomy' => TRUE,
       'administer url aliases' => TRUE,
       'administer users' => TRUE,
+      'assign roles' => TRUE,
       'bypass file access' => TRUE,
       'bypass node access' => TRUE,
       'change layouts in place editing' => TRUE,

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.features.filter.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.features.filter.inc
@@ -32,11 +32,6 @@ function dkan_sitewide_filter_default_formats() {
           'filter_html_nofollow' => 0,
         ),
       ),
-      'filter_autop' => array(
-        'weight' => 0,
-        'status' => 1,
-        'settings' => array(),
-      ),
       'filter_url' => array(
         'weight' => -45,
         'status' => 1,
@@ -46,6 +41,11 @@ function dkan_sitewide_filter_default_formats() {
       ),
       'filter_htmlcorrector' => array(
         'weight' => -44,
+        'status' => 1,
+        'settings' => array(),
+      ),
+      'filter_autop' => array(
+        'weight' => 0,
         'status' => 1,
         'settings' => array(),
       ),

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.info
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.info
@@ -19,6 +19,7 @@ dependencies[] = google_fonts_api
 dependencies[] = markdown
 dependencies[] = module_filter
 dependencies[] = restws
+dependencies[] = roleassign
 dependencies[] = strongarm
 dependencies[] = text
 features[ctools][] = strongarm:strongarm:1

--- a/test/features/user.admin.feature
+++ b/test/features/user.admin.feature
@@ -57,7 +57,7 @@ Feature: User
     # Site managers trigger honeypot when creating users.
     # See https://github.com/NuCivic/dkan/issues/811
     # Workaround: Wait for 6 seconds so that honeypot doesn't overreact
-  Scenario: Create user
+  Scenario: Create user and assign role as site manager
     Given I am logged in as "John"
     And I am on "Users" page
     When I follow "Add user"
@@ -66,9 +66,12 @@ Feature: User
       | E-mail address    | tempuser@example.com |
       | Password          | temp123              |
       | Confirm password  | temp123              |
+    And I check "editor"
     And I wait for 6 seconds
     And I press "Create new account"
     Then I should see "Created a new user account for tempuser."
+    When I am on "Users" page
+    Then I should see "editor" in the "tempuser" row
 
   Scenario: Block user
     Given I am logged in as "John"
@@ -89,7 +92,7 @@ Feature: User
     And I press "Cancel account"
     Then I wait for "Katie has been disabled"
 
-  Scenario: Modify user roles
+  Scenario: Modify user roles as administrator
     Given I am logged in as "aadmin"
     And I am on "Users" page
     When I click "edit" in the "Jaz" row
@@ -100,6 +103,16 @@ Feature: User
     When I am on "Users" page
     Then I should see "content creator" in the "Jaz" row
 
+  Scenario: Modify user roles as site manager
+    Given I am logged in as "John"
+    And I am on "Users" page
+    When I click "edit" in the "Jaz" row
+    And I uncheck "content creator"
+    And I check "site manager"
+    And I press "Save"
+    Then I should see "The changes have been saved"
+    When I am on "Users" page
+    Then I should see "site manager" in the "Jaz" row
 
 
 

--- a/test/features/user.admin.feature
+++ b/test/features/user.admin.feature
@@ -114,7 +114,7 @@ Feature: User
     When I am on "Users" page
     Then I should see "site manager" in the "Jaz" row
 
-
-
-
-
+Scenario: Modify user as editor
+    Given I am logged in as "Jaz"
+    And I am on "Users" page
+    Then I should see "Access denied"


### PR DESCRIPTION
issue: civic 2811
https://github.com/NuCivic/dkan/issues/1180

## Description
As a Site Manager creating a new user, I am not allowed to set the user's role in DKAN 7.x-1.12.

## User story / stories
- [ ] As a site manager I need to assign roles when adding new users.

## Acceptance criteria
- [ ] As a site manager I can assign new users any of the following roles: site manager, editor, content creator.
- [ ] As a site manager, when dkan_workflow is enabled, I can assign new users any of the following roles: Workflow Contributor, Workflow Manager, Workflow Supervisor.
- [ ] Tests pass

## PR Dependency
Adds workflow roles to the available roles for site admins to assign users to
https://github.com/NuCivic/dkan_workflow/pull/45
