### PR TITLE
Reset php memory back to 256.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ dependencies:
      #- "dkan/test/sites/default"
   pre:
     - rm /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
-    - echo "memory_limit = 512M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
     - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
   override:
     - printenv


### PR DESCRIPTION
Description
===
The PHP memory limit was recently updated as a timeout measure but this is not
required at this point.  This PR reverts that change.