### PR TITLE
Fix ruby script not exiting properly.

### DIFF
--- a/.ahoy/.scripts/dkan-test.rb
+++ b/.ahoy/.scripts/dkan-test.rb
@@ -51,8 +51,12 @@ def main
   Dir.chdir(BEHAT_FOLDER) do
     puts "RUNNING: bin/behat #{files} #{params} #{CONFIG}"
 
-    IO.popen("bin/behat #{files} #{params} #{CONFIG}").each do |line|
-      puts line
+    IO.popen("bin/behat #{files} #{params} #{CONFIG}") do |io|
+      while line = io.gets
+        print line
+      end
+      io.close
+      exit(1) unless $?.success?
     end
   end
 end


### PR DESCRIPTION
REF CIVIC-4103

A recent change that uses ruby instead of bash to run circle scripts is not
exiting properly on errors.  This is causing some false positive to get through
that needs to be correct ASAP.

This change fixes the underlying cause of the issue.

QA Steps
===
- [ ] Write a failing feature `test/features/myfailure.feature`
- [ ] Write up the following bash script: test_ruby_failures.sh
```
set -e
echo "Hello"
ruby dkan/.ahoy/.scripts/circle-behat.rb dkan/test/features/myfailure.feature
echo "World"
```
- [ ] bash into your docker environment `ahoy docker exec bash`
- [ ] bash ./test_ruby_failures.sh
- [ ] verify that you do NOT see "World" printed out.