### PR TITLE
Update changelog with fix for group teaser links CIVIC-4947 (release)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 -------------------------
 - Update ctools to 1.11
+- Fixed link to group page on group node teaser when site has clean urls disabled
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -163,7 +163,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch: civic-4947-release
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -163,7 +163,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: civic-4947-release
+      branch: release-1-12
     type: theme
   radix:
     type: theme


### PR DESCRIPTION
Issue: civic-4947
https://github.com/NuCivic/dkan/issues/1560

## Description
If running the site with clean urls disabled, the link for the dataset count button on group teasers will not work.

## QA Steps
1. Disable clean urls
2. Go to the 'Groups' page
3. Click the blue dataset count button on one of the groups
4. Confirm that you do not get a Page not found error, you see the group node

## Related PR
https://github.com/NuCivic/nuboot_radix/pull/101

Restore **drupal-org.make** file when done with QA