### PR TITLE
Panelizer patch 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-7.x-1-12.x
+7.x-1-12.7
 --------------------------
 - Update contrib modules uuid, services, manualcrop, markdown, panelizer, panopoly_widgets, panopoly_images
 - Fix bug that produced a "Cannot use a scalar value" error when trying to add a content pane to a data story node in panels.
@@ -7,6 +7,7 @@
 - Provide "data proxy" to serve remote CSVs through local domain and resolve cross-origin issues with previews n these resources
 - Some changes to the Resource node form to improve UX of links and file attachments, especially by replacing the label "Link to an API" to "API or Website URL"
 - Fix bug on relative paths for links in theme template files.
+- Fix minor typo in DKAN topics menu link
 
 7.x-1.12.6 2016-07-26
 --------------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.12.x
+--------------------------
+- Patch panelizer module to correct bug introduced in previous release. See release notes for details.
+
 7.x-1-12.7 2016-08-09
 --------------------------
 - Update contrib modules uuid, services, manualcrop, markdown, panelizer, panopoly_widgets, panopoly_images

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-7.x-1-12.7
+7.x-1-12.7 2016-08-09
 --------------------------
 - Update contrib modules uuid, services, manualcrop, markdown, panelizer, panopoly_widgets, panopoly_images
 - Fix bug that produced a "Cannot use a scalar value" error when trying to add a content pane to a data story node in panels.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -106,6 +106,8 @@ projects:
     version: 1.0-alpha11
   panelizer:
     version: '3.2'
+    patch:
+      2762351: https://www.drupal.org/files/issues/panelizer-n2762351-7.patch
   views_autocomplete_filters:
     version: '1.2'
     patch:

--- a/test/features/data_story.author.feature
+++ b/test/features/data_story.author.feature
@@ -10,6 +10,7 @@ Feature: Data Stories
       | DKAN Data Story Test Story Post | Jaz         | 1        |
       | Unpublished Test Story Post     | Jaz         | 1        |
 
+  @customizable
   Scenario: Menu Item
     Given I am on the homepage
     Then I should see "Stories"

--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -149,7 +149,8 @@ Feature: Dataset Features
 
   Scenario: View available author filters for datasets
     Given I am on "Datasets Search" page
-    Then I click on the text "Author"
+    And I wait for "Author"
+    When I click on the text "Author"
     And I wait for "1" seconds
     Then I should see "Gabriel (2)" in the "filter by author" region
     Then I should see "Katie (1)" in the "filter by author" region

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -13,10 +13,10 @@ Feature: Widgets
       | csv 2  |
     And datasets:
       | title                          | publisher | author | published        | tags     | description |
-      | Afghanistan Election Districts | Group 01  | admin  | Yes              | Health 2 | Test        |
+      | 11111AAAAAAafghanistan Election Districts | Group 01  | admin  | Yes              | Health 2 | Test        |
     And resources:
       | title          | publisher | format | author | published | dataset                        | description |
-      | District Names | Group 01  | csv 2  | admin  | Yes       | Afghanistan Election Districts |             |
+      | District Names | Group 01  | csv 2  | admin  | Yes       | 11111AAAAAAafghanistan Election Districts |             |
     And I am logged in as a user with the "site manager" role
     And I wait for "Customize this page"
     When I click "Customize this page"
@@ -126,7 +126,7 @@ Feature: Widgets
       And I select "Title" from "exposed[sort_by]"
       And I press "Finish"
     And I wait and press "Save"
-    Then I should see "Afghanistan Election Districts"
+    Then I should see "11111AAAAAAafghanistan"
       And I should see "Posted by admin"
 
   Scenario: Adds "New Content Item Widget" block to home page using panels ipe editor


### PR DESCRIPTION
The following patch is necessary for some sites to upgrade properly: https://www.drupal.org/node/2762351

This adds the following to the ``panaleizer_update_7300()`` function:

```
    // Bail if no records found.
    if (empty($sandbox['max'])) {
      return t('No records need to be fixed.');
    }
```

Which produces volumes of ``Division by zero panelizer.install:1203 [warning]``. Following the warnings the update functions run which may cause the updates to fail.

<img width="639" alt="screen shot 2016-08-11 at 10 02 16 am" src="https://cloud.githubusercontent.com/assets/512243/17591216/354119fa-5fab-11e6-9410-5882a6e02f50.png">



## Acceptance criteria
- [ ] Test pass