### PR TITLE
Missing spyc library civic 4099

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -192,7 +192,6 @@ libraries:
       revision: 13d5dd373cbf3f2bddd8ac2ee8df3a1966a62d09
     directory_name: font_awesome
   spyc:
-    type: library
     download:
       type: file
       url: 'https://raw.github.com/mustangostang/spyc/master/Spyc.php'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -11,6 +11,8 @@ includes:
 projects:
   manualcrop:
     version: '1.5'
+    patch:
+      2504119: 'https://www.drupal.org/files/issues/multiple_versions-2504119-26.patch'
   tablefield:
     version: '2.4'
   simple_gmap:
@@ -190,12 +192,11 @@ libraries:
       revision: 13d5dd373cbf3f2bddd8ac2ee8df3a1966a62d09
     directory_name: font_awesome
   spyc:
+    type: library
     download:
-      type: get
-      url: https://raw.github.com/mustangostang/spyc/79f61969f63ee77e0d9460bc254a27a671b445f3/spyc.php
-    filename: "../spyc.php"
-    directory_name: lib
-    destination: modules/contrib/services/servers/rest_server
+      type: file
+      url: 'https://raw.github.com/mustangostang/spyc/master/Spyc.php'
+    directory_name: spyc
 defaults:
   projects:
     subdir: contrib


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4099

## Description
Warnings displayed on status page: (admin/reports/status)
  imgAreaSelect Not installed
 The Spyc library could not be found.

## User story / stories
- [ ] As product team we  don't want to see any error about libraries missing on admin status page.

## Acceptance criteria
- [ ] Go to admin status page and you shouldn't see any warning message about spyc or imgAreaSelect.
