### PR TITLE
Update jquery to 1.10

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 --------------------------
 - Add "2x" "3x" etc to datset teasers when more than one resource of a particular format present.
+- Update the default jquery library setting from 1.7 to 1.10
 
 7.x-1.12.10 2016-09-07
 --------------------------

--- a/dkan.install
+++ b/dkan.install
@@ -14,3 +14,12 @@ function dkan_update_7001() {
   module_load_include("profile", "dkan");
   dkan_bueditor_markdown_install();
 }
+
+/**
+ * Update the default jquery library to 1.10.
+ */
+function dkan_update_7002() {
+	if(version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
+  	variable_set('jquery_update_jquery_version', '1.10');
+  }
+}

--- a/dkan.profile
+++ b/dkan.profile
@@ -292,7 +292,7 @@ function dkan_misc_variables_set(&$context) {
   variable_set('page_manager_node_edit_disabled', FALSE);
   variable_set('page_manager_user_view_disabled', FALSE);
   // variable_set('page_manager_override_anyway', 'TRUE');
-  variable_set('jquery_update_jquery_version', '1.7');
+  variable_set('jquery_update_jquery_version', '1.10');
   // Disable selected views enabled by contributed modules.
   $views_disable = array(
     'og_extras_nodes' => TRUE,


### PR DESCRIPTION
Issue: CIVIC-3117

## Description
 - Acunetics scan (see epic CIVIC-3063) identified a vulnerability in jquery 1.8
 - jquery 1.9 breaks recline previews
 - jquery 1.10 fixes both issues: this PR updates the default library setting on install and includes a hook update to run on current builds.

## QA Steps
- [ ] Navigate to the jquery update config screen and confirm that the library being used is 1.10.
- [ ] Navigate to a .csv resource page and confirm that the preview functions as expected.

## PR dependencies
