### PR TITLE
Add test for using too many resource types CIVIC-3687

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.12.x
 ----------
+- Fix validation on resource forms when multiple resource type fields are populated
 - Start caching recline "embed" pages (previews rendered with no headers/sidebars for iframe) (recline module)
 - Upgrade Drupal core to 7.52
 - Update ctools to 1.11

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@
 api: '2'
 core: 7.x
 includes:
-- https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
+- https://raw.githubusercontent.com/NuCivic/dkan_dataset/CIVIC-3687/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
@@ -39,7 +39,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_dataset.git
-      branch: release-1-12
+      branch: CIVIC-3687
   dkan_datastore:
     subdir: dkan
     download:
@@ -161,7 +161,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch: CIVIC-3687
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@
 api: '2'
 core: 7.x
 includes:
-- https://raw.githubusercontent.com/NuCivic/dkan_dataset/CIVIC-3687/dkan_dataset.make
+- https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
@@ -39,7 +39,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_dataset.git
-      branch: CIVIC-3687
+      branch: release-1-12
   dkan_datastore:
     subdir: dkan
     download:
@@ -161,7 +161,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: CIVIC-3687
+      branch: release-1-12
     type: theme
   radix:
     type: theme

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -10,6 +10,8 @@ use Drupal\DKANExtension\ServiceContainer\EntityStore;
 use Drupal\DKANExtension\ServiceContainer\PageStore;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 use EntityFieldQuery;
 
 /**

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -67,6 +67,21 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
   }
 
   /**
+   * @BeforeSuite
+   */
+  public static function disableAdminMenuCache(BeforeSuiteScope $scope) {
+    // Turn off cache so the menu lives in the html.
+    variable_set('admin_menu_cache_client', FALSE);
+  }
+
+  /**
+   * @AfterSuite
+   */
+  public static function enableAdminMenuCache(AfterSuiteScope $scope) {
+    variable_set('admin_menu_cache_client', TRUE);
+  }
+
+  /**
    * @BeforeScenario
    */
   public function gatherContexts(BeforeScenarioScope $scope) {

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -60,7 +60,8 @@ Feature: Resource
     Given I am logged in as "Katie"
     And I am on the "Content" page
     And I click "Resource"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+
     When I fill in "Title" with "Resource 06"
     And I press "Save"
     Then I should see "Resource Resource 06 has been created"
@@ -71,7 +72,7 @@ Feature: Resource
     And I am on the "Content" page
     And I click "Resource"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I click "API or Website URL"
     And I fill in "edit-field-link-api-und-0-url" with "http://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2014-01-01&endtime=2014-01-02"
     When I fill in "Title" with "Resource 06"
@@ -233,7 +234,7 @@ Feature: Resource
     And I am on "Resource 05" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
     And I press "Save"
     And I am on "Resource 05" page
     When I click "Manage Datastore"
@@ -243,12 +244,12 @@ Feature: Resource
     And I should see "imported items total"
 
   @noworkflow @javascript
-  Scenario: DEBUG
+  Scenario: Delete items on datastore of own resource
     Given I am logged in as "John"
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page
@@ -268,7 +269,7 @@ Feature: Resource
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -61,9 +61,24 @@ Feature: Resource
     And I am on the "Content" page
     And I click "Resource"
     And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+
     When I fill in "Title" with "Resource 06"
     And I press "Save"
     Then I should see "Resource Resource 06 has been created"
+
+  @noworkflow @javascript
+  Scenario: Create resource with too many sources. 
+    Given I am logged in as "Katie"
+    And I am on the "Content" page
+    And I click "Resource"
+    And I click "Remote file"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I click "API or Website URL"
+    And I fill in "edit-field-link-api-und-0-url" with "http://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2014-01-01&endtime=2014-01-02"
+    When I fill in "Title" with "Resource 06"
+    And I press "Save"
+    Then I should see "Remote file is populated - only one resource type can be used at a time"
+    And I should see "API or Website URL is populated - only one resource type can be used at a time"
 
   @noworkflow
   #TODO: Content creator will be a role added later, but for now we stick with authenticated user

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -60,19 +60,18 @@ Feature: Resource
     Given I am logged in as "Katie"
     And I am on the "Content" page
     And I click "Resource"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
-
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     When I fill in "Title" with "Resource 06"
     And I press "Save"
     Then I should see "Resource Resource 06 has been created"
 
   @noworkflow @javascript
-  Scenario: Create resource with too many sources. 
+  Scenario: Create resource with too many sources.
     Given I am logged in as "Katie"
     And I am on the "Content" page
     And I click "Resource"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I click "API or Website URL"
     And I fill in "edit-field-link-api-und-0-url" with "http://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2014-01-01&endtime=2014-01-02"
     When I fill in "Title" with "Resource 06"
@@ -234,7 +233,7 @@ Feature: Resource
     And I am on "Resource 05" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     And I am on "Resource 05" page
     When I click "Manage Datastore"
@@ -244,12 +243,12 @@ Feature: Resource
     And I should see "imported items total"
 
   @noworkflow @javascript
-  Scenario: Delete items on datastore of own resource
+  Scenario: DEBUG
     Given I am logged in as "John"
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page
@@ -269,7 +268,7 @@ Feature: Resource
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-remotefile-url" with "http://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page


### PR DESCRIPTION
Issue: CIVIC-3687

## Description

Currently validation is not complete on the resource file fields. 

## QA Tests
1.  Add a new resource: `node/add/resource`
2. Fill in both the **Remote file** and the **API or Website URL** fields
3. Enter a title
4. Save - confirm you see errors about adding more than one resource type 

## PR dependencies

- [x] https://github.com/NuCivic/dkan_dataset/pull/293
- [x] https://github.com/NuCivic/nuboot_radix/pull/102
- [x] update drupal-org.make
