### PR TITLE
Restore harvest status set up CIVIC-4927

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.pages.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.pages.inc
@@ -25,6 +25,7 @@ function dkan_harvest_page_event_log($node) {
       'field' => 'starttime',
       'sort' => 'desc',
     ),
+    'status' => array('data' => t('Status'), 'field' => 'failed'),
     'duration' => array('data' => t('Duration'), 'field' => 'duration'),
     'created' => array('data' => t('Created'), 'field' => 'created'),
     'updated' => array('data' => t('Updated'), 'field' => 'updated'),
@@ -33,6 +34,8 @@ function dkan_harvest_page_event_log($node) {
     'unchanged' => array('data' => t('Unchanged'), 'field' => 'unchanged'),
   );
 
+  $status_text = array(0 => t('OK'), 1 => l(t('ERROR'), 'node/' . $node->nid . '/harvest-errors', array('attributes' => array('alt' => 'Error'))));
+  $status_class = array(0 => 'alert-success', 1 => t('alert-danger'));
   $harvest_source = HarvestSource::getHarvestSourceFromNode($node);
   $harvest_source_migration = dkan_harvest_get_migration($harvest_source);
   $log_table = $harvest_source_migration->getMap()->getLogTable();


### PR DESCRIPTION
Issue: civic-4927
Undefined variable breaks Events table

## How to reproduce

1.  create a harvest source
2. visit the Events tab under the source page

## QA Tests

- [ ] Create a harvest source, confirm there are no errors on the harvest events page

<img width="978" alt="events___dkan" src="https://cloud.githubusercontent.com/assets/314172/20489491/72877dac-afd0-11e6-9fb6-a68137d355ac.png">
