### PR TITLE
[CIVIC-5112] Extension detection mismatch lead to error during Harvest

### DIFF
--- a/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
+++ b/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * @file
- * Class to get content type and name of remote file.
- *
- * Socrata shim copied from data.gov.
- */
-
 namespace dkanDataset;
 
 /**
@@ -15,12 +8,24 @@ namespace dkanDataset;
 class GetRemoteFileInfo {
 
   /**
+   * CURL header info of the remote URL.
+   *
+   * @var info
+   */
+  public $info = FALSE;
+  public $url;
+  public $agent;
+  public $followRedirect;
+
+  /**
    * Class constructor.
    */
   public function __construct($url, $agent, $followRedirect = TRUE) {
     $this->url = $url;
     $this->agent = $agent;
     $this->followRedirect = $followRedirect;
+
+    $this->info = $this->curlHeader($this->url, $this->agent, $this->followRedirect);
   }
 
   /**
@@ -82,8 +87,8 @@ class GetRemoteFileInfo {
     curl_setopt($ch, CURLOPT_COOKIE, "");
 
     // Include the header in the output.
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE );
-    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET' );
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
     curl_setopt($ch, CURLOPT_HEADER, TRUE);
 
     return $ch;
@@ -93,9 +98,6 @@ class GetRemoteFileInfo {
    * Gets header info for requested file.
    */
   public function getInfo() {
-    if (!isset($this->info)) {
-      $this->info = $this->curlHeader($this->url, $this->agent, $this->followRedirect);
-    }
     return $this->info;
   }
 

--- a/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
+++ b/modules/dkan/dkan_dataset/includes/getRemoteFileInfo.php
@@ -123,29 +123,50 @@ class GetRemoteFileInfo {
   }
 
   /**
-   * Return a canonical file extension from the file type.
+   * Return a canonical file extension.
+   *
+   * Try to use the mimetype to return the best possible correct extension. Use
+   * the parsed extension from the URL as backup.
+   *
+   * @return extension
+   *   Content extension.
    */
   public function getExtension() {
-    $extension = NULL;
+    // Parse the extension from the URL.
+    $path = parse_url($this->getEffectiveUrl(), PHP_URL_PATH);
+    $extension_parsed = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
-    if (!is_null($this->getType())) {
-      include_once DRUPAL_ROOT . '/includes/file.mimetypes.inc';
-      $mimetype_mappings = file_mimetype_mapping();
-      $mimetypes = $mimetype_mappings['mimetypes'];
-      $extension_key = array_search($this->getType(), $mimetypes);
-      if ($extension_key !== FALSE) {
-        // "canonical" file extension found!
-        $extensions = $mimetype_mappings['extensions'];
-        $extension = array_search($extension_key, $extensions);
-      }
-      else {
-        // No "canonical" extension found. Try to parse the url.
-        $path = parse_url($this->getEffectiveUrl(), PHP_URL_PATH);
-        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-      }
+    if (is_null($this->getType())) {
+      return $extension_parsed;
     }
 
-    return $extension;
+    // Use drupal file mimetypes store.
+    include_once DRUPAL_ROOT . '/includes/file.mimetypes.inc';
+    $mimetype_mappings = file_mimetype_mapping();
+    $mimetype_keys = array_keys($mimetype_mappings['mimetypes'], $this->getType());
+
+    // If the destination mimetype in unknown to us then default to the
+    // extension as parsed from the url.
+    if (empty($mimetype_keys)) {
+      return $extension_parsed;
+    }
+
+    // Get the candidate extensions from the mimetype_keys.
+    $extensions_lookup = array();
+    foreach ($mimetype_keys as $mimetype_key) {
+      $extensions_lookup = array_merge($extensions_lookup,
+        array_keys($mimetype_mappings['extensions'], $mimetype_key));
+    }
+
+    // If we couldn't find any potential candidates or the extension from the
+    // url matches one of the candidate extensions then use it.
+    if (empty($extensions_lookup) || in_array($extension_parsed, $extensions_lookup)) {
+      return $extension_parsed;
+    }
+
+    // At this point we may have multiple candidate extensions and we couldn't
+    // find the best one. Default to the first element.
+    return array_pop($extensions_lookup);
   }
 
   /**

--- a/test/phpunit/dkan_dataset/getRemoteFileInfoTest.php
+++ b/test/phpunit/dkan_dataset/getRemoteFileInfoTest.php
@@ -54,7 +54,7 @@ Age: 5730';
    * extension.
    */
   public function testUrlExtension() {
-    $url = "http://opendata.comune.bari.it/dataset/a66a3b73-5a39-42b6-84ac-7c8260f3f6d1/resource/c397042b-f530-46f6-8987-210b3a215ff4/download/20121212t163303albo.xls";
+    $url = "https://s3.amazonaws.com/dkan-default-content-files/files/albo.xls";
     $fileInfo = new getRemoteFileInfo($url, 'test', TRUE);
     $this->assertEquals($fileInfo->getType(), 'application/vnd.ms-excel');
     $this->assertEquals($fileInfo->getExtension(), 'xls');

--- a/test/phpunit/dkan_dataset/getRemoteFileInfoTest.php
+++ b/test/phpunit/dkan_dataset/getRemoteFileInfoTest.php
@@ -46,4 +46,18 @@ Age: 5730';
     $this->assertEquals($fileInfo->getName(), 'Hospital_Inpatient_Discharges_by_DRG__Northwest__FY2011.csv');
   }
 
+  /**
+   * Test URL extension.
+   *
+   * Mimetype can have multiple extensions associated to it. This test make sure
+   * that the returned extension matches both the Mimetype and the actual file
+   * extension.
+   */
+  public function testUrlExtension() {
+    $url = "http://opendata.comune.bari.it/dataset/a66a3b73-5a39-42b6-84ac-7c8260f3f6d1/resource/c397042b-f530-46f6-8987-210b3a215ff4/download/20121212t163303albo.xls";
+    $fileInfo = new getRemoteFileInfo($url, 'test', TRUE);
+    $this->assertEquals($fileInfo->getType(), 'application/vnd.ms-excel');
+    $this->assertEquals($fileInfo->getExtension(), 'xls');
+  }
+
 }


### PR DESCRIPTION
Issue: CIVIC-5112

## Description
This was reported by @marciuz afteris facing issue when harvesting xls resources with `application/vnd.ms-excel` mimetype with the following error:

{code:none}
Resource remote url ([Redacted])   [error]
extension (xlb) not allowed
{code}

The remote file mimetype is {{application/vnd.ms-excel}}, which can have mulitple extensions pre the default Drupal mimetype library {{xlb}}, {{xlt}}, and {{xls}}. Faced with this choice the Harvest will return the first extension {{xlb}} as the detected extension which is not part of the allowed extension list and will generate the error.

## Steps to Reproduce
1. Using a data.json, set a resource url to xls file with 
2. Harvest the source.

*Expected*: The harvest should pass with no error. The harvested dataset should have a resource with the {{testdoc.xls}} remote file showed as an exel file. 
*Actual*: Same error is returned after the harvest. No resource with exel file.

## Acceptance Criteria
1. When detecting the remote file extension and faced with multiple possibilities. Use the extension from the URL as a tie breaker. 

h2. Test Updates
1. Add a test for the GetRemoteFileInfo class with {{application/vnd.ms-excel}} file.

## Changelog
N/A