### PR TITLE
Removed field mapping warnings on dkan_default_content

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@
 - Page link added to the command center menu.
 - Add more frequency update options to the dataset creation form https://project-open-data.cio.gov/iso8601_guidance/#accrualperiodicity
 - Fix for relative paths to ensure links still work when a site is installed into a subdirectory.
+- Removed field mapping warnings during import of default content.
 
 7.x-1-12.9 2016-08-30
 --------------------------

--- a/modules/dkan/dkan_fixtures/includes/dataset.inc
+++ b/modules/dkan/dkan_fixtures/includes/dataset.inc
@@ -14,7 +14,7 @@ class DkanDatasetImport extends MigrateCkanDatasetBase {
 
     $fields = $this->additionalFields();
     foreach ($fields as $id => $field) {
-      $this->addFieldMapping($field, $field);
+      $this->addFieldMapping($field, $field, FALSE);
     }
 
     $this->addFieldMapping('field_topic', 'topic_names');


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3833

## Description
Two warnings were displayed during install because of the override on field mapping.

## User story / stories
- As a user I should not see any warnings during DKAN installation.

## QA Tests
- [x] Install DKAN.
- [x] Check that no workings are being displayed during the import of the default content.
- [x] Check that the spatial data on OOB datasets was imported.

