### PR TITLE
Point recline module to branch fixed_warning_messages_on_view_changes…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.12.x
 --------------------------
+- Fixed a bug in Recline regarding file objects and node forms that caused errors when using the "view changes" button on Dataset or Resource edit form,=.
 - Center group images in "Groups" page and group node page sidebar
 - Add "2x" "3x" etc to datset teasers when more than one resource of a particular format present.
 - Update the default jquery library setting from 1.7 to 1.10

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@
 api: '2'
 core: 7.x
 includes:
-- https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
+- https://raw.githubusercontent.com/NuCivic/dkan_dataset/fixed_warning_messages_on_view_changes_civic_1_12_416/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
@@ -41,7 +41,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_dataset.git
-      branch: release-1-12
+      branch: fixed_warning_messages_on_view_changes_civic_1_12_416
   dkan_datastore:
     subdir: dkan
     download:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@
 api: '2'
 core: 7.x
 includes:
-- https://raw.githubusercontent.com/NuCivic/dkan_dataset/fixed_warning_messages_on_view_changes_civic_1_12_416/dkan_dataset.make
+- https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
@@ -41,7 +41,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_dataset.git
-      branch: fixed_warning_messages_on_view_changes_civic_1_12_416
+      branch: release-1-12
   dkan_datastore:
     subdir: dkan
     download:


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4162

## Description

The Dataset and Resource edit pages have a button to view the changes made to the fields so that a user can review them before saving. Instead of a list of changes being displayed, clicking on the 'View Changes' button either throws an error, or creates a duplicate node that includes the changes currently entered into fields!


## How to reproduce

1.  If the PR fixes a bug, include instructions for reproducing the bug on a current DKAN release.

## QA Tests

- [ ] Given I am editing a resource or dataset page And I have made no edits to any fields and then click 'View Changes'
-[ ] Then I should always see a response that no changes have been made
- [ ] Edit title and click view changes
- [ ] You should see the change on the title 
## PR dependencies

- [ ] https://github.com/NuCivic/dkan_dataset/pull/285
- [ ] https://github.com/NuCivic/recline/pull/70 