### PR TITLE
Move dkan make and build ahoy to scripts.

### DIFF
--- a/.ahoy/.scripts/dkan-make.sh
+++ b/.ahoy/.scripts/dkan-make.sh
@@ -1,0 +1,13 @@
+if [ $(uname) == "Darwin" ]; then
+  concurrency=`sysctl -n hw.ncpu`
+else
+  concurrency=`grep -c ^processor /proc/cpuinfo`
+fi
+
+if [ "$AHOY_CMD_PROXY" = "DOCKER" ]; then
+  working_copy="--working-copy"
+else
+  working_copy=""
+fi
+
+drush --root=docroot -y make --no-core --contrib-destination=./ dkan/drupal-org.make --no-recursion --no-cache --verbose $working_copy --concurrency=$concurrency docroot/profiles/dkan $@

--- a/.ahoy/.scripts/dkan-si.sh
+++ b/.ahoy/.scripts/dkan-si.sh
@@ -1,0 +1,4 @@
+drush si dkan --root=docroot --verbose --account-pass='admin' "$1" --site-name='DKAN' install_configure_form.update_status_module='array(FALSE,FALSE)' --yes && \
+  drush --root=docroot sql-dump > backups/last_install.sql.tmp && \
+  mv backups/last_install.sql.tmp backups/last_install.sql && \
+  echo "Installed DKAN and created a new backup at backups/last_install.sql"

--- a/.ahoy/.scripts/drupal-rebuild.sh
+++ b/.ahoy/.scripts/drupal-rebuild.sh
@@ -1,0 +1,16 @@
+if [ $(uname) == "Darwin" ]; then
+  concurrency=`sysctl -n hw.ncpu`
+else
+  concurrency=`grep -c ^processor /proc/cpuinfo`
+fi
+
+if [ "$AHOY_CMD_PROXY" = "DOCKER" ]; then
+  working_copy="--working-copy"
+else
+  working_copy=""
+fi
+
+drush --root=docroot  make --concurrency=$concurrency --prepare-install dkan/drupal-org-core.make docroot --yes
+
+drush --root=docroot -y --verbose $root si minimal --sites-subdir=default --account-pass='admin' --db-url=$1 install_configure_form.update_status_module='array(false,false)' &&
+  ln -s ../../dkan docroot/profiles/dkan

--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -19,9 +19,7 @@ commands:
           ahoy confirm "./docroot folder alredy exists. Delete it and reinstall drupal?" && chmod -R 777 docroot/sites/default && rm -rf docroot ||
           { echo ".. skipping installation"; exit 1;}
       fi
-      ahoy drush make --concurrency=32 --prepare-install dkan/drupal-org-core.make docroot --yes
-      ln -s ../../dkan docroot/profiles/dkan &&
-      ahoy drush "-y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url=$ARGS install_configure_form.update_status_module='''''array\(FALSE,FALSE\)'''''"
+      ahoy cmd-proxy bash dkan/.ahoy/.scripts/drupal-rebuild.sh $ARGS
 
   remake:
     usage: Rebuild all the dkan projects from the drupal-org.make file using drush make.
@@ -37,7 +35,7 @@ commands:
         ARGS="--projects=$ARGS"
         echo "Running drush make for the following modules: $ARGS."
       fi
-      ahoy drush -y make --no-core --contrib-destination=./ dkan/drupal-org.make --no-recursion --no-cache --verbose --concurrency=32 docroot/profiles/dkan $ARGS
+      ahoy cmd-proxy bash dkan/.ahoy/.scripts/dkan-make.sh "$ARGS"
 
   reinstall:
     usage: Reinstall the dkan install profile (db only).
@@ -57,11 +55,9 @@ commands:
         else
           MYSQL=''
         fi
-        ahoy drush "si dkan --verbose --account-pass='admin' $MYSQL --site-name='DKAN' install_configure_form.update_status_module='''''array\(FALSE,FALSE\)''''' --yes" && \
-        ahoy drush sql-dump > backups/last_install.sql.tmp && \
-        mv backups/last_install.sql.tmp backups/last_install.sql && \
-        echo "Installed DKAN and created a new backup at backups/last_install.sql"
+        ahoy cmd-proxy bash dkan/.ahoy/.scripts/dkan-si.sh $MYSQL
       fi
+
   module-fetch:
     usage: Checkout a dkan module from the NuCivic github repo.
     cmd: |


### PR DESCRIPTION
## Description

Some ahoy commands require a lot of escaping in order to work.  Unfortunately this voodoo magic is known to fail in some cases.  By moving these portions out we avoid errors that happen because the escaping acts differently in the local environment than in CI or Probo environment

## QA Tests

- [ ] `ahoy dkan drupal-rebuild` works as expected
- [ ] `ahoy dkan remake` works as expected
- [ ] `ahoy dkan dkan reinstall ` works as expeced
