### PR TITLE
Add tests for the geofiled widget

### DIFF
--- a/test/behat.yml
+++ b/test/behat.yml
@@ -76,6 +76,7 @@ default:
         dataset resource list: '#data-and-resources'
         dataset body: '.field-name-body'
         dataset edit body: '#edit-body'
+        dataset spatial: '#edit-field-spatial'
         resource title: '.pane-node .pane-title'
         resource groups: '#edit-groups'
         search_area: '.panel-col-last'

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -55,4 +55,67 @@ class FeatureContext extends RawDKANContext
       $this->getSession()->switchToWindow($windowNames[1]);
     }
   }
+
+  /**
+   * @Then the :tag element with id set to :value in the :region( region) exists
+   *
+   * This is a reword of the MarkupContext::assertRegionElementAttribute()
+   * method which only checks for the first matched tag not the matched
+   * attribute. Also added tests for element visibility.
+   */
+  public function assertRegionElementId($tag, $value, $region) {
+    $attribute = 'id';
+
+    $session = $this->getSession();
+    $regionObj = $session->getPage()->find('region', $region);
+    if (!$regionObj) {
+      throw new \Exception(sprintf('No region "%s" found on the page %s.', $region, $session->getCurrentUrl()));
+    }
+
+    $elements = $regionObj->findAll('css', $tag);
+    if (empty($elements)) {
+      throw new \Exception(sprintf('The element "%s" was not found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()));
+    }
+
+    $found_attr = FALSE;
+    // Loop threw all the matching elements.
+    foreach ($elements as $element) {
+      $attr = $element->getAttribute($attribute);
+      if (!empty($attr)) {
+        $found_attr = TRUE;
+        if (strpos($attr, "$value") !== FALSE) {
+          // Found match.
+          return $element;
+        }
+      }
+    }
+
+    if (!$found_attr) {
+      throw new \Exception(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()));
+    }
+    else {
+      throw new \Exception(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
+   * @Then the :tag element with id set to :value in the :region( region) should be visible
+   */
+  public function assertRegionElementIdVisible($tag, $value, $region) {
+    $element = $this->assertRegionElementId($tag, $value, $region);
+    if (!$element->isVisible()) {
+        throw new \Exception(sprintf('The "%s" attribute is not visible on the element "%s" in the "%s" region on the page %s', "id", $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
+   * @Then the :tag element with id set to :value in the :region( region) should not be visible
+   */
+  public function assertRegionElementIdNotVisible($tag, $value, $region) {
+    $element = $this->assertRegionElementId($tag, $value, $region);
+    if ($element->isVisible()) {
+        throw new \Exception(sprintf('The "%s" attribute is visible on the element "%s" in the "%s" region on the page %s', 'id', $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
 }

--- a/test/features/leaflet_draw_widget.feature
+++ b/test/features/leaflet_draw_widget.feature
@@ -1,0 +1,33 @@
+# time:0m11.71s
+@api @javascript
+Feature: Leaflet Map Widget
+
+  Scenario: Adds "New Table Widget" block to home page using panels ipe editor
+
+    Given "Tags" terms:
+      | name     |
+      | New Tag |
+    And datasets:
+      | title                  | author | published | tags    | description |
+      | This is a test dataset | admin  | Yes       | New Tag | Test        |
+    And I am logged in as a user with the "editor" role
+    And I visit the "This is a test dataset" page
+    And I click "Edit"
+    Then I should see "Spatial / Geographical Coverage Area"
+    And I should see the link "Map" in the "dataset spatial" region
+    And I should see the link "GeoJSON" in the "dataset spatial" region
+    And I should see the link "Points" in the "dataset spatial" region
+    # Default Map element
+    Then the "div" element with id set to "leaflet-widget_field-spatial" in the "dataset spatial" region should be visible
+    And the "textarea" element with id set to "leaflet-widget_field-spatial-geojson-textarea" in the "dataset spatial" region should not be visible
+    And the "input" element with id set to "leaflet-widget_field-spatial-points-input" in the "dataset spatial" region should not be visible
+    # GeoJSON tab
+    When I click "GeoJSON" in the "dataset spatial" region
+    Then I should see "Enter GeoJSON" in the "dataset spatial" region
+    And the "textarea" element with id set to "leaflet-widget_field-spatial-geojson-textarea" in the "dataset spatial" region should be visible
+    And the "div" element with id set to "leaflet-widget_field-spatial" in the "dataset spatial" region should not be visible
+    # Points tab
+    When I click "Points" in the "dataset spatial" region
+    Then the "div" element with id set to "leaflet-widget_field-spatial" in the "dataset spatial" region should be visible
+    And the "input" element with id set to "leaflet-widget_field-spatial-points-input" in the "dataset spatial" region should be visible
+    And I should see the link "Add Points" in the "dataset spatial" region


### PR DESCRIPTION
Issue: CIVIC-4774

## Description

Improvement for the Geofield widget.
This PR include only added/altered behat tests. The main [PR](https://github.com/NuCivic/leaflet_draw_widget/pull/10) is listed on the PR dependecies. 

## QA Tests

1. Go to the dataset edit page.
2. Use the "Point", "GeoJson", and "Use map" button to switch the Geofield input fields.

This will lead to an extra unremovable text field to appear. Multiple buttons with the same label, and multiple input field to show up at the same time not reaspecting the exclusivity.

Using the PR on the leaflet_draw_widget should provide improved UI.

## PR dependencies

- [https://github.com/NuCivic/leaflet_draw_widget/pull/10

