### PR TITLE
Fix publisher token so data.json displays group title CIVIC-5125

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Fix publisher token in open_data_schema_map_dkan
  - Remove Panels IPE from dataset and search pages; in DKAN, we only want to show IPE for panelizer layouts, not templates or other "sitewide" pages.
  - Update user profile page search to be consistant with the rest of the site and moves user info to sidebar block.
  - Fixes typo in "add data story" link in command center menu

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_dashboard/views/handlers/views_handler_field_boolean_harvest_status.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_dashboard/views/handlers/views_handler_field_boolean_harvest_status.inc
@@ -130,6 +130,7 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
 
     $harvest_source_migration = dkan_harvest_get_migration($harvest_source);
     $messageTable = $harvest_source_migration->getMap()->getMessageTable();
+    $logTable = $harvest_source_migration->getMap()->getLogTable();
 
     // Let's see if we got errors during the last migration.
     $query_message_table = db_query("SELECT COUNT(*) FROM " . $messageTable . " WHERE mlid = :mlid AND level = :error_level",
@@ -139,6 +140,13 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
       ));
     $result_message_table = $query_message_table->fetchAssoc();
 
+    // Let's see if we didn't get errors during the last migration but failed.
+    $query_log_table = db_query("SELECT failed FROM " . $logTable . " WHERE mlid = :mlid",
+      array(
+        ':mlid' => $mlid,
+      ));
+    $result_log_table = $query_log_table->fetchField();
+
     if (empty($result_message_table)) {
       // i'm confused. This should no happen.
       watchdog('dkan_harvest_dashboard', "Result for error message not found.", array(), WATCHDOG_ERROR);
@@ -146,7 +154,7 @@ class views_handler_field_boolean_harvest_status extends views_handler_field_boo
     }
 
     $errors_count = array_pop($result_message_table);
-    return $errors_count > 0 ? TRUE : FALSE;
+    return (($errors_count > 0) || $result_log_table) ? TRUE : FALSE;
   }
 
   /**

--- a/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
+++ b/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
@@ -1374,7 +1374,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'publisher' => array(
-        'value' => '[node:og_group_ref:0]',
+        'value' => '[node:og_group_ref]',
         'type' => 'string',
       ),
       'references' => array(
@@ -1552,7 +1552,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
           'type' => '',
         ),
         'name' => array(
-          'value' => '[node:og_group_ref:0]',
+          'value' => '[node:og_group_ref]',
           'type' => '',
         ),
         'subOrganizationOf' => array(


### PR DESCRIPTION
Issue: CIVIC-5125

## Description

data.json displays $base_url (default when no group present) rather than the publisher name due to a bad token.
See: https://github.com/NuCivic/open_data_schema_map_dkan/pull/18
Not sure why we needed to limit to a single publisher but if so then we may need to create a custom token...?

## How to reproduce

1. view http://demo.getdkan.com/data.json
2. notice the datasets that do have groups still display default publisher values >> `publisher":{"@type":"org:Organization","name":"demo.getdkan.com"}`

## QA Tests

- [x] View data.json of the QA site, confirm that the publisher data is correct

## Release PR
Same fix on the original repo for fixing 7.x-1.12.x sites
https://github.com/NuCivic/open_data_schema_map_dkan/pull/24