### PR TITLE
Data Story Menu Item Test Should be Customizable

### DIFF
--- a/test/features/data_story.author.feature
+++ b/test/features/data_story.author.feature
@@ -10,6 +10,7 @@ Feature: Data Stories
       | DKAN Data Story Test Story Post | Jaz         | 1        |
       | Unpublished Test Story Post     | Jaz         | 1        |
 
+  @customizable
   Scenario: Menu Item
     Given I am on the homepage
     Then I should see "Stories"

--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -149,7 +149,8 @@ Feature: Dataset Features
 
   Scenario: View available author filters for datasets
     Given I am on "Datasets Search" page
-    Then I click on the text "Author"
+    And I wait for "Author"
+    When I click on the text "Author"
     And I wait for "1" seconds
     Then I should see "Gabriel (2)" in the "filter by author" region
     Then I should see "Katie (1)" in the "filter by author" region

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -13,10 +13,10 @@ Feature: Widgets
       | csv 2  |
     And datasets:
       | title                          | publisher | author | published        | tags     | description |
-      | Afghanistan Election Districts | Group 01  | admin  | Yes              | Health 2 | Test        |
+      | 11111AAAAAAafghanistan Election Districts | Group 01  | admin  | Yes              | Health 2 | Test        |
     And resources:
       | title          | publisher | format | author | published | dataset                        | description |
-      | District Names | Group 01  | csv 2  | admin  | Yes       | Afghanistan Election Districts |             |
+      | District Names | Group 01  | csv 2  | admin  | Yes       | 11111AAAAAAafghanistan Election Districts |             |
     And I am logged in as a user with the "site manager" role
     And I wait for "Customize this page"
     When I click "Customize this page"
@@ -126,7 +126,7 @@ Feature: Widgets
       And I select "Title" from "exposed[sort_by]"
       And I press "Finish"
     And I wait and press "Save"
-    Then I should see "Afghanistan Election Districts"
+    Then I should see "11111AAAAAAafghanistan"
       And I should see "Posted by admin"
 
   Scenario: Adds "New Content Item Widget" block to home page using panels ipe editor


### PR DESCRIPTION
Test updates:

- The "Stories" menu item is customizable so should be noted as so in the tests.
- Widget tests expects that ``Afghanistan Elections District``  be one of the top 3 datasets alphabetically but that is not the case in some clients.
- Adds wait for facet to show up in Dataset search

## Acceptance criteria
- [x] Tests pass.