### PR TITLE
Fix icons disappearing when adding or editing topics

### DIFF
--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -14,7 +14,7 @@ commands:
           ahoy confirm "./docroot folder alredy exists. Delete it and reinstall drupal?" && chmod -R 777 docroot/sites/default && rm -rf docroot ||
           { echo ".. skipping installation"; exit 1;}
       fi
-      ahoy drush make --prepare-install dkan/drupal-org-core.make docroot --yes
+      ahoy drush make --concurrency=8 --prepare-install dkan/drupal-org-core.make docroot --yes
       ln -s ../../dkan docroot/profiles/dkan &&
       ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url={{args}} install_configure_form.update_status_module=\"'array\(FALSE,FALSE\)'\""
 
@@ -27,7 +27,7 @@ commands:
       rm -rf docroot/profiles/dkan/modules/dkan/dkan_datastore ;
       rm -rf docroot/profiles/dkan/modules/contrib ;
       echo "removed dkan/modules folders created by make and running a fresh drush make."
-      ahoy drush -y make --no-core --contrib-destination=./ dkan/drupal-org.make --no-recursion --no-cache --verbose --working-copy docroot/profiles/dkan
+      ahoy drush -y make --concurrency=8 --no-core --contrib-destination=./ dkan/drupal-org.make --no-recursion --no-cache --verbose --working-copy docroot/profiles/dkan
 
   reinstall:
     usage: Reinstall the dkan install profile (db only).
@@ -114,7 +114,7 @@ commands:
         echo "No make file found at $MODULE_PATH/$MODULE.make. Consider running 'ahoy dkan link-module'."
         exit 1
       fi
-      ahoy drush -y make --no-core --contrib-destination=dkan $MODULE_PATH/$MODULE.make --no-recursion --no-cache --verbose --working-copy
+      ahoy drush -y make --concurrency=8 --no-core --contrib-destination=dkan $MODULE_PATH/$MODULE.make --no-recursion --no-cache --verbose --working-copy
 
   test:
     usage: Run the tests for dkan.

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,9 @@ dependencies:
      #- "backups"
      #- "dkan/test/sites/default"
   pre:
+    - rm /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
     - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
   override:
     - printenv
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -89,6 +89,7 @@ projects:
       1: patches/fontyourface-no-ajax-browse-view.patch
       2: patches/fontyourface-clear-css-cache.patch
       2644694: https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch
+      2816837: 'https://www.drupal.org/files/issues/font_your_face-remove_div_general_text_option-D7.patch'
   imagecache_actions:
     version: '1.7'
     type: module

--- a/test/features/dataset.admin.feature
+++ b/test/features/dataset.admin.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor
@@ -73,7 +73,6 @@ Feature: Dataset Features
     Given I am logged in as "John"
     And I am on "Dataset 05" page
     When I click "Edit"
-    When I click "Publishing options"
     And I check the box "Published"
     And I press "Finish"
     Then I should see "Dataset Dataset 05 has been updated"

--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 
   # TODO: 5 datasets are created in the test but the DKAN site has 4 datasets pre-made,
   #       with 2 of the datasets created are unpublished so the
@@ -134,24 +134,17 @@ Feature: Dataset Features
   # TODO: make sure it works when we don't have default content on.
   Scenario: View available tag filters for datasets
     Given I am on "Datasets Search" page
-    Then I click on the text "Tags"
-    And I wait for "1" seconds
     Then I should see "Health 2 (2)" in the "filter by tag" region
     Then I should see "Gov 2 (1)" in the "filter by tag" region
 
   # TODO: make sure it works when we don't have default content on.
   Scenario: View available resource format filters for datasets
     Given I am on "Datasets Search" page
-    When I click on the text "Format"
-    And I wait for "1" seconds
     Then I should see "csv 2 (1)" in the "filter by resource format" region
     And I should see "html 2 (2)" in the "filter by resource format" region
 
   Scenario: View available author filters for datasets
     Given I am on "Datasets Search" page
-    And I wait for "Author"
-    When I click on the exact text "Author"
-    And I wait for "1" seconds
     Then I should see "Gabriel (2)" in the "filter by author" region
     Then I should see "Katie (1)" in the "filter by author" region
 
@@ -162,7 +155,6 @@ Feature: Dataset Features
     And I press "Apply"
     Then I should see "3 results"
     And I should see "3" items in the "datasets" region
-    Then I click on the text "Tags"
     When I click "Health 2" in the "filter by tag" region
     Then I should see "2 results"
     And I should see "2" items in the "datasets" region
@@ -174,8 +166,6 @@ Feature: Dataset Features
     And I press "Apply"
     Then I should see "3 results"
     And I should see "3" items in the "datasets" region
-    Then I click on the text "Format"
-    Then I wait for "1" seconds
     When I click "csv 2" in the "filter by resource format" region
     Then I should see "1 results"
     And I should see "1" items in the "datasets" region
@@ -187,8 +177,6 @@ Feature: Dataset Features
     And I press "Apply"
     Then I should see "3 results"
     And I should see "3" items in the "datasets" region
-    Then I click on the text "Author"
-    Then I wait for "1" seconds
     When I click "Gabriel" in the "filter by author" region
     Then I should see "2 results"
     And I should see "2" items in the "datasets" region

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -1,4 +1,4 @@
- @api @javascript
+@api
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor
@@ -60,7 +60,7 @@ Feature: Dataset Features
       | Resource 05 |           | csv    | Katie  | Yes       | Dataset 08 |             |
       | Resource 06 | Group 02  | csv    | Katie  | Yes       | Dataset 09 |             |
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Create dataset as content creator
     Given I am logged in as "Katie"
     And I am on "Datasets Search" page
@@ -125,7 +125,7 @@ Feature: Dataset Features
     And I press "Delete"
     Then I should see "Dataset 03 has been deleted"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Add a dataset to group that I am a member of
     Given I am logged in as "Katie"
     And I am on "Dataset 03" page
@@ -141,7 +141,7 @@ Feature: Dataset Features
   Scenario: Dummy test
     Given I am on "/"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Add a resource with no dataset to a dataset with no resource
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
@@ -157,7 +157,7 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Remove a resource with only one dataset from the dataset
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
@@ -176,7 +176,7 @@ Feature: Dataset Features
     And I click "Back to dataset"
     Then I should see "There is no dataset associated with this resource"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Add a resource with no group to a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
@@ -192,7 +192,7 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Remove a resource from a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
@@ -213,7 +213,7 @@ Feature: Dataset Features
     And I click "Edit"
     Then I should not see "Group 01" in the "resource groups" region
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Add group to a dataset with resources
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page
@@ -226,7 +226,7 @@ Feature: Dataset Features
     And I click "Edit"
     Then I should see "Group 02" in the "resource groups" region
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Remove group from dataset with resources
     Given I am logged in as "Katie"
     And I am on "Dataset 09" page
@@ -239,7 +239,7 @@ Feature: Dataset Features
     And I click "Edit"
     Then I should not see "Group 02" in the "resource groups" region
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Add group and resource to a dataset on the same edition
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page

--- a/test/features/dataset.editor.feature
+++ b/test/features/dataset.editor.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor
@@ -63,7 +63,6 @@ Background:
     Given I am logged in as "Gabriel"
     And I am on "Dataset 05" page
     When I click "Edit"
-    When I click "Publishing options"
     And I check the box "Published"
     And I press "Finish"
     Then I should see "Dataset Dataset 05 has been updated"

--- a/test/features/group.all.feature
+++ b/test/features/group.all.feature
@@ -1,4 +1,4 @@
-@api @javascript
+@api
 Feature: Site Manager administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/group.author.feature
+++ b/test/features/group.author.feature
@@ -1,4 +1,3 @@
-@javascript
 Feature: Site Manager administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 Feature: Site Manager administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 # in the resource tests, when it uses "Given resources:" it defines a property called 'datastore created' with either a 'yes' or 'no', which is used in some tests -  should I try to map that when creating the resource in resourceContext? @Frank
 Feature: Resource
 
@@ -63,7 +63,6 @@ Feature: Resource
     Given I am logged in as "John"
     And I am on "Resource 04" page
     When I click "Edit"
-    And I click "Publishing options"
     And I check "Published"
     And I press "Save"
     Then I should see "Resource Resource 04 has been updated"
@@ -84,7 +83,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "There is nothing to manage! You need to upload or link to a file in order to use the datastore."
 
-  @noworkflow
+  @noworkflow @javascript 
   Scenario: Import items on datastore of any resource
     Given I am logged in as "John"
     And I am on "Resource 02" page
@@ -98,7 +97,7 @@ Feature: Resource
     Then I should see "Last import"
     And I should see "imported items total"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Delete items on datastore of any resource
     # Backgorund steps to add a file to a resource
     Given I am logged in as "John"
@@ -118,7 +117,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "No imported items."
 
-  @noworkflow
+  @noworkflow @javascript 
   Scenario: Drop datastore of any resource
     # Backgorund steps to add a file to a resource
     Given I am logged in as "John"

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -1,4 +1,3 @@
-@javascript
 Feature: Resource
 
   Background:

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 Feature: Resource
 
   Background:
@@ -60,7 +60,6 @@ Feature: Resource
     Given I am logged in as "Katie"
     And I am on the "Content" page
     And I click "Resource"
-    And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
     When I fill in "Title" with "Resource 06"
     And I press "Save"
@@ -214,7 +213,7 @@ Feature: Resource
     And I click "Manage Datastore"
     Then I should see "There is nothing to manage! You need to upload or link to a file in order to use the datastore."
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Import items on datastore of own resource
     Given I am logged in as "Celeste"
     And I am on "Resource 05" page
@@ -229,7 +228,7 @@ Feature: Resource
     Then I should see "Last import"
     And I should see "imported items total"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Delete items on datastore of own resource
     Given I am logged in as "John"
     And I am on "Resource 03" page
@@ -249,7 +248,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "No imported items."
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Drop datastore of own resource
     Given I am logged in as "John"
     And I am on "Resource 03" page

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -1,4 +1,4 @@
-@javascript @api
+@api
 Feature: Resource
 
   Background:
@@ -72,7 +72,6 @@ Feature: Resource
     Given I am logged in as "Celeste"
     And I am on "Resource 04" page
     When I click "Edit"
-    And I click "Publishing options"
     And I check "Published"
     And I press "Save"
     Then I should see "Resource Resource 04 edited has been updated"
@@ -93,7 +92,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "There is nothing to manage! You need to upload or link to a file in order to use the datastore."
 
-  @noworkflow
+  @noworkflow @javascript 
   Scenario: Import items on datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
     And I am on "Resource 01" page
@@ -108,7 +107,7 @@ Feature: Resource
     And I wait for "Delete Items"
     Then I should see "Last import"
     And I should see "imported items total"
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Delete items on datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
     And I am on "Resource 01" page
@@ -128,7 +127,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "No imported items."
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: Drop datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
     And I am on "Resource 01" page

--- a/test/features/user.admin.feature
+++ b/test/features/user.admin.feature
@@ -1,4 +1,4 @@
-@api @javascript
+@api
 Feature: User
 
   Background:
@@ -41,7 +41,7 @@ Feature: User
       | Dataset 03 | Group 01  | Gabriel | Yes              | Gov      | Test        |
       | Dataset 04 | Group 01  | Katie   | Yes              | Health   | Test        |
 
-
+   @javascript
   Scenario: Edit any user account
     Given I am logged in as "John"
     And I am on "Users" page
@@ -53,7 +53,7 @@ Feature: User
     And I click "About" in the "tabs" region
     Then I should see "This is Katie!"
 
-  @dkanBug @deleteTempUsers
+  @dkanBug @deleteTempUsers @javascript
     # Site managers trigger honeypot when creating users.
     # See https://github.com/NuCivic/dkan/issues/811
     # Workaround: Wait for 6 seconds so that honeypot doesn't overreact
@@ -83,6 +83,7 @@ Feature: User
     When I am on "Users" page
     Then I should see "blocked" in the "Katie" row
 
+  @javascript
   Scenario: Disable user
     Given I am logged in as "John"
     And I am on "Users" page
@@ -114,7 +115,7 @@ Feature: User
     When I am on "Users" page
     Then I should see "site manager" in the "Jaz" row
 
-Scenario: Modify user as editor
+  Scenario: Modify user as editor
     Given I am logged in as "Jaz"
     And I am on "Users" page
     Then I should see "Access denied"

--- a/test/features/user.all.feature
+++ b/test/features/user.all.feature
@@ -1,4 +1,4 @@
-@api @javascript
+@api
 Feature: User
 
   Background:
@@ -51,7 +51,7 @@ Feature: User
     When I follow "Log out"
     Then I should see "Log in"
 
-  @deleteTempUsers @customizable
+  @deleteTempUsers @customizable @javascript
   Scenario: Register
     Given I am on the homepage
     When I follow "Register"
@@ -82,12 +82,10 @@ Feature: User
 
   Scenario: View list of published datasets created by user on user profile
     Given I am on "Katie" page
-    And I click "Datasets" in the "tabs" region
     Then I should see "2" items in the "user content" region
 
   Scenario: Search datasets created by user on user profile
     Given I am on "Katie" page
-    And I click "Datasets" in the "tabs" region
     When I fill in "Test" for "Search" in the "content search" region
     And I press "Apply"
     Then I should see "2 results" in the "user content" region
@@ -95,7 +93,6 @@ Feature: User
 
   Scenario: See list of user memberships on user profile
     Given I am on "Katie" page
-    And I click "Groups" in the "tabs" region
     Then I should see "Group membership:"
     Then I should see "Group 01"
     And I should not see "Group 02"

--- a/test/features/user.author.feature
+++ b/test/features/user.author.feature
@@ -1,4 +1,4 @@
-
+@api
 Feature: User
 
   Background:
@@ -40,7 +40,6 @@ Feature: User
       | Dataset 03 | Group 01  | Gabriel | Yes              | Gov      | Test        |
       | Dataset 04 | Group 01  | Katie   | Yes              | Health   | Test        |
 
-  @api @javascript
   Scenario: Edit own user account
     Given I am logged in as "Katie"
     And I am on "Katie" page
@@ -50,16 +49,14 @@ Feature: User
     Then I should see "The changes have been saved"
     Given I am an anonymous user
     When I am on "Katie" page
-    And I click "About" in the "tabs" region
     Then I should see "This is my profile"
 
-  @api @javascript
   Scenario: View the list of own published datasets on profile
     Given I am logged in as "Katie"
     And I am on "Katie" page
     Then I should see "2" items in the "tabs" region
 
-  @api @fixme @testBug
+  @fixme @testBug
     # TODO: Needs definition.
     #       This would take a long time to test manually, having to wait N minutes each time it's run.
     #       A possible solution to this would be to edit the cookies directly and speed up the waiting time


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-2963

## Description
When the CSS Selector for Standard Text is modified by an Admin or Site Manager in the @font-your-face section, icons disappear when adding or editing topics.

## QA Test
- [ ] Log-in as Site Manager or Admin.
- [ ] Go to /admin/appearance/fontyourface > Browse All Fonts and enable a new font.
- [ ] Click on Enabled Fonts and change the font setting for CSS Selector to Standard Text for the font just enabled.
- [ ] Click "Save applied fonts" to save new settings.
- [ ] Navigate to /structure/taxonomy/dkan_topics and click Add Term.
- [ ] Notice that icons are visible.