### PR TITLE
Remove the manage datastore button from the harvest preview page. CIVIC-5020

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,8 @@ DKAN Harvest:
  - Added 'Add Source' shortcut on Harvest Dashboard pages.
  - Fixed breadcrumb on harvest sources pages: Preview, Manage Datasets, Events, Errors.
  - Fixed harvesting of resources with remote files with redirects.
+ - Fix "Manage Datastore" tab leaking to the harvest source node.
+ - Add icons for harvest source tabs.
 DKAN Migrate Base:
  - Added DKAN Migrate Base module into DKAN Core.
  - Removed row from migration map table when a dataset is deleted.

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -163,7 +163,7 @@ function dkan_datastore_feeds_access($action, $node) {
   }
 
   // All available operations requires the 'manage datastore' permission.
-  if (user_access('manage datastore') && node_access('update', $node)) {
+  if (user_access('manage datastore') && node_access('update', $node) && $node->type == 'resource') {
     return TRUE;
   }
 

--- a/themes/nuboot_radix/includes/menu.inc
+++ b/themes/nuboot_radix/includes/menu.inc
@@ -92,6 +92,22 @@ function nuboot_radix_menu_local_task($variables) {
         $icon_type = 'eraser';
         break;
 
+      case 'node/%/datasets':
+        $icon_type = 'cubes';
+        break;
+
+      case 'node/%/harvest-preview':
+        $icon_type = 'check-circle';
+        break;
+
+      case 'node/%/harvest-events':
+        $icon_type = 'calendar';
+        break;
+
+      case 'node/%/harvest-errors':
+        $icon_type = 'exclamation-circle';
+        break;
+
       default:
         $icon_type = '';
         break;


### PR DESCRIPTION
Issue: CIVIC-5020

## Description

Harvest source nodes display a 'manage datastore' button that should not be there

## Acceptance Steps
- [ ] When on a harvest source node, you should not see a 'Manage Datastore' button
- [ ] Icons added to the Preview, Manages Datasets, Events, and Errors tabs