### PR TITLE
Fix views relative apth civic 3648

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -162,7 +162,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch:  release-1-12
+      branch: release-1-12
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -162,7 +162,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch:  fix_views_relative_apth_civic_3648
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -162,7 +162,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch:  fix_views_relative_apth_civic_3648
+      branch:  release-1-12
     type: theme
   radix:
     type: theme

--- a/themes/dkan/templates/node--dataset.tpl.php
+++ b/themes/dkan/templates/node--dataset.tpl.php
@@ -3,7 +3,7 @@
   <?php print render($title_prefix); ?>
   <?php if (!$page && $title): ?>
   <header>
-    <h2<?php print $title_attributes; ?>><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+    <h2<?php print $title_attributes; ?>><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
   </header>
   <?php endif; ?>
   <?php print render($title_suffix); ?>

--- a/themes/dkan/templates/node--group.tpl.php
+++ b/themes/dkan/templates/node--group.tpl.php
@@ -21,7 +21,7 @@
   ?>
   <article class="node-teaser">
     <div class="field-name-field-image"><?php print render($group_logo); ?></div>
-    <h2 class="node-title"><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+    <h2 class="node-title"><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
     <div class="content">
       <p>
         <?php $field = field_view_field('node', $node, 'body', array(
@@ -43,7 +43,7 @@
     <?php print render($title_prefix); ?>
     <?php if (!$page && $title): ?>
     <header>
-      <h2<?php print $title_attributes; ?>><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+      <h2<?php print $title_attributes; ?>><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
     </header>
     <?php endif; ?>
     <?php print render($title_suffix); ?>

--- a/themes/dkan/templates/node--resource.tpl.php
+++ b/themes/dkan/templates/node--resource.tpl.php
@@ -3,7 +3,7 @@
   <?php print render($title_prefix); ?>
   <?php if (!$page && $title): ?>
   <header>
-    <h2<?php print $title_attributes; ?>><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+    <h2<?php print $title_attributes; ?>><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
   </header>
   <?php endif; ?>
   <?php print render($title_suffix); ?>

--- a/themes/dkan/templates/node.tpl.php
+++ b/themes/dkan/templates/node.tpl.php
@@ -3,7 +3,7 @@
   <?php print render($title_prefix); ?>
   <?php if (!$page && $title): ?>
   <header>
-    <h2<?php print $title_attributes; ?>><a href="<?php print $node_url ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
+    <h2<?php print $title_attributes; ?>><a href="<?php print url($node_url) ?>" title="<?php print $title ?>"><?php print $title ?></a></h2>
   </header>
   <?php endif; ?>
   <?php print render($title_suffix); ?>

--- a/themes/dkan/templates/region--branding.tpl.php
+++ b/themes/dkan/templates/region--branding.tpl.php
@@ -3,7 +3,7 @@
     <?php if ($logo || $site_name || $site_slogan): ?>
     <div class="branding-data clearfix">
       <?php if ($logo): ?>
-        <a href="/" title="<?php print t('Home'); ?>" rel="home" id="logo">
+        <a href="<?php print url('') ?>" title="<?php print t('Home'); ?>" rel="home" id="logo">
           <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
         </a>
       <?php endif; ?>


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3647 https://github.com/NuCivic/dkan/issues/1225

## Description
If we are using a folder with the host for example hostname/dkan we are gettings some problems with links in some pages because we are using / instead to use relative paths. 

## User story / stories
- [ ] As product team I can access to all links on the website with relative paths.

## Acceptance criteria
- [ ] I can access to relative paths in all website. You need to install dkan over a subfolder. domain/dkan. Then access to dkan (domain/dkan) and check full links on the site (homepage, dataset, search results on dataset and groups pages) have the subfolder. For example for dataset page the link should be domain/dkan/dataset instead domain/dataset.



…-3647
