### PR TITLE
Fix topics menu to work with special characters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 --------------------------
 - Add "2x" "3x" etc to datset teasers when more than one resource of a particular format present.
+- Fix topics menu and facet links if special characters are used in topic terms.
 
 7.x-1.12.10 2016-09-07
 --------------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -160,7 +160,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch: civic-4008
     type: theme
   radix:
     type: theme

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
@@ -36,12 +36,17 @@ function _facet_is_content_type($value) {
  * @return boolean
  */
 function _facet_is_term($name, $tid) {
-  $result = db_select('taxonomy_term_data', 'terms')
+  $query = db_select('taxonomy_term_data', 'terms')
               ->fields('terms', array('name'))
-              ->condition('name', $name, 'LIKE')
               ->condition('tid', $tid)
               ->execute();
-  return $result->rowCount() > 0;
+  $result = $query->fetchObject();
+  if ($query->rowCount() > 0) {
+    $n1 = pathauto_cleanstring($result->name);
+    $n2 = pathauto_cleanstring(urldecode($name));
+    return $n1 == $n2;
+  }
+  return FALSE;
 }
 
 /**
@@ -99,7 +104,7 @@ function _alter_search_callback($argument) {
         if (!is_numeric($last)) {
           return drupal_not_found();
         }
-        $term = array(implode('_', $term), $last);
+        $term = array(implode('-', $term), $last);
         // Save the extra query if we can.
         if (count($term) == 1) {
           return drupal_not_found();

--- a/modules/dkan/dkan_topics/dkan_topics.entity_path.inc
+++ b/modules/dkan/dkan_topics/dkan_topics.entity_path.inc
@@ -19,7 +19,7 @@ function dkan_topics_entity_path_config_default() {
   $entity_path_config->query_pattern = '';
   $entity_path_config->fragment_pattern = '';
   $entity_path_config->config = array(
-    'pathauto_cleanstring' => 0,
+    'pathauto_cleanstring' => 1,
     'space_separator' => 1,
     'space_separator_char' => '-',
     'path_case' => 'lowercase',

--- a/modules/dkan/dkan_topics/dkan_topics.features.field_base.inc
+++ b/modules/dkan/dkan_topics/dkan_topics.features.field_base.inc
@@ -10,7 +10,7 @@
 function dkan_topics_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'field_icon_type'
+  // Exported field_base: 'field_icon_type'.
   $field_bases['field_icon_type'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -35,7 +35,7 @@ function dkan_topics_field_default_field_bases() {
     'type' => 'list_text',
   );
 
-  // Exported field_base: 'field_topic'
+  // Exported field_base: 'field_topic'.
   $field_bases['field_topic'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -61,7 +61,7 @@ function dkan_topics_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
-  // Exported field_base: 'field_topic_icon'
+  // Exported field_base: 'field_topic_icon'.
   $field_bases['field_topic_icon'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -80,7 +80,7 @@ function dkan_topics_field_default_field_bases() {
     'type' => 'font_icon_select_icon',
   );
 
-  // Exported field_base: 'field_topic_icon_color'
+  // Exported field_base: 'field_topic_icon_color'.
   $field_bases['field_topic_icon_color'] = array(
     'active' => 1,
     'cardinality' => 1,

--- a/modules/dkan/dkan_topics/dkan_topics.features.field_instance.inc
+++ b/modules/dkan/dkan_topics/dkan_topics.features.field_instance.inc
@@ -10,7 +10,7 @@
 function dkan_topics_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'node-data_dashboard-field_topic'
+  // Exported field_instance: 'node-data_dashboard-field_topic'.
   $field_instances['node-data_dashboard-field_topic'] = array(
     'bundle' => 'data_dashboard',
     'default_value' => NULL,
@@ -57,7 +57,7 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_topic'
+  // Exported field_instance: 'node-dataset-field_topic'.
   $field_instances['node-dataset-field_topic'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -104,7 +104,7 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dkan_data_story-field_topic'
+  // Exported field_instance: 'node-dkan_data_story-field_topic'.
   $field_instances['node-dkan_data_story-field_topic'] = array(
     'bundle' => 'dkan_data_story',
     'default_value' => NULL,
@@ -151,7 +151,7 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'taxonomy_term-dkan_topics-field_icon_type'
+  // Exported field_instance: 'taxonomy_term-dkan_topics-field_icon_type'.
   $field_instances['taxonomy_term-dkan_topics-field_icon_type'] = array(
     'bundle' => 'dkan_topics',
     'default_value' => array(
@@ -185,7 +185,7 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'taxonomy_term-dkan_topics-field_image'
+  // Exported field_instance: 'taxonomy_term-dkan_topics-field_image'.
   $field_instances['taxonomy_term-dkan_topics-field_image'] = array(
     'bundle' => 'dkan_topics',
     'deleted' => 0,
@@ -261,7 +261,7 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'taxonomy_term-dkan_topics-field_topic_icon'
+  // Exported field_instance: 'taxonomy_term-dkan_topics-field_topic_icon'.
   $field_instances['taxonomy_term-dkan_topics-field_topic_icon'] = array(
     'bundle' => 'dkan_topics',
     'default_value' => NULL,
@@ -298,7 +298,8 @@ function dkan_topics_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'taxonomy_term-dkan_topics-field_topic_icon_color'
+  // Exported field_instance:
+  // 'taxonomy_term-dkan_topics-field_topic_icon_color'.
   $field_instances['taxonomy_term-dkan_topics-field_topic_icon_color'] = array(
     'bundle' => 'dkan_topics',
     'default_value' => NULL,

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -63,8 +63,11 @@ function dkan_topics_preprocess_menu_link(&$variables) {
     foreach ($submenu as $child) {
       if(isset($child['#href'])) {
         $url  = explode("/", $child['#href']);
+        // Prepare term to match menu class.
         $term = strtolower($child['#title']);
-        $term = str_replace(' ', '-', $term);
+        $term = str_replace(array('\\', '/', '[', ' '), '-', $term);
+        $term = str_replace(array(']', '{', '}'), '', $term);
+        $term = preg_replace('/[^\p{L}0-9\-™®]/u', '', $term);
         $type = db_query('SELECT field_icon_type_value FROM {field_data_field_icon_type} WHERE entity_id = :id', array(':id' => $url[2]))->fetchField();
         if($type == 'font') {
           $icon = db_query('SELECT field_topic_icon_value FROM {field_data_field_topic_icon} WHERE entity_id = :id', array(':id' => $url[2]))->fetchField();
@@ -122,12 +125,9 @@ function dkan_topics_views_pre_render(&$view) {
           if(!empty($row->field_field_topic_icon_color[0]['raw']['rgb'])) {
             $new_prefix .= ' style="color:' . $row->field_field_topic_icon_color[0]['raw']['rgb'] . '"';
           }
-          else {
-            $new_prefix .= '';
-          }
           $new_prefix .= $prefix_clipped;
           $row->field_field_topic_icon[0]['rendered']['#prefix'] = $new_prefix;
-          $row->field_field_topic_icon[0]['rendered']['#suffix'] = '</a>';
+          $row->field_field_topic_icon[0]['rendered']['#suffix'] = '<span class="screenreader">icon</span></a>';
         }
       }
     }

--- a/test/features/topics.feature
+++ b/test/features/topics.feature
@@ -1,0 +1,28 @@
+Feature: Topics
+
+  Background:
+    Given "dkan_topics" terms:
+      | name         | Icon Type | Icon   |
+      | Topic1       | font      | xe977  |
+      | Topic2 & $p@ | font      | xe97b  |
+
+  @api @Topics
+  Scenario: See topics on the homepage as anonymous user
+    When I am on the homepage
+    Then I should see "Topic1"
+    And I should see "Topic2 & $p@"
+    And I should see "icon" in the ".font-icon-select-1-e977" element
+
+  @api @Topics
+  Scenario: See topic in the main menu
+    When I am on the homepage
+    Then I click on the text "Topics"
+    Then I should see "Topic1"
+
+  @api @Topics
+  Scenario: Check topic facet link
+    When I am on the homepage
+    Then I click on the text "Topics"
+    Then I should see "Topic1"
+    When I click on the text "Topic2 & $p@"
+    Then I should see "results"


### PR DESCRIPTION
Issue: civic-4008, civic-4068

## Description
Using an & or / in a Topic name shouldn't cause the icon to disappear.

## QA steps
- [x] Add a new topic term that contains special characters, confirm that the menu link in the Topics dropdown menu displays the icon as expected.
- [x] Edit a topic term to include a few special characters including a '/' and confirm that the link for that term in the Topics menu, AND the facets block still functions as expected.

## Related PR
https://github.com/NuCivic/nuboot_radix/pull/97