### PR TITLE
Fix undefined index error on drupal_find_base_themes

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -273,7 +273,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      branch: CIVIC-5053
   ref_field:
     download:
       type: git


### PR DESCRIPTION
Issue: CIVIC-5053

## Description

When building dkan, you will get this error message in the output after running `ahoy dkan reinstall`

 `Undefined index: base theme in drupal_find_base_themes() (line 844 of /var/www/docroot/includes/theme.inc).  `


## How to reproduce

1.  Check the terminal output when building drupal

## QA Tests

- [x] The error above is not present when building a dkan site.

## PR dependencies

- [x] https://github.com/NuCivic/recline/pull/77

