### PR TITLE
Pin cli image to tag. (#1415)

### DIFF
--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -43,7 +43,7 @@ db:
 # Used for all console commands and tools.
 cli:
   hostname: cli
-  image: nuams/drupal-cli
+  image: nuams/drupal-cli:2016-10-14
   environment:
     - XDEBUG_CONFIG=idekey=cli
     - PHP_IDE_CONFIG=serverName=dkan.docker


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4369
Downstream integration of REF #1415

Description
====
Pin cli image to a tag instead of latest. The idea is to control the upgrade
process to ahoy v2 without breaking developers environments.