### PR TITLE
Fix Format search facet does not display selected terms

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 -------------------------
 - Update ctools to 1.11
+- Fix "format" facet collapsed even when selected on the search page.
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
@@ -23,15 +23,21 @@ function dkan_sitewide_panels_preprocess_panels_style_collapsible(&$variables) {
     $pane = $variables['pane'];
     if (substr($pane->type, 0, 8)) {
       foreach (array_keys($adapter->getAllActiveItems()) as $param) {
-        // We match the first part of the param to a mapped facet name
-        $param_parts = explode(':', $param, 2);
-        $param_name = $param_parts[0];
+        // We match the non digits parts of the param name. Using the first part
+        // will break Composite fields link field_resources:field_format
+        // filters.
+        $param_name = preg_replace("/:\d+/", "", $param);
         // The pane subtype will be something like "facetapi-wsVI1ENUXwf4Rz08n9fg2WvfQ0Gs5h2a"
         $facet_hash = substr($pane->subtype, 9);
         $facet_delta_map = facetapi_get_delta_map();
         if (in_array($facet_hash, array_keys($facet_delta_map))) {
           $mapping_parts = explode(':', $facet_delta_map[$facet_hash]);
           $facet_name = $mapping_parts[2];
+
+          // Composite facet names have the colon encoded into RFC 3986. Decode
+          // that.
+          $facet_name = rawurldecode($facet_name);
+
           if ($facet_name == $param_name) {
             $variables['collapsed'] = 0;
           }

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.module
@@ -22,11 +22,10 @@ function dkan_sitewide_panels_preprocess_panels_style_collapsible(&$variables) {
     // Find out if the pane matches a facet in the query string; un-collapse if so
     $pane = $variables['pane'];
     if (substr($pane->type, 0, 8)) {
-      foreach (array_keys($adapter->getAllActiveItems()) as $param) {
-        // We match the non digits parts of the param name. Using the first part
-        // will break Composite fields link field_resources:field_format
-        // filters.
-        $param_name = preg_replace("/:\d+/", "", $param);
+      foreach ($adapter->getAllActiveItems() as $param_key => $param_value) {
+        // Use the field alias as the param_name.
+        $param_name = $param_value['field alias'];
+
         // The pane subtype will be something like "facetapi-wsVI1ENUXwf4Rz08n9fg2WvfQ0Gs5h2a"
         $facet_hash = substr($pane->subtype, 9);
         $facet_delta_map = facetapi_get_delta_map();
@@ -38,8 +37,11 @@ function dkan_sitewide_panels_preprocess_panels_style_collapsible(&$variables) {
           // that.
           $facet_name = rawurldecode($facet_name);
 
+          // Un-collapse the facet if it is part of the request.
           if ($facet_name == $param_name) {
             $variables['collapsed'] = 0;
+            // We have a match! no need to continue.
+            break;
           }
         }
       }


### PR DESCRIPTION
Issue: CIVIC-4771

## Description
The *Format* search facet does not display selected terms as expected, the block keeps the 'ctools-toggle-collapsed' class which hides the active content

## QA
1. Go to the search page
2. Select a Format term
3. Format facet item should not be collapsed (see screenshot).

![image](https://cloud.githubusercontent.com/assets/1914306/20434731/8b2cbb98-ada9-11e6-8677-919e6f23e10a.png)
