### PR TITLE
Fix topics page

### DIFF
--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -48,7 +48,7 @@ function dkan_topics_menu_link_insert($link) {
  * Set main menu topics link to null.
  */
 function topics_page() {
-  drupal_goto('search/field_topic');
+  drupal_goto('search/field_topics');
 }
 
 /*

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -80,6 +80,7 @@ default:
         facet container: '.radix-layouts-sidebar'
         filter by resource format: '.facetapi-facet-field-resourcesfield-format'
         filter by author: '.facetapi-facet-author'
+        filter by topics: '.facetapi-facet-field-topic'
         filter by tag: '.facetapi-facet-field-tags'
         filter by date changed: '.facetapi-facet-changed'
         social: '.pane-dkan-sitewide-dkan-sitewide-social'

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -11,6 +11,7 @@ Feature: Search
     | name                      | url                                                |
     | Dataset Search            | /search/type/dataset                               |
     | Dataset Results           | /search/type/dataset?query=Dataset%2001            |
+    | Topics Search             | /search/field_topics                               |
     | Not valid type search     | /search/type/notvalid                              |
     | Not valid tags search     | /search/field_tags/notvalid                        |
     | Not valid topics search   | /search/field_topic/notvalid                       |
@@ -28,12 +29,16 @@ Feature: Search
       | Gabriel | Group 01 | administrator member | Active            |
     And "Tags" terms:
       | name         |
-      | something01 |
-      | politics01 |
+      | something01  |
+      | politics01   |
+    And "Topics" terms:
+      | name         |
+      | edumication  |
+      | dazzling     |
     And datasets:
-      | title           | publisher | author  | published | tags         | description |
-      | Test Dataset 01 |           | Gabriel | Yes       | something01 | Test 01     |
-      | Test Dataset 02 | Group 01  | Gabriel | Yes       | politics01  | Test 02     |
+      | title           | publisher | author  | published | tags         | topics      | description |
+      | Test Dataset 01 |           | Gabriel | Yes       | something01  | edumication | Test 01     |
+      | Test Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
 
   Scenario: Searching datasets
     When I search for "Dataset 01"
@@ -57,6 +62,13 @@ Feature: Search
     When I click "Group 01"
     Then I should not see "Dataset 01"
     But I should see "Dataset 02"
+
+  Scenario: View Topics Search Page
+    Given I am on the "Topics Search" page
+    Then I should see "edumication" in the "filter by topics" region
+    When I click "edumication"
+    Then I should not see "Dataset 02"
+    But I should see "Dataset 01"
 
   Scenario Outline: Forbid XSS injection in search
     Given I am on the "<page>" page

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -12,6 +12,7 @@ Feature: Search
     | Dataset Search            | /search/type/dataset                               |
     | Dataset Results           | /search/type/dataset?query=Dataset%2001            |
     | Topics Search             | /search/field_topics                               |
+    | Topics Redirect           | /topics                                            |
     | Not valid type search     | /search/type/notvalid                              |
     | Not valid tags search     | /search/field_tags/notvalid                        |
     | Not valid topics search   | /search/field_topic/notvalid                       |
@@ -69,6 +70,11 @@ Feature: Search
     When I click "edumication"
     Then I should not see "Dataset 02"
     But I should see "Dataset 01"
+
+  Scenario: Topics redirect
+    Given I visit "topics"
+    Then I should see "Search"
+    And I should not see "Page not found"
 
   Scenario Outline: Forbid XSS injection in search
     Given I am on the "<page>" page


### PR DESCRIPTION
Issue: CIVIC-3773

## Description
Topics broke with the XSS fix. This restores the topics page.

## User story / stories
- [x] A a site visitor when I click on Topics I should see the Topics search and topics extended.

## Acceptance criteria
- [x] Tests fail then pass

