### PR TITLE
Update the php version in circle.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   # Version of ruby to use
   php:
-    version: '5.5.11'
+    version: '5.5.21'
 
   # Override /etc/hosts
   #hosts:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   # Version of ruby to use
   php:
-    version: '5.6.14'
+    version: '5.6.22'
 
   # Override /etc/hosts
   #hosts:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   # Version of ruby to use
   php:
-    version: '5.5.21'
+    version: '5.6.14'
 
   # Override /etc/hosts
   #hosts:

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ dependencies:
      #- "backups"
      #- "dkan/test/sites/default"
   pre:
-    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
+    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.6.14/etc/conf.d/memory.ini
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,8 @@ dependencies:
      #- "dkan/test/sites/default"
   pre:
     - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
-    - sudo apt-get remove --purge mysql* -y
+    - sudo apt-get purge mysql-server mysql-client mysql-common mysql-server-core-5.7 mysql-client-core-5.7
+    - sudo rm -rf /etc/mysql /var/lib/mysql
     - sudo apt-get autoremove -y
     - sudo apt-get autoclean -y
     - sudo apt-get install mysql-server-5.6 -y

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ dependencies:
      #- "backups"
      #- "dkan/test/sites/default"
   pre:
-    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.6.14/etc/conf.d/memory.ini
+    - echo "memory_limit = 256M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ dependencies:
      #- "backups"
      #- "dkan/test/sites/default"
   pre:
-    - echo "memory_limit = 256M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,10 @@ dependencies:
      #- "dkan/test/sites/default"
   pre:
     - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - sudo apt-get remove --purge mysql*
+    - sudo apt-get autoremove
+    - sudo apt-get autoclean
+    - sudo apt-get install mysql-server-5.6
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -42,10 +42,10 @@ dependencies:
      #- "dkan/test/sites/default"
   pre:
     - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
-    - sudo apt-get remove --purge mysql*
-    - sudo apt-get autoremove
-    - sudo apt-get autoclean
-    - sudo apt-get install mysql-server-5.6
+    - sudo apt-get remove --purge mysql* -y
+    - sudo apt-get autoremove -y
+    - sudo apt-get autoclean -y
+    - sudo apt-get install mysql-server-5.6 -y
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit


### PR DESCRIPTION
Issue: CIVIC-4224

## Description
New images in CircleCi are not supporting PHP version 5.5.11 by default.  PHP 5.5.21 is the currently highest supported in newer Ubuntu 12.04 images.

QA Steps
==
- [ ] dkan builds in circle.