### PR TITLE
QA PR for [CIVIC-3961] 'Step' value in chart has no effect

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/fix-calcTickValues/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"


### PR DESCRIPTION
related issue: CIVIC-3961

### Description
Changing the Y-axis 'Step' value in a chart visualization is not changing how the chart is rendered.

For any value entered into the 'step' field, the y-axis always shows a label for many more values. This can crash a chart if the range is set very high for large data values. (see attached image)

Tested on Mac/Chrome with DKAN 12.8

### Steps to Reproduce

Using demo content...

Create a chart using Table of Gold Prices dataset. Use 'price' as the series, and 'date' as the x-field.
Select a bar chart
Try to change the Y-axis 'Step' field and you will see no change in the chart
Change the 'Tick Values' range to \[0,100\] → \[0,1000] → \[0,10000\] and you will see *many* numbers rendered a label on the y-axis regardless of the 'Step' setting. This may crash your browser when you reach >10000.

### Acceptance Criteria
When I change the Y-axis 'Step' value on a chart visualization to 4
Then I should see a 4 increment in the labels displayed on Y-axis

### Related PR
This is the PR to merge: https://github.com/NuCivic/recline.view.nvd3.js/pull/31
Please do not merge this PR.