### PR TITLE
Chart preview doesn't work with anothers delimiters for CSV

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -115,6 +115,7 @@ DKAN Dataset:
  - Removed warning when a resource is created without title.
  - Add limit to proxy resources.
  - Improved download of remote files.
+ - Fixes to chart preview with csv and selecting another delimiter
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -115,7 +115,6 @@ DKAN Dataset:
  - Removed warning when a resource is created without title.
  - Add limit to proxy resources.
  - Improved download of remote files.
- - Fixes to chart preview with csv and selecting another delimiter
 
 7.x-1.12.11 2016-10-20
 --------------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,7 +4,7 @@ includes:
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta2/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
-  - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
+  - "https://raw.githubusercontent.com/NuCivic/recline/bug_delimiters_settings_with_csv_doesnt_work_civic_5058/recline.make"
 projects:
   admin_menu:
     version: '3.0-rc5'
@@ -276,7 +276,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      branch: bug_delimiters_settings_with_csv_doesnt_work_civic_5058
   ref_field:
     download:
       type: git


### PR DESCRIPTION
…58 recline with the fix for chart preview #CIVIC-5058

Issue: https://jira.govdelivery.com/browse/CIVIC-5058

## Description

If we use another delimiter in resource creating the preview fail and doesn't use the delimiter. 



## How to reproduce

1.  Create a resource with a csv with delimiter +
2. Select + delimiter
3. Save resource and is failing the preview

## QA Tests

- [x] Create a resource with csv with delimiter +, |, ... is when you save the preview is fine.

## PR dependencies

- [x] https://github.com/NuCivic/recline/pull/80
