### PR TITLE
Use correct term table fields.

### DIFF
--- a/test/features/topics.feature
+++ b/test/features/topics.feature
@@ -2,16 +2,16 @@ Feature: Topics
 
   Background:
     Given "dkan_topics" terms:
-      | name         | Icon Type | Icon   |
-      | Topic1       | font      | xe977  |
-      | Topic2 & $p@ | font      | xe97b  |
+      | name         | field_icon_type  | field_topic_icon   |
+      | Topic1       | font             | xe904              |
+      | Topic2 & $p@ | font             | xe97b              |
 
   @api @Topics
   Scenario: See topics on the homepage as anonymous user
     When I am on the homepage
     Then I should see "Topic1"
     And I should see "Topic2 & $p@"
-    And I should see "icon" in the ".font-icon-select-1-e977" element
+    And I should see "icon" in the ".font-icon-select-1-e904" element
 
   @api @Topics
   Scenario: See topic in the main menu


### PR DESCRIPTION
REF https://jira.govdelivery.com/browse/CIVIC-4703

Description
===
The current behat scenario "Scenario: See topics on the homepage as anonymous
user" is testing a mute test becuase it checks for an icon that is already added
by the dkan profile on installation.  The problem is that on older sites that do
not run the profile, the default icon is not added revealing a test bug when
this icon is checked for.  Although the test adds the icon a background step, it
fails to correctly add the icon font and icon type because the table field are
not correctly mapped or the correct table field name is not used.

This commit fixes two issues.
- [ ] Make sure to use an icon in the test that is not already added to the
  front page, that way if there is an uderlying issue it is caught but the
  upstream tests.

- [ ] Make sure to use the correct field labels for the background table.

Steps to reproduce:
===
* On an OOB site remove the term topic term with the little bus (icon xe977).
* Run  the features/topics.feature tests... test should fail.

QA Steps
===
- [x] Tests pass.