### PR TITLE
Added tab preview to node to show info before import with harvest #CI…

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -74,7 +74,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/dkan_harvest.git'
-      branch: harvest_dkan_integration
+      branch: harvest_preview_civic_2695
     type: module
   admin_menu:
     version: 3.0-rc5

--- a/test/features/dkan_harvest.feature
+++ b/test/features/dkan_harvest.feature
@@ -73,6 +73,23 @@ Feature: Dkan Harvest
 
 
   @api
+  Scenario: As a user I should have access to see harvest preview information.
+  Given users:
+    | name             | mail                   | roles           |
+    | Administrator    | admin@fakeemail.com    | administrator   |
+  And harvest sources:
+    | title      | machine name | source uri                        | type               | author        | published |
+    | Source one | source_one   | http://demo.getdkan.com/data.json | datajson_v1_1_json | Administrator | Yes       |
+  And I am logged in as a "Administrator"
+  And I am on the "Source one" page
+  Given The "source_one" source is harvested
+  When I am on the "Source one" page
+  Then I should see the link "Preview"
+  And I click "Preview"
+  And I should see the link "Import/Process information"
+  And I should see the text "Wisconsin Polling Places"
+
+  @api
   Scenario Outline: As a user I should have access to the Event log tab on the Harvest Source.
   Given users:
     | name             | mail                   | roles           |


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-2695

## Description
Added new tab preview on node harvest resource to preview information before import.

## User story / stories
- [ ] As product team we need to see the preview information before import to see if the data is right or not.

## Acceptance criteria
- [ ] Add new harvest resource node.
- [ ] Click on preview tab and see if is right the information.

## PR dependencies


…VIC-2695