### PR TITLE
Fix location warning when creating a remote resource

### DIFF
--- a/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
+++ b/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
@@ -207,8 +207,8 @@ class GetRemoteFileInfo {
     if ($info = $this->getInfo()) {
       // Check Location for proper URL.
       // When URL have redirects the ['header']['Location'] will be an array.
-      $location = $info['header']['Location'];
-      if (is_array($location)) {
+      if (isset($info['header']['Location']) && is_array($info['header']['Location'])) {
+        $location = $info['header']['Location'];
         $location = array_shift($location);
       }
 


### PR DESCRIPTION
## Description
When we create a resource using a remote file we are getting:

```
Notice: Undefined index: Location in /Users/aaron/docker-share/dkan/dkan/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php on line 210
string(59) "Hospital_Inpatient_Discharges_by_DRG__Northwest__FY2011.csv"
```

## QA Steps
- [ ] Create a resource using a remote file http://s3.amazonaws.com/dkan-default-content-files/files/Polling_Places_Madison_0.csv (don't press select)
- [ ] Save
- [ ] No errors should be displayed