### PR TITLE
Updates datastore cron workflow

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,7 +59,8 @@
  - Upgrade search_api to 1.20
 DKAN Datastore:
  - Added DKAN Datastore module into DKAN Core.
- - Greatly expand the datastore API to support aggregation functions, better joins, multiple queries. See dkan_datastore_api's README file
+ - Greatly expand the datastore API to support aggregation functions, better joins, multiple queries. See dkan_datastore_api's README file.
+ - Fixed bugs when running the datastore via cron.
 DKAN Harvest:
  - Added DKAN Harvest module into DKAN Core.
  - Added UI to add harvest sources

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
@@ -30,9 +30,8 @@ function dkan_dataset_rest_api_services_request_postprocess_alter($controller, $
     if (isset($result[0]['uri'])) {
       $nid = $args[0];
       $uuid = current(entity_get_uuid_by_id('node', array($nid)));
-      $fid = $result[0]['fid'];
 
-      dkan_datastore_queue_import($uuid, $fid);
+      dkan_datastore_queue_import($uuid);
     }
   }
 }

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -163,7 +163,7 @@ function dkan_datastore_feeds_access($action, $node) {
   }
 
   // All available operations requires the 'manage datastore' permission.
-  if (user_access('manage datastore') && node_access('update', $node)) {
+  if (user_access('manage datastore') && node_access('update', $node) && $node->type == 'resource') {
     return TRUE;
   }
 

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -163,7 +163,7 @@ function dkan_datastore_feeds_access($action, $node) {
   }
 
   // All available operations requires the 'manage datastore' permission.
-  if (user_access('manage datastore') && node_access('update', $node) && $node->type == 'resource') {
+  if (user_access('manage datastore') && node_access('update', $node)) {
     return TRUE;
   }
 
@@ -590,22 +590,18 @@ function dkan_datastore_cron_queue_info() {
 /**
  * Utility function for add a new resource to datastore queue.
  */
-function dkan_datastore_queue_import($uuid, $fid) {
+function dkan_datastore_queue_import($uuid) {
   $item = array(
     'uuid' => $uuid,
-    'fid' => $fid,
   );
   DrupalQueue::get('dkan_datastore_queue')->createItem($item);
-  watchdog('dkan_datastore', 'Added @file to queue for import into datastore', array('%file' => $fid));
+  watchdog('dkan_datastore', 'Added resource %uuid to queue for import into datastore', array('%uuid' => $uuid));
 }
 
 /**
  * Callback used with queue for index content into datastore.
  */
 function dkan_datastore_queue_import_worker($item) {
-  $file = file_load($item['fid']);
-  $uri = $file->uri;
-  $file_path = file_create_url($uri);
   $datastore = dkan_datastore_go($item['uuid']);
-  $datastore->updateByFile($file_path);
+  $datastore->importByCLI();
 }

--- a/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
@@ -412,89 +412,80 @@ class DkanDatastore extends Datastore implements DatastoreFormInterface {
     $feed = isset($this->feed) ? $this->feed : $this->feed($this->node);
     $feed['source']->startImport();
   }
+  /**
+   * Starts import without invoking batch UI process.
+   */
+  public function importByCLI() {
+    $source = $this->setUpSource();
+    // Import new items.
+    while (FEEDS_BATCH_COMPLETE != $source->import()) {
+      continue;
+    };
+  }
 
   /**
-   * Update datastore with file.
+   * Updates the resource file using the URI.
+   *
+   * @param string $uri
+   *   The URI, ie public://myfile.png, for the file.
+   * @param bool $copy_file
+   *   A boolean indicating whether to copy the file locally.
+   *   If set to TRUE the file is copied locally.
    */
-  public function updateByFile($uri = '', $copy_file = TRUE, $truncate = TRUE) {
+  public function updateFileByURI($uri, $copy_file = TRUE) {
 
-    if (!$uri) {
+    if ($copy_file) {
+      $file = array();
+      $file = file_get_contents($uri);
+      $file = file_save_data($new_file, 'public://' . drupal_basename($uri));
+    }
+    else {
+      // The file exists.
+      $fid = db_query('SELECT fid FROM {file_managed} WHERE uri = :uri', array(':uri' => $uri))->fetchField();;
+      $file = file_load($fid);
+    }
+
+    if ($fid) {
+      $this->updateFile($file);
+    }
+    else {
       return FALSE;
     }
 
-    try {
-      // Get current file.
-      $current_file = $this->file();
+  }
 
-      $new_file = array();
-      if ($copy_file) {
-        // Save new file.
-        $new_file = file_get_contents($uri);
-        $new_file = file_save_data($new_file, 'public://' . drupal_basename($uri));
+  /**
+   * Update resource with file.
+   *
+   * @param bool $use_current_setttings
+   *  If set to TRUE use the current file visibility settings.
+   *
+   */
+  public function updateFile($file, $use_current_setttings = TRUE) {
+    // Get current file.
+    $current_file = $this->file();
+
+    if ($current_file && $use_current_setttings) {
+      // Copy view settings from current file.
+      if (isset($current_file->map)) {
+        $file->map = $current_file->map;
       }
-      else {
-        // The file exists.
-        $fid = db_query('SELECT fid FROM {file_managed} WHERE uri = :uri', array(':uri' => $uri))->fetchField();;
-        $new_file = file_load($fid);
+      if (isset($current_file->grid)) {
+        $file->grid = $current_file->grid;
       }
-
-      if ($new_file) {
-        // Set default settings.
-        $new_file->status = FILE_STATUS_PERMANENT;
-        $new_file->display = 1;
-        $new_file->description = '';
-        $new_file->map = 1;
-        $new_file->grid = 1;
-        $new_file->graph = 1;
-
-        if ($current_file) {
-          // Copy view settings from current file.
-          if (isset($current_file->map)) {
-            $new_file->map = $current_file->map;
-          }
-          if (isset($current_file->grid)) {
-            $new_file->grid = $current_file->grid;
-          }
-          if (isset($current_file->graph)) {
-            $new_file->graph = $current_file->graph;
-          }
-          // Delete current file.
-          $this->deleteFile();
-        }
-
-        // Save new file.
-        file_save($new_file);
-
-        $file_field = dkan_datastore_file_upload_field();
-        $this->node->{$file_field} = array(LANGUAGE_NONE => array((array) $new_file));
-        node_save($this->node);
-
-        // Add importer if not present.
-        if (!$this->importerId) {
-          feeds_node_insert($this->node);
-          $this->importerId = $this->importerId();
-          $this->source = $this->source();
-          $this->importer = $this->importer();
-        }
-
-        // Set up importer.
-        $source = $this->setUpSource();
-        // Import new items.
-        while (FEEDS_BATCH_COMPLETE != $source->import()) {
-          continue;
-        };
-
-        return TRUE;
-
+      if (isset($current_file->graph)) {
+        $file->graph = $current_file->graph;
       }
-      else {
-        return FALSE;
-      }
-
+      // Delete current file.
+      $this->deleteFile();
     }
-    catch (Exception $e) {
-      return FALSE;
-    }
+
+    // Save new file.
+    file_save($file);
+
+    $file_field = dkan_datastore_file_upload_field();
+    $this->node->{$file_field} = array(LANGUAGE_NONE => array((array) $file));
+    node_save($this->node);
   }
 
   /**


### PR DESCRIPTION
## Description

This fixes a couple of bugs with running the datastore via cron.

The ``dkan_datastore_queue_import_worker()`` was calling a method ``updateByFile()`` that copied the file attached to the resource even if it already existed. The method was also being passed the ``$url`` instead of the ``$uri`` which meant that once cron was run the actual file was replaced with a URL.

I broke up the ``updateByFile()`` method to ``updateByFileURI()``, ``updateFile()``, and ``updateByCLI()``.

``dkan_datastore_queue_import_worker()`` now just calls ``updateByCLI()`` since the cron job has no reason to care about the file being attached. If files need to be attached then they can use the ``updateFile()` or ``updateByFileURI()`` methods. 

## How to reproduce

1. Tests wouldn't pass on DKAN Starter or locally. 
2. Running ``dkan_datastore_queue_import_worker()`` with a resource uuid and fid locally erases the file on a resource and replaces it with a URL:

<img width="656" alt="screen shot 2016-12-06 at 3 38 27 pm" src="https://cloud.githubusercontent.com/assets/512243/20983837/f7b4ea9c-bc8b-11e6-8732-a5714a2c8067.png">

## Acceptance Criteria

- [x] Tests pass
- [x] ~~Either write tests for or remove ``updateByFile()`` and ``updateByFileURI()`` methods~~ Create separate ticket for datastore class tests 
