### PR TITLE
Removed row from migration map table when a dataset is deleted

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ DKAN Harvest:
  - Added UI to add harvest sources
  - Added UI to manage harvest sources and datasets
  - Fix dkan harvest feature overridden after install.
+ - Removed row from migration map table when a dataset is deleted.
 DKAN Migrate Base
  - Added DKAN Migrate Base module into DKAN Core.
 DKAN Workflow:

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -725,6 +725,18 @@ function dkan_harvest_node_delete($node) {
     $harvest_source = HarvestSource::getHarvestSourceFromNode($node);
     dkan_harvest_deregister_sources(array($harvest_source));
   }
+
+  if ($node->type == 'dataset') {
+    // Delete the associated row from the migration map table.
+    $dataset_wrapper = entity_metadata_wrapper('node', $node);
+    $harvest_source_node = $dataset_wrapper->field_harvest_source_ref->value();
+    if ($harvest_source_node) {
+      $harvest_source = HarvestSource::getHarvestSourceFromNode($harvest_source_node);
+      $harvest_migration = $harvest_source->getMigration();
+      $migration_map_table = $harvest_migration->getMap();
+      $migration_map_table->deleteDestination(array($dataset_wrapper->getIdentifier()));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4503

## Description

When a dataset is deleted the associated row on the harvest migration map table needs to be deleted as well in order to re-create the dataset when the source is harvested again.

## QA Tests

- [x] Go and create a Harvest Source on the QA site.
- [x] Harvest the source.
- [x] Check the number of datasets displayed on the Harvest Dashboard and the source page.
- [x] Delete any of the datasets associated with the Harvest Source.
- [x] Confirm that the number of datasets displayed on the Harvest Dashboard is OK.
- [x] Harvest the source again.
- [x] Confirm that the dataset was re-created.
- [x] Confirm that the number of datasets displayed on the Harvest Dashboard is OK.
- [x] Go and delete any dataset that is NOT associated with the source.
- [x] Confirm that no errors were displayed.