### PR TITLE
Fix hidden page body field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
 - Fixed link to group page on group node teaser when site has clean urls disabled
 - Fix "format" facet collapsed even when selected on the search page.
 - Update media to 2.0-beta13
+- Fix hidden body field on page content type
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.features.field_instance.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.features.field_instance.inc
@@ -20,7 +20,7 @@ function dkan_sitewide_field_default_field_instances() {
       'default' => array(
         'label' => 'hidden',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'text_default',
         'weight' => 0,
       ),
       'search_result' => array(


### PR DESCRIPTION
## Description

Accidental change to page body field to hidden on the release branch causes page content to 'disappear', the page content type is not panelized until 1.13
https://github.com/NuCivic/dkan/pull/1413

## QA Tests

- [x] Check that the About page displays body content.
