### PR TITLE
Removing markdown shortcuts from test steps.

### DIFF
--- a/test/features/markdown_editor.feature
+++ b/test/features/markdown_editor.feature
@@ -21,16 +21,16 @@ Feature: Markdown Editor
     Then I should have an "html" text format option
     And I should have an "plain_text" text format option
     # Buttons that the user should see on the toolbar
-    And I should see the button "Make selected text into a header (Alt + H)" in the "dataset edit body"
-    And I should see the button "Italics: Make selected text emphasized (Alt + I)" in the "dataset edit body"
-    And I should see the button "Bold: Make selected text strong (Alt + B)" in the "dataset edit body"
-    And I should see the button "Make selected text into a block quote (Alt + Q)" in the "dataset edit body"
-    And I should see the button "Make selected text into an ordered list (numbered) (Alt + O)" in the "dataset edit body"
-    And I should see the button "Make selected text into an unordered list (bullets) (Alt + N)" in the "dataset edit body"
-    And I should see the button "Make text into an autolink (turns URLs in links, turns words into section identifiers for navigating the document) (Alt + A)" in the "dataset edit body"
-    And I should see the button "Make text into a link (turns text into a link with more options) (Alt + L)" in the "dataset edit body"
-    And I should see the button "Insert an image (Alt + M)" in the "dataset edit body"
-    And I should see the button "Insert a line break (Alt + R)" in the "dataset edit body"
+    And I should see the button "Make selected text into a header" in the "dataset edit body"
+    And I should see the button "Italics: Make selected text emphasized" in the "dataset edit body"
+    And I should see the button "Bold: Make selected text strong" in the "dataset edit body"
+    And I should see the button "Make selected text into a block quote" in the "dataset edit body"
+    And I should see the button "Make selected text into an ordered list (numbered)" in the "dataset edit body"
+    And I should see the button "Make selected text into an unordered list (bullets)" in the "dataset edit body"
+    And I should see the button "Make text into an autolink (turns URLs in links, turns words into section identifiers for navigating the document)" in the "dataset edit body"
+    And I should see the button "Make text into a link (turns text into a link with more options)" in the "dataset edit body"
+    And I should see the button "Insert an image" in the "dataset edit body"
+    And I should see the button "Insert a line break" in the "dataset edit body"
     And I should see the button "Help" in the "dataset edit body"
     # Buttons that the user should not see on the toolbar
     And I should not see the button "Insert a table" in the "dataset edit body"
@@ -49,7 +49,7 @@ Feature: Markdown Editor
     Then I should have an "html" text format option
     And I should have an "plain_text" text format option
     # Buttons that the user should see on the toolbar
-    And I should see the button "Make selected text into a header (Alt + H)" in the "dataset edit body"
+    And I should see the button "Make selected text into a header" in the "dataset edit body"
     # Buttons that the user should not see on the toolbar
     And I should not see the button "Insert a table" in the "dataset edit body"
 
@@ -60,7 +60,7 @@ Feature: Markdown Editor
     Then I should have an "html" text format option
     And I should have an "plain_text" text format option
     # Buttons that the user should see on the toolbar
-    And I should see the button "Make selected text into a header (Alt + H)" in the "dataset edit body"
+    And I should see the button "Make selected text into a header" in the "dataset edit body"
     # Buttons that the user should not see on the toolbar
     And I should not see the button "Insert a table" in the "dataset edit body"
 
@@ -179,5 +179,5 @@ Feature: Markdown Editor
     Given I am logged in as "Jaz"
     When I am on "Add Dataset" page
     And I select "Plain text" from "edit-body-und-0-format--2" chosen.js select box
-    Then I should not see the button "Make selected text into a header (Alt + H)" in the "dataset edit body"
-    And I should not see the button "Italics: Make selected text emphasized (Alt + I)" in the "dataset edit body"
+    Then I should not see the button "Make selected text into a header" in the "dataset edit body"
+    And I should not see the button "Italics: Make selected text emphasized" in the "dataset edit body"


### PR DESCRIPTION
Dkan markdown_editor tests fail because some of the shortcuts changed.
It is possible to run the same test steps without explicitly stating the shortcuts.
This PR removes the shortcuts from the testing steps.