### PR TITLE
QA - Update data dictionary field to use filtered html

### DIFF
--- a/dkan.profile
+++ b/dkan.profile
@@ -45,6 +45,7 @@ function dkan_additional_setup() {
       array('dkan_install_default_content', array()),
       array('dkan_set_adminrole', array()),
       array('dkan_set_roleassign_roles', array()),
+      array('dkan_set_bueditor_excludes', array()),
     ),
   );
 }
@@ -410,4 +411,20 @@ function dkan_set_roleassign_roles(&$context) {
     $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
   }
   variable_set('roleassign_roles', $roleassign_roles);
+}
+
+/**
+ * Add data dictionary textarea id to bueditor excludes list.
+ */
+function dkan_set_bueditor_excludes() {
+  db_update('bueditor_editors')
+    ->fields(array(
+      'excludes' => 'edit-log
+edit-menu-description
+*data-dictionary*',
+    ))
+    ->condition('eid', '5')
+    ->execute();
+
+  drupal_flush_all_caches();
 }


### PR DESCRIPTION
civic 1748

## Description
The Dataset's Data Dictionary field does not filter using HTML. The instructions that appear for the Data Dictionary field suggest creating a table, "This usually consists of a table." Having that instruction in a field where it is impossible to add a table is a bug.

## Acceptance criteria
The field remains a textarea field but is reduced to a single line, expandable if needed.
<img width="908" alt="dkan" src="https://cloud.githubusercontent.com/assets/314172/17829401/f3a4d6ac-6672-11e6-8f8b-52cec1eb4745.png">

- [ ] Edit a dataset, add a url to the data dictionary field, the url should display as a link
- [ ] The help text for the Data Dictionary field should not encourage user to add a table.
- [ ] Tests pass

## PR dependencies
https://github.com/NuCivic/dkan_dataset/pull/258
