### PR TITLE
Warning message edit resource without dataset civic 4447

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@
  - Added DKAN Dataset module into DKAN Core.
  - Added DKAN Migrate Base module into DKAN Core.
  - Update DKAN workflow vbo customizations to not affect other vbo forms.
+ - Removed warning message when try edit resource without dataset.
 DKAN Dataset:
  - Upgrade Features to 7.x-2.9
  - Make date facet use "day" granularity.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,18 +22,11 @@
  - Fix for relative paths to ensure links still work when a site is installed into a subdirectory.
  - Removed field mapping warnings during import of default content.
  - Removed conditional_fields from dkan_topics.
- - Fix bugs in resource mimetypes and previews.
- - Added DKAN Harvest module into DKAN Core.
- - Added DKAN Datastore module into DKAN Core.
- - Added DKAN Dataset module into DKAN Core.
- - Added DKAN Migrate Base module into DKAN Core.
- - Update DKAN workflow vbo customizations to not affect other vbo forms.
- - Removed warning message when try edit resource without dataset.
-DKAN Dataset:
  - Upgrade Features to 7.x-2.9
  - Make date facet use "day" granularity.
  - Remove ARC2 library.
  - Disable pathauto for content created using dkan_fixtures.
+ - Removed warning message when try edit resource without dataset.
 DKAN Datastore:
  - Added DKAN Datastore module into DKAN Core.
  - Greatly expand the datastore API to support aggregation functions, better joins, multiple queries. See dkan_datastore_api's README file

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -761,7 +761,7 @@ function dkan_harvest_form_alter(&$form, &$form_state, $form_id) {
     //Show a warning message if is a harvested content.
     $node = $form['#node'];
 
-    if ($form_id == 'resource_node_form' && isset($node->field_dataset_ref)) {
+    if ($form_id == 'resource_node_form' && isset($node->field_dataset_ref[LANGUAGE_NONE][0]['target_id'])) {
       $node = node_load($node->field_dataset_ref[LANGUAGE_NONE][0]['target_id']);
     }
 


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4447

## Description

An "Notice: Undefined index: und" is being displayed when a resource is being edited.


## How to reproduce

1. Go to node/add/resource and create a resource. Do not assign a dataset.
2.- No errors will be displayed.
3.- On the resource page click 'Edit'
4.- A "Notice: Undefined index: und" warning will be displayed..

## QA Tests

- [ ] Edit a resource without dataset associated and you shouldn't see any warning message.

