### PR TITLE
Exclude the weight selector from using the chosen widget CIVIC-4732

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.node-form  select, .field-name-field-format select, .field-name-field-dataset-ref select';
+  $strongarm->value = '.node-form select, .field-name-field-format select, .field-name-field-dataset-ref select, not([name*=\'field_resources\']) select';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Issue: CIVIC-4732

## Description

The 508 issues of fields that use the draggable handles (additional info, related content, etc) was "addressed" by drupal core maintainers by adding the 'show row weights' link, however, the selectors that appear once you do this are using the chosen widget which is not compliant so we need to exclude these selectors.
*Drupal Conversation on the topic*: https://www.drupal.org/node/448292?page=1#comment-3110726

> It looks like we've reached a compromise between the accessibility and usability teams. This patch results in no visual changes, but makes it possible for blind users to access the old 'weight' fields we know and love from Drupal 5 and previous by clicking a link that becomes visible on hover (same method as "Skip to navigation" links).

## How to reproduce

Visit a dataset edit form and turn on the WAVE extension. View the Resources field.

## QA Tests

1. Visit a dataset edit form. 
2. View the Resources field, click the 'show row weights' link
3. Confirm that the weight select inputs are not using the chosen widget

## PR dependencies
This PR fixes the missing label problems on the resources field and other 508 issues on the form.
https://github.com/NuCivic/dkan/pull/1602

