### PR TITLE
Remove ipe from dataset and search pages

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
@@ -377,7 +377,7 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $handler->conf = array(
     'title' => 'Dataset',
     'no_blocks' => 0,
-    'pipeline' => 'ipe',
+    'pipeline' => 'standard',
     'body_classes_to_remove' => '',
     'body_classes_to_add' => '',
     'css_id' => '',
@@ -1022,7 +1022,7 @@ function dkan_sitewide_panels_default_page_manager_pages() {
   $handler->conf = array(
     'title' => 'With Topics',
     'no_blocks' => 0,
-    'pipeline' => 'ipe',
+    'pipeline' => 'standard',
     'body_classes_to_remove' => '',
     'body_classes_to_add' => '',
     'css_id' => '',
@@ -1363,7 +1363,7 @@ return TRUE;
   $handler->conf = array(
     'title' => 'Without Topics',
     'no_blocks' => 0,
-    'pipeline' => 'ipe',
+    'pipeline' => 'standard',
     'body_classes_to_remove' => '',
     'body_classes_to_add' => '',
     'css_id' => '',

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.views_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.views_default.inc
@@ -376,7 +376,7 @@ function dkan_sitewide_panels_views_default_views() {
   $handler->display->display_options['fields']['title']['element_type'] = 'h3';
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
-  /* Field: Content: Body */
+  /* Field: Content: Description */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';


### PR DESCRIPTION
## Description
The search page and dataset pages invite the user to modify these pages with the IPE buttons, and we do not want users changing these particular pages.

## Acceptance criteria
- [x] When viewing the search page or dataset pages, the user should not see the IPE buttons at the bottom.
