### PR TITLE
Fix odsm validation

### DIFF
--- a/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
+++ b/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
@@ -1713,7 +1713,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
     'bundle' => 'dataset',
     'mapping' => array(
       '@type' => array(
-        'value' => 'dcat:dataset',
+        'value' => 'dcat:Dataset',
         'type' => 'string',
       ),
       'accessLevel' => array(


### PR DESCRIPTION
Issue: civic-4101
The data.json validation is failing because of errors on the '@type' property.

**This is where the change happened**
https://github.com/NuCivic/open_data_schema_map_dkan/commit/0b6fc89bf1e5bb836ff70012cb682fae7ca3b305