### PR TITLE
XSS fix for dkan search

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.facetapi_defaults.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.facetapi_defaults.inc
@@ -80,7 +80,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -100,6 +125,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:author'] = $facet;
 
@@ -114,7 +140,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -134,6 +185,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:field_format'] = $facet;
 
@@ -211,7 +263,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -231,6 +308,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:field_resources:field_format'] = $facet;
 
@@ -245,7 +323,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -265,6 +368,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:field_tags'] = $facet;
 
@@ -279,7 +383,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -299,6 +428,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:og_group_ref'] = $facet;
 
@@ -313,7 +443,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -333,6 +488,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:search_api_language'] = $facet;
 
@@ -347,7 +503,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -367,6 +548,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:search_api_viewed'] = $facet;
 
@@ -381,7 +563,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -401,6 +608,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:title'] = $facet;
 
@@ -415,7 +623,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'content_types',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -446,6 +679,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
       'format' => 'html',
     ),
     'submit_realm' => 'Save and go back to realm settings',
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:type'] = $facet;
 
@@ -460,7 +694,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -480,6 +739,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@default_node_index:block:author'] = $facet;
 
@@ -494,7 +754,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -514,6 +799,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@default_node_index:block:body:value'] = $facet;
 
@@ -528,7 +814,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -548,6 +859,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@default_node_index:block:created'] = $facet;
 
@@ -562,7 +874,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -582,6 +919,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@default_node_index:block:search_api_language'] = $facet;
 
@@ -596,7 +934,32 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'facetapi_links',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-48',
+      ),
+      'narrow_results' => array(
+        'status' => 0,
+        'weight' => '-47',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-46',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -616,6 +979,7 @@ function dkan_sitewide_search_db_facetapi_default_facet_settings() {
     'soft_limit' => 20,
     'nofollow' => 1,
     'show_expanded' => 0,
+    'rewrite_items' => 1,
   );
   $export['search_api@default_node_index:block:title'] = $facet;
 

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.info
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.info
@@ -6,6 +6,7 @@ project = dkan
 dependencies[] = ctools
 dependencies[] = entity
 dependencies[] = facetapi
+dependencies[] = facetapi_bonus
 dependencies[] = search_api
 dependencies[] = search_api_db
 dependencies[] = strongarm

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.module
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dkan_sitewide_search_db.features.inc';
+include_once 'dkan_sitewide_search_db.security.inc';
 
 /**
  * Implements hook_menu_local_tasks_alter().

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @file
+ * Code for the dkan_sitewide_search_db feature.
+ */
+
+/**
+ * Helper for array_map to sanitize facet markup
+ */
+function _filter_xss(&$facet) {
+  $facet['#markup'] = filter_xss($facet['#markup']);
+}
+
+/**
+ * Implements hook_facet_items_alter().
+ */
+function dkan_sitewide_search_db_facet_items_alter(&$build, &$settings) {
+  // Apply filter xss to every facet in build.
+  array_map('_filter_xss', $build);
+}
+
+/**
+ * Cross references value with available node types.
+ * @param  string $value content type
+ * @return boolean
+ */
+function _facet_is_content_type($value) {
+  $cts = node_type_get_types();
+  $cts = array_keys($cts);
+  return in_array($value, $cts);
+}
+
+/**
+ * Cross reference value with term data
+ * @param  string $value term
+ * @return boolean
+ */
+function _facet_is_term($name, $tid) {
+  $result = db_select('taxonomy_term_data', 'terms')
+              ->fields('terms', array('name'))
+              ->condition('name', $name, 'LIKE')
+              ->condition('tid', $tid)
+              ->execute();
+  return $result->rowCount() > 0;
+}
+
+/**
+ * Cross reference value with user data
+ */
+function _facet_is_user($uid) {
+  $result = db_select('users', 'users')
+              ->fields('users', array('name'))
+              ->condition('uid', $uid)
+              ->execute();
+  return $result->rowCount() > 0;
+}
+
+/**
+ * Implements hook_menu_alter().
+ */
+function dkan_sitewide_search_db_menu_alter(&$items) {
+  $items['search']['page callback'] = '_alter_search_callback';
+}
+
+/**
+ * Wrapper callback for $items['search'].
+ */
+function _alter_search_callback($argument) {
+  $path = explode('/', current_path());
+  // Extra xss sanitation here just in case.
+  $path = array_map('filter_xss', $path);
+
+  // Validate CT's.
+  if (in_array('type', $path)) {
+    $n = array_search('type', $path);
+    $type = $path[$n+1];
+    if (!_facet_is_content_type($type)) {
+      return drupal_not_found();
+    }
+  }
+  // Validate terms.
+  $vocabs_to_validate = array(
+    'field_tags' => 'tags',
+    'field_topic' => 'dkan_topics',
+    'field_resources%3Afield_format' => 'format'
+  );
+  foreach ($vocabs_to_validate as $key => $map) {
+    $in_array = array_keys($path, $key);
+    if (count($in_array)) {
+      foreach ($in_array as $i) {
+        // Check if a value is provided after the mark.
+        if (!isset($path[$i+1])) {
+          return drupal_not_found();
+        }
+        $term = $path[$i+1];
+        $term = explode('-', $term);
+        $last = array_pop($term);
+        // Check if last element is a term id.
+        if (!is_numeric($last)) {
+          return drupal_not_found();
+        }
+        $term = array(implode('_', $term), $last);
+        // Save the extra query if we can.
+        if (count($term) == 1) {
+          return drupal_not_found();
+        }
+        // Grab term and validate. 
+        if (!_facet_is_term($term[0], $term[1])) {
+          return drupal_not_found();
+        }
+      }
+    }
+  }
+  // Validate license field.
+  $in_array = array_keys($path, 'field_license');
+  if (count($in_array)) {
+    $allowed_values = dkan_dataset_content_types_license_allowed_values();
+    $allowed_values = array_keys($allowed_values);
+    foreach ($in_array as $i) {
+      // Check if a value is provided after the mark.
+      if (!isset($path[$i+1])) {
+        return drupal_not_found();
+      }
+      $license = $path[$i+1];
+      if (!in_array($license, $allowed_values)) {
+        return drupal_not_found();
+      }
+    }
+  }
+  // Validate author
+  $in_array = array_keys($path, 'author');
+  if (count($in_array)) {
+    foreach($in_array as $i) {
+      if (!isset($path[$i+1])) {
+        // Check if a value is provided after the mark.
+        return drupal_not_found();
+      }
+      $uid = $path[$i+1];
+      // Check if uid is numeric.
+      if (!is_numeric($uid)) {
+        return drupal_not_found();
+      }
+      if (!_facet_is_user($uid)) {
+        return drupal_not_found();
+      }
+    }
+  }
+  // If anything works as expected, call the original callback.
+  return page_manager_page_execute($argument);
+}

--- a/modules/dkan/dkan_topics/dkan_topics.facetapi_defaults.inc
+++ b/modules/dkan/dkan_topics/dkan_topics.facetapi_defaults.inc
@@ -21,7 +21,36 @@ function dkan_topics_facetapi_default_facet_settings() {
   $facet->settings = array(
     'weight' => 0,
     'widget' => 'terms',
-    'filters' => array(),
+    'filters' => array(
+      'active_items' => array(
+        'status' => 0,
+        'weight' => '-50',
+      ),
+      'current_depth' => array(
+        'status' => 0,
+        'weight' => '-49',
+      ),
+      'exclude_items' => array(
+        'status' => 0,
+        'weight' => '-48',
+      ),
+      'rewrite_items' => array(
+        'status' => 1,
+        'weight' => '-47',
+      ),
+      'narrow_results' => array(
+        'status' => 1,
+        'weight' => '-46',
+      ),
+      'show_if_minimum_items' => array(
+        'status' => 0,
+        'weight' => '-45',
+      ),
+      'deepest_level_items' => array(
+        'status' => 0,
+        'weight' => '-44',
+      ),
+    ),
     'active_sorts' => array(
       'active' => 'active',
       'count' => 'count',
@@ -55,6 +84,10 @@ function dkan_topics_facetapi_default_facet_settings() {
     'pretty_paths_taxonomy_pathauto' => 0,
     'pretty_paths_taxonomy_pathauto_vocabulary' => 'dkan_topics',
     'submit_realm' => 'Save and go back to realm settings',
+    'exclude' => '',
+    'regex' => 0,
+    'show_minimum_items' => 2,
+    'rewrite_items' => 1,
   );
   $export['search_api@datasets:block:field_topic'] = $facet;
 


### PR DESCRIPTION
Issue #CIVIC-3513

+ Sets facets to be rewritable via `hook_facet_items_alter` in order to run `filter_xss` on them
+ Validates content type parameter from the value provided in the url: 'search/type/<content_type>`
+ Validates term ids from the value provided in the url for `search/<taxonomy_field>/<format>-<tid>` when `taxonomy_field` is either:
  + field_tags
  + field_topics
  + field_resources%253Afield_format

### Acceptance Criteria

- [ ] `search/type/notvalid` should return a 404 for everything for everything but but valid content types
- [ ] `search/field_tags/notvalid` should return a 404 for everything for everything but but valid term values for tags
- [ ] `search/field_topic/notvalid` should return a 404 for everything but for everything but valid term values for topics
- [ ] `search/field_resources%253Afield_format/notvalid` should return a 404 for everything but valid term values for formats
- [ ] If one of Multiple ocurrances of a facet based on taxonomies is not valid, It should return a 404
- [ ] `search/field_license/notvalid` should return a 404 for everything but valid license occurances
- [ ] any invalid combo of the above options should return a 404