### PR TITLE
Support mysql 5.7 (#1379)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   # Version of ruby to use
   php:
-    version: '5.5.11'
+    version: '5.6.22'
 
   # Override /etc/hosts
   #hosts:
@@ -41,7 +41,7 @@ dependencies:
      #- "backups"
      #- "dkan/test/sites/default"
   pre:
-    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
+    - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/modules/dkan/dkan_topics/dkan_topics.make
+++ b/modules/dkan/dkan_topics/dkan_topics.make
@@ -14,6 +14,7 @@ projects[taxonomy_menu][version] = 1.5
 projects[color_field][version] = 1.8
 projects[color_field][patch][2696505] = https://www.drupal.org/files/issues/color_field-requirements-2696505-v2.patch
 projects[entity_path][version] = 1.x-dev
+projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_1.diff
 projects[globalredirect][version] = 1.5
 
 ; Patches


### PR DESCRIPTION
* Update the php version in circle.

New images in CircleCi are not supporting PHP version 5.5.11 by default.  PHP 5.5.21 is the currently highest supported in newer Ubuntu 12.04 images.

REF CIVIC-4224

* Update php version to 5.6.14

REF civic-4224

running out of memory when trying version 5.5.21

* Update circle.yml

* Update circle.yml

* Update circle.yml

* Update circle.yml

* Use mysql-version 5.6

* Update circle.yml

* Update dkan_topics.make

* Update dkan_topics.make