### PR TITLE
Fix subtheme creation command on release branch CIVIC-4409

### DIFF
--- a/.ahoy/theme.ahoy.yml
+++ b/.ahoy/theme.ahoy.yml
@@ -70,6 +70,7 @@ commands:
         echo "Creating theme $ARGS at $THEME_DIR"
       fi
       ORIGINAL_THEME=`ahoy drush vget theme_default --format=string`
+      ahoy drush pm-enable radix -y
       ahoy drush vset theme_default radix
       ahoy cmd-proxy drush cc drush
       KIT_URL="https://github.com/NuCivic/radix-kit-nuboot/archive/master.zip"
@@ -82,6 +83,7 @@ commands:
         ahoy drush en $ARGS -y
         ahoy drush vset theme_default $ARGS -y
         ahoy drush pm-disable $ORIGINAL_THEME -y
+        ahoy drush pm-disable radix -y
       else
         echo "Can't seem to download kit from $KIT_URL, restoring original theme"
         ahoy drush vset theme_default $ORIGINAL_THEME


### PR DESCRIPTION
Issue: CIVIC-4409

## Description

The ahoy command for creating a subtheme was not working
```ahoy dkan theme new-from-kit [theme name]```

## Acceptance Steps
1. set up local build
2. run the command above (use a one word theme name or use an underscore)
3. confirm that the new subtheme was created and is enabled as the default theme