### PR TITLE
Hide "Back to dataset" button for datasetless resources [CIVIC-4448]

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,6 +81,7 @@ DKAN Dataset:
  - Replace field notes by field body in harvest source content type.
  - Fixed text on 'Download All' button to not display HTML.
  - Add patch for workbench_moderation to avoid php shutdown function errors.
+ - Removed 'Back to dataset' button on standalone resources.
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -428,12 +428,12 @@ function dkan_form_create_stages($op, $dataset_nid = NULL, $resource_nid = NULL)
  * Access callback for back link.
  */
 function dkan_dataset_back_access($node) {
-  if ($node->type != 'resource') {
+  if ($node->type != 'resource'
+  || empty($node->field_dataset_ref)) {
     return FALSE;
   }
-  else {
-    return node_access('view', $node);
-  }
+
+  return node_access('view', $node);
 }
 
 /**

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -167,8 +167,7 @@ Feature: Dataset Features
     And I should see "Groups were updated on 1 resource(s)"
     And I should not see "Resource 04" in the "resource title" region
     When I am on "Resource 04" page
-    And I click "Back to dataset"
-    Then I should see "There is no dataset associated with this resource"
+    Then I should not see the link "Back to dataset"
 
   @noworkflow @javascript
   Scenario: Add a resource with no group to a dataset with group

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -152,3 +152,11 @@ Feature: Resource
     When I press "Open With"
     Then I should see the local preview link
     And I should see "CartoDB"
+
+  @api @here
+  Scenario: Hide "Back to dataset" button on resources without dataset
+    Given resources:
+      | title                    | publisher | format | dataset | author | published | description |
+      | Resource Without Dataset | Group 01  | csv    |         | Katie  | Yes       | Old Body    |
+    And I am on "Resource Without Dataset" page
+    Then I should not see the link "Back to dataset"

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -129,10 +129,7 @@ Feature: Resource
     And I press "Save"
     Then I should see "Resource 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    When I click "Back to dataset"
-    Then I should see "There is no dataset associated with this resource"
-    Given I am on "Dataset 04" page
-    Then I should not see "Resource 07" in the "dataset resource list" region
+    And I should not see the link "Back to dataset"
 
   @noworkflow
   Scenario: Add a resource with no group to a dataset with group


### PR DESCRIPTION
Issue: CIVIC-4448

## Description
When the "Back to dataset" button is clicked on a resource with no associated dataset the URL changes to /node/XXX/dataset and the view looks empty.

## How to reproduce

* Create a resource without associated dataset.
* Go to the view page.
* Click on "Back to dataset".
* The URL will change and the view will be empty (only the buttons will be displayed).

## QA Tests
- "Back to dataste" button should not be available for resources without datasets.
