### PR TITLE
Truncate table message before execute a new migration on phpunit test

### DIFF
--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -261,6 +261,7 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
   public function testHarvestSourceAlternative() {
     // Get the current values.
     $migrationOld = dkan_harvest_get_migration(self::getOriginalTestSource());
+    $this->resetMessageTableFromMigration($migrationOld);
     $migrationOldMap = $this->getMapTableFromMigration($migrationOld);
     $migrationOldLog = $this->getLogTableFromMigration($migrationOld);
     $migrationOldMessage = $this->getMessageTableFromMigration($migrationOld);
@@ -279,6 +280,7 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
     dkan_harvest_migrate_sources(array(self::getAlternativeTestSource()));
 
     $migrationAlternative = dkan_harvest_get_migration(self::getAlternativeTestSource());
+    $this->resetMessageTableFromMigration($migrationAlternative);
     $migrationAlternativeMap = $this->getMapTableFromMigration($migrationAlternative);
     $migrationAlternativeLog = $this->getLogTableFromMigration($migrationAlternative);
     $migrationAlternativeMessage = $this->getMessageTableFromMigration($migrationAlternative);
@@ -869,6 +871,19 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
       ->execute();
 
     return $result->fetchAllAssoc('msgid');
+  }
+
+  /**
+   * Helper method to reset a harvest migration map table from the harvest
+   * migration.
+   *
+   * @param HarvestMigration $migration
+   *
+   * @return Bool status after reset message.
+   */
+  private function resetMessageTableFromMigration(HarvestMigration $migration) {
+    $map = $migration->getMap();
+    return db_truncate($map->getMessageTable())->execute();
   }
 
   /**


### PR DESCRIPTION
Issue: link_to_jira_github_issue

## Description

Phpunit test is failing on harvest integration


## How to reproduce

1. PHP unit test fail

## QA Tests

- [ ]  PHP unit test pass.


