### PR TITLE
Fix: Error status is lost when harvest run for a second time

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_dashboard/views/handlers/views_handler_field_boolean_harvest_status.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_dashboard/views/handlers/views_handler_field_boolean_harvest_status.inc
@@ -130,6 +130,7 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
 
     $harvest_source_migration = dkan_harvest_get_migration($harvest_source);
     $messageTable = $harvest_source_migration->getMap()->getMessageTable();
+    $logTable = $harvest_source_migration->getMap()->getLogTable();
 
     // Let's see if we got errors during the last migration.
     $query_message_table = db_query("SELECT COUNT(*) FROM " . $messageTable . " WHERE mlid = :mlid AND level = :error_level",
@@ -139,6 +140,13 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
       ));
     $result_message_table = $query_message_table->fetchAssoc();
 
+    // Let's see if we didn't get errors during the last migration but failed.
+    $query_log_table = db_query("SELECT failed FROM " . $logTable . " WHERE mlid = :mlid",
+      array(
+        ':mlid' => $mlid,
+      ));
+    $result_log_table = $query_log_table->fetchField();
+
     if (empty($result_message_table)) {
       // i'm confused. This should no happen.
       watchdog('dkan_harvest_dashboard', "Result for error message not found.", array(), WATCHDOG_ERROR);
@@ -146,7 +154,7 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
     }
 
     $errors_count = array_pop($result_message_table);
-    return $errors_count > 0 ? TRUE : FALSE;
+    return (($errors_count > 0) || $result_log_table) ? TRUE : FALSE;
   }
 
   /**


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4922

## Description

When you execute a harvest migration and fail the first time if you try to execute again the status on dashboard is ok.


## How to reproduce

1.  Create a harvest node with https://raw.githubusercontent.com/NuCivic/dkan/7.x-1.x/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_error.json you should see on dashboard status ERROR.
2.- Execute again and you will see OK on status field.

## QA Tests

- [ ] Create a harvest node with source https://raw.githubusercontent.com/NuCivic/dkan/7.x-1.x/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_error.json and status field is "Error"
- [ ] Execute migration again and you should see "Error" on status field.