### PR TITLE
Added to makefile patch for fontyourface to fix problem using text ge…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@
 - Update the default jquery library setting from 1.7 to 1.10
 - Fix topics menu and facet links if special characters are used in topic terms.
 - Fix form redirect issues on dataset form validation
+- Patch fontyourface to remove <div> from the "standard text" selector, to prevent unpredictable results from this option
 
 7.x-1.12.10 2016-09-07
 --------------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -89,6 +89,7 @@ projects:
       1: patches/fontyourface-no-ajax-browse-view.patch
       2: patches/fontyourface-clear-css-cache.patch
       2644694: https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch
+      2816837: 'https://www.drupal.org/files/issues/font_your_face-remove_div_general_text_option-D7.patch'
   imagecache_actions:
     version: '1.7'
     type: module


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-2963

## Description
When the CSS Selector for Standard Text is modified by an Admin or Site Manager in the @font-your-face section, icons disappear when adding or editing topics.

This PR adds a patch that reduces the scope of the "standard text" selector in font-your-face to use only the `<p>` tag, rather than the `<div>` tag, which seems much to broad. Users who wish to change the fonts on their entire site can use the `<body>` tag for the same, and more predictable, results.

## QA Test
- [x] Log-in as Site Manager or Admin.
- [x] Go to /admin/appearance/fontyourface > Browse All Fonts and enable a new font.
- [x] Click on Enabled Fonts and change the font setting for CSS Selector to Standard Text for the font just enabled.
- [x] Click "Save applied fonts" to save new settings.
- [x] Navigate to /structure/taxonomy/dkan_topics and click Add Term.
- [x] Notice that icons are visible.