### PR TITLE
Harvest "Errors" first event table have wrong date in the header

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.pages.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.pages.inc
@@ -185,7 +185,7 @@ function dkan_harvest_page_error_log($node) {
     $collapsible_item_offset = 0;
     // We can use the mlid key as the bases of the sorting. The bigger the mlid
     // the more recent the harvest migrate event. Preserve the key.
-    $collapsible_items = array_reverse($collapsible_items, FALSE);
+    $collapsible_items = array_reverse($collapsible_items, TRUE);
     foreach ($collapsible_items as $collapsible_item_mlid => $collapsible_item) {
       $collapsible_inner_table = array(
         '#attached' => array(


### PR DESCRIPTION
Issue: [CIVIC-4496](https://jira.govdelivery.com/browse/CIVIC-4496)

## Description
![image](https://cloud.githubusercontent.com/assets/1914306/19638581/ea5f1cca-99d4-11e6-87ff-68a3bbf815e0.png)

The date issue only affects the last event table (top table).

## Steps to Reproduce
1. Create Harvest Source {{Test}}. This source should have bag records that will generate harvest errors.
2.  Harvest {{Test}}.
3. Open **Errors** tab.
4. The top table header should have the correct errors count but the date should be wrong.

## Acceptance Criteria
1. The date should be correct.

## Test Updates
1. Update the Behat tests to include a check for the date.

## QA Tests

- [x] After going throu the steps to reproduce. The date displayed in the first item on the error tab should be the correct date.

## PR dependencies

N/A