### PR TITLE
Update dkan_topics.make

### DIFF
--- a/modules/dkan/dkan_topics/dkan_topics.make
+++ b/modules/dkan/dkan_topics/dkan_topics.make
@@ -14,7 +14,7 @@ projects[taxonomy_menu][version] = 1.5
 projects[color_field][version] = 1.8
 projects[color_field][patch][2696505] = https://www.drupal.org/files/issues/color_field-requirements-2696505-v2.patch
 projects[entity_path][version] = 1.x-dev
-projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_1.diff
+projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_2.diff
 projects[globalredirect][version] = 1.5
 
 ; Patches

--- a/modules/dkan/dkan_topics/dkan_topics.make
+++ b/modules/dkan/dkan_topics/dkan_topics.make
@@ -14,7 +14,7 @@ projects[taxonomy_menu][version] = 1.5
 projects[color_field][version] = 1.8
 projects[color_field][patch][2696505] = https://www.drupal.org/files/issues/color_field-requirements-2696505-v2.patch
 projects[entity_path][version] = 1.x-dev
-projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_2.diff
+projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff
 projects[globalredirect][version] = 1.5
 
 ; Patches


### PR DESCRIPTION
## Description

Fixes MySQL 5.7 patch. The patch pulled here: https://github.com/NuCivic/dkan/pull/1380 needs to be updated because it drops the wrong table name: 
```
db_drop_primary_key('cid');
```

Should be:

```
db_drop_primary_key('entity_path_config');
```
This will break database updates.