### PR TITLE
Changes endpoint dcat pass online validation civic 4481

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@
  - Removed warning message when try edit resource without dataset.
  - Removed redundant definition for CKAN package_list endpoint from open_data_schema_map_dkan, allowing that feature to be in default state after install.
  - Update ctools to version 1.10, which fixes some PHP7 incompatibilities
+ - Alter dcat endpoint to pass online validation
 DKAN Datastore:
  - Added DKAN Datastore module into DKAN Core.
  - Greatly expand the datastore API to support aggregation functions, better joins, multiple queries. See dkan_datastore_api's README file

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@ api: '2'
 core: 7.x
 includes:
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
+  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/changes_endpoint_dcat_pass_online_validation_civic_4481/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
 projects:
@@ -240,7 +240,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/open_data_schema_map.git'
-      branch: 7.x-1.x
+      branch: changes_endpoint_dcat_pass_online_validation_civic_4481
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4481

## Description

We are getting some errors when try to pass online validation and catalog.xml endpoint (http://www.dcat.be/validator/). 



## How to reproduce

1.  Put the url catalog.xml from a dkan fresh to http://www.dcat.be/validator/ and will show 3 errors .

## QA Tests

- [ ] Access to http://www.dcat.be/validator/ and when you paste xml output from catalog.xml the validation should pass without show any error message

## PR dependencies

- [ ] https://github.com/NuCivic/open_data_schema_map/pull/75
