### PR TITLE
Hidden fields view modes panelizer 4093

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -162,7 +162,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: hidden_fields_view_modes_panelizer_4093
+      branch: release-1-12
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -162,7 +162,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch: hidden_fields_view_modes_panelizer_4093
     type: theme
   radix:
     type: theme

--- a/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.features.field_instance.inc
+++ b/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.features.field_instance.inc
@@ -19,9 +19,8 @@ function dkan_data_dashboard_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'text',
         'settings' => array(),
-        'type' => 'text_default',
+        'type' => 'hidden',
         'weight' => 1,
       ),
       'search_result' => array(

--- a/modules/dkan/dkan_data_story/dkan_data_story.features.field_instance.inc
+++ b/modules/dkan/dkan_data_story/dkan_data_story.features.field_instance.inc
@@ -19,9 +19,8 @@ function dkan_data_story_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'text',
         'settings' => array(),
-        'type' => 'text_default',
+        'type' => 'hidden',
         'weight' => 2,
       ),
       'search_result' => array(
@@ -71,12 +70,7 @@ function dkan_data_story_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'image',
-        'settings' => array(
-          'image_link' => '',
-          'image_style' => 'story_image_full',
-        ),
-        'type' => 'image',
+        'type' => 'hidden',
         'weight' => 1,
       ),
       'search_result' => array(
@@ -168,9 +162,8 @@ function dkan_data_story_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'taxonomy',
         'settings' => array(),
-        'type' => 'taxonomy_term_reference_link',
+        'type' => 'hidden',
         'weight' => 3,
       ),
       'search_result' => array(

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.features.field_instance.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.features.field_instance.inc
@@ -19,9 +19,8 @@ function dkan_sitewide_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'text',
         'settings' => array(),
-        'type' => 'text_default',
+        'type' => 'hidden',
         'weight' => 0,
       ),
       'search_result' => array(

--- a/modules/dkan/dkan_topics/dkan_topics.features.field_instance.inc
+++ b/modules/dkan/dkan_topics/dkan_topics.features.field_instance.inc
@@ -19,9 +19,8 @@ function dkan_topics_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'dkan_topics',
         'settings' => array(),
-        'type' => 'dkan_topic_formatter',
+        'type' => 'hidden',
         'weight' => 0,
       ),
       'search_result' => array(
@@ -113,9 +112,8 @@ function dkan_topics_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'dkan_topics',
         'settings' => array(),
-        'type' => 'dkan_topic_formatter',
+        'type' => 'hidden',
         'weight' => 0,
       ),
       'search_result' => array(


### PR DESCRIPTION
Issue:https://jira.govdelivery.com/browse/CIVIC-4093

## Description
The default view modes of panelized content types should have all fields marked as hidden. 

## Acceptance criteria
- [ ] When you access to report status page you shouldn't see the message "This view mode is being controlled via Panelizer. For performance reasons, it is recommended to move all fields to 'hidden'. Fields not marked as hidden will be prepared for output but will not actually output, thus needlessly increasing render and page load time."


## PR dependencies
- [ ] https://github.com/NuCivic/nuboot_radix/pull/98