### PR TITLE
Fix resource body import

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -970,7 +970,7 @@ class HarvestMigration extends MigrateDKAN {
             '@url' => $url,
             '@extension' => $extension,
           ));
-        self::displayMessage($message , 'error');
+        self::displayMessage($message, 'error');
         return FALSE;
       }
     }
@@ -1017,7 +1017,10 @@ class HarvestMigration extends MigrateDKAN {
     $resource_emw = entity_metadata_wrapper('node', $resource_node);
 
     $resource_emw->title = $res->title;
-    $resource_emw->body->value->set($res->description);
+    $resource_emw->body->set(array(
+      'value' => $res->description,
+      'format' => 'html',
+    ));
 
     if (isset($res->format)) {
       $term = $this->createTax($res->format, 'format');


### PR DESCRIPTION
Issue: [CIVIC-4499](https://jira.govdelivery.com/browse/CIVIC-4499)
### Description

After a harvest, Harvested resources have the description imported and visible on their view page but missing from the Dataset view page.

![image](https://cloud.githubusercontent.com/assets/1914306/19523821/fa6dc010-961b-11e6-9041-80dbb173caca.png)
### Steps to Reproduce
1. Create a test Harvest Source node `test`.
2. Harvest `test`.
3. All the resources imported as part of the harvest appears on their respective datasets view page but are missing the description.
### Acceptance Criteria

The Harvested Resources should behave like manually created resources.
### Test Updates

Update the Behat tests to check for the resources creation and their description on the dataset view page.
### Documenation Updates

N/A
