### PR TITLE
Revert menu links for workbench after enabling DKAN workflow

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Add install hook to DKAN Workflow to force a Features revert of dkan_sitewide_menu, to make sure Workflow links added correctly
  - Remove Panels IPE from dataset and search pages; in DKAN, we only want to show IPE for panelizer layouts, not templates or other "sitewide" pages.
  - Update user profile page search to be consistant with the rest of the site and moves user info to sidebar block.
  - Fixes typo in "add data story" link in command center menu

--- a/modules/dkan/dkan_workflow/dkan_workflow.install
+++ b/modules/dkan/dkan_workflow/dkan_workflow.install
@@ -39,4 +39,7 @@ function dkan_workflow_enable() {
   dkan_workflow_revert_views();
 
   variable_set('dkan_workflow_content_types', $dkan_workflow_content_types);
+
+  //Revert dkan sitewide menu to add links to command center.
+  features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 }


### PR DESCRIPTION
Issue: CIVIC-5111

## Description

After enable dkan workflow we have missing menu links to workbench. 



## How to reproduce

1.  Enable dkan workflow. And then you can't see any link on the top.

## QA Tests

- [ ] Enable dkan workflow and you can see menu links on the top.

