### PR TITLE
Couple fixes for DKAN test default params and run directory

### DIFF
--- a/.ahoy/.scripts/behat-parse-params.rb
+++ b/.ahoy/.scripts/behat-parse-params.rb
@@ -51,7 +51,11 @@ def behat_parse_params args
       params.push param
     end
   end
-  params.unshift '--colors'
+
+  unless params.include? '--no-colors'
+    params.unshift '--colors'
+  end
+
   {:files => files, :params => params}
 end
 

--- a/.ahoy/.scripts/dkan-test.rb
+++ b/.ahoy/.scripts/dkan-test.rb
@@ -44,11 +44,11 @@ def main
     `bash dkan/.ahoy/.scripts/composer-install.sh #{BEHAT_FOLDER}`
   end
 
-  parsed = behat_parse_params(payload)
-  files = parsed[:files].join(" ")
-  params = behat_join_params(parsed[:params])
-
   Dir.chdir(BEHAT_FOLDER) do
+    parsed = behat_parse_params(payload)
+    files = parsed[:files].join(" ")
+    params = behat_join_params(parsed[:params])
+
     puts "RUNNING: bin/behat #{files} #{params} #{CONFIG}"
 
     IO.popen("bin/behat #{files} #{params} #{CONFIG}") do |io|


### PR DESCRIPTION
Description
===

The parameter --no-colors is not being handled properly by our parameter parser because it's misspelled. Fixing the typo will fix this issue.

QA Steps
===

- [ ] Run ahoy dkan test --no-colors locally should work as expected.