### PR TITLE
Move legend code inside check for workbench form ID

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@
  - Added DKAN Datastore module into DKAN Core.
  - Added DKAN Dataset module into DKAN Core.
  - Added DKAN Migrate Base module into DKAN Core.
+ - Update DKAN workflow vbo customizations to not affect other vbo forms.
 DKAN Dataset:
  - Upgrade Features to 7.x-2.9
  - Make date facet use "day" granularity.

--- a/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -73,8 +73,6 @@ function views_dkan_workflow_tree_action_info() {
 }
 
 function views_dkan_workflow_tree_views_bulk_operations_form_alter(&$form, &$form_state, $vbo) {
-
-
   // Workbench Moderation VBO action permissions check
   // @TODO This is temporary and needs to be moved to the front-end.
   if (strpos($form['#form_id'], 'views_form_workbench_moderation') === 0) {
@@ -99,48 +97,48 @@ function views_dkan_workflow_tree_views_bulk_operations_form_alter(&$form, &$for
         }
       }
     }
-  }
 
-  $form['select']['#type'] = 'div';
+    $form['select']['#type'] = 'div';
 
-  // Change "Select all items" button position
-  if ($form_state['step'] == 'views_form_views_form' && isset($form['select_all_markup'])) {
-    $select_all = array('select_all_markup' => $form['select_all_markup']);
-    $form['select'] = $select_all + $form['select'];
-    unset($form['select_all_markup']);
+    // Change "Select all items" button position
+    if ($form_state['step'] == 'views_form_views_form' && isset($form['select_all_markup'])) {
+      $select_all = array('select_all_markup' => $form['select_all_markup']);
+      $form['select'] = $select_all + $form['select'];
+      unset($form['select_all_markup']);
 
-    $dataset_icon = array(
-      'type' => 'dataset',
-      'class' => array('icon-dkan')
-    );
-    $resource_icon = array(
-      'type' => 'resource',
-      'class' => array('icon-dkan')
-    );
-    $story_icon = array(
-      'type' => 'dkan_data_story',
-      'class' => array('icon-dkan')
-    );
-    $dashboard_icon = array(
-      'type' => 'data_dashboard',
-      'class' => array('icon-dkan')
-    );
-    
-    $dataset_legend = '<span>'. theme('facet_icons', $dataset_icon) . ' Dataset</span>';
-    $resource_legend = '<span>'. theme('facet_icons', $resource_icon) . ' Resource</span>';
-    $story_legend = '<span>'. theme('facet_icons', $story_icon) . ' Data Story</span>';
-    $dashboard_legend = '<span>' . theme('facet_icons', $dashboard_icon) . ' Data Dashboard</span>';
-
-    if(module_exists('dkan_feedback')) {
-      $feedback_icon = array(
-        'type' => 'feedback',
+      $dataset_icon = array(
+        'type' => 'dataset',
         'class' => array('icon-dkan')
       );
-      $feedback_legend = '<span>'. theme('facet_icons', $feedback_icon) . ' Feedback</span>';
-      $form['#suffix'] = '<div class="references">' . $dataset_legend . $resource_legend . $story_legend . $dashboard_legend . $feedback_legend . '</div>';
-    }
-    else {
-      $form['#suffix'] = '<div class="references">' . $dataset_legend . $resource_legend . $story_legend . $dashboard_legend . '</div>';
+      $resource_icon = array(
+        'type' => 'resource',
+        'class' => array('icon-dkan')
+      );
+      $story_icon = array(
+        'type' => 'dkan_data_story',
+        'class' => array('icon-dkan')
+      );
+      $dashboard_icon = array(
+        'type' => 'data_dashboard',
+        'class' => array('icon-dkan')
+      );
+      
+      $dataset_legend = '<span>'. theme('facet_icons', $dataset_icon) . ' Dataset</span>';
+      $resource_legend = '<span>'. theme('facet_icons', $resource_icon) . ' Resource</span>';
+      $story_legend = '<span>'. theme('facet_icons', $story_icon) . ' Data Story</span>';
+      $dashboard_legend = '<span>' . theme('facet_icons', $dashboard_icon) . ' Data Dashboard</span>';
+
+      if(module_exists('dkan_feedback')) {
+        $feedback_icon = array(
+          'type' => 'feedback',
+          'class' => array('icon-dkan')
+        );
+        $feedback_legend = '<span>'. theme('facet_icons', $feedback_icon) . ' Feedback</span>';
+        $form['#suffix'] = '<div class="references">' . $dataset_legend . $resource_legend . $story_legend . $dashboard_legend . $feedback_legend . '</div>';
+      }
+      else {
+        $form['#suffix'] = '<div class="references">' . $dataset_legend . $resource_legend . $story_legend . $dashboard_legend . '</div>';
+      }
     }
   }
 }


### PR DESCRIPTION
Issue: civic-4410

## Description

Workbench legend variables display on harvest VBO forms due to small glitch in the views_dkan_workflow_tree_views_bulk_operations_form_alter function.


## Steps to Reproduce:
0. Enable dkan_workflow and dkan_harvest.
1. Create Harvest Source.
2. Harvest The source.
3. Go to "Manage Datasets" page.
4. Confirm the legend vars are displayed at the bottom of the form

## Acceptance Criteria
No glitches at the bottom of the "Manage Datasets" page.

## QA Tests

0. Enable dkan_workflow and dkan_harvest.
1. Create Harvest Source.
2. Harvest The source.
3. Go to "Manage Datasets" page.
4. Confirm there are no legend vars displayed at the bottom of the form
