### PR TITLE
Fix dataset download all link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,7 @@ DKAN Dataset:
  - Fix keywords/tags creating broken links when containing spaces, and add missing keywords to default content.
  - Add support "Compound" fields on Filters/Overrides/Excludes/Default in DKAN Harvest.
  - Fix ODSM permissions for non-admin roles.
+ - Fixed text on 'Download All' button to not display HTML.
 
 
 7.x-1.12.11

--- a/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
@@ -122,9 +122,10 @@ function theme_dkan_dataset_resource_view($vars) {
       ));
     }
     if ($file_count > 1) {
-      $link = t('Download All <i class="fa fa-download"></i>');
+      $link = t('Download All');
+      $icon = '<i class="fa fa-download"></i>';
       $download_all = '<div property="dcat:Distribution"><span class="links">';
-      $download_all .= l($link, 'node/' . $vars['node']->nid . '/dataset/download', array(
+      $download_all .= l($link . ' ' . $icon, 'node/' . $vars['node']->nid . '/dataset/download', array(
         'html' => TRUE,
         'attributes' => array(
           'class' => array('btn', 'btn-primary'),

--- a/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
@@ -122,8 +122,9 @@ function theme_dkan_dataset_resource_view($vars) {
       ));
     }
     if ($file_count > 1) {
+      $link = t('Download All <i class="fa fa-download"></i>');
       $download_all = '<div property="dcat:Distribution"><span class="links">';
-      $download_all .= l(t('Download All @fa_download', array('@fa_download' => '<i class="fa fa-download"></i>')), 'node/' . $vars['node']->nid . '/dataset/download', array(
+      $download_all .= l($link, 'node/' . $vars['node']->nid . '/dataset/download', array(
         'html' => TRUE,
         'attributes' => array(
           'class' => array('btn', 'btn-primary'),


### PR DESCRIPTION
## Description

Button text for the dataset download all link is displaying html

![crime_data_for_the_ten_most_populous_cities_in_the_u_s____dkan](https://cloud.githubusercontent.com/assets/314172/20354278/3ccce8c8-abe3-11e6-98e3-bfaad8d7e8d1.png)

## Acceptance Steps
Confirm that the 'Download All' button on dataset pages show an icon and not the html for the icon.