### PR TITLE
Adding wait to dataset search to get tests passing

### DIFF
--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -135,6 +135,7 @@ Feature: Dataset Features
   Scenario: View available tag filters for datasets
     Given I am on "Datasets Search" page
     Then I click on the text "Tags"
+    And I wait for "1" seconds
     Then I should see "Health 2 (2)" in the "filter by tag" region
     Then I should see "Gov 2 (1)" in the "filter by tag" region
 
@@ -142,12 +143,14 @@ Feature: Dataset Features
   Scenario: View available resource format filters for datasets
     Given I am on "Datasets Search" page
     Then I click on the text "Format"
+    And I wait for "1" seconds
     Then I should see "csv 2 (1)" in the "filter by resource format" region
     Then I should see "html 2 (2)" in the "filter by resource format" region
 
   Scenario: View available author filters for datasets
     Given I am on "Datasets Search" page
     Then I click on the text "Author"
+    And I wait for "1" seconds
     Then I should see "Gabriel (2)" in the "filter by author" region
     Then I should see "Katie (1)" in the "filter by author" region
 


### PR DESCRIPTION
This fixes some of the failing dataset search scenarios by adding wait instructions.