### PR TITLE
Modified field help texts on harvest source form

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -7,7 +7,7 @@ includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/7.x-1.x/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity_charts/master/visualization_entity_charts.make
-- https://raw.githubusercontent.com/NuCivic/dkan_harvest/harvest_dkan_integration/dkan_harvest.make
+- https://raw.githubusercontent.com/NuCivic/dkan_harvest/3343-new-help-text/dkan_harvest.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
 projects:
@@ -74,7 +74,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/dkan_harvest.git'
-      branch: harvest_dkan_integration
+      branch: 3343-new-help-text
     type: module
   admin_menu:
     version: 3.0-rc5


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3343

## Acceptance criteria
- [ ] Enable Dkan Harvest module.
- [ ] Go to /node/add/harvest-source
- [ ] Check that the help texts look like specified on https://jira.govdelivery.com/browse/CIVIC-3342

## PR dependencies
- [ ] Dkan Harvest: https://github.com/NuCivic/dkan_harvest/pull/21

