### PR TITLE
[CIVIC-5160] Support 'limit' migration option in HarvestMigration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,6 +81,7 @@ DKAN Harvest:
  - Fixed harvesting of resources with remote files with redirects.
  - Fix "Manage Datastore" tab leaking to the harvest source node.
  - Add icons for harvest source tabs.
+ - Added support for --limit, --instruments, --skiphash and --idlist options on drush commands.
 DKAN Migrate Base:
  - Added DKAN Migrate Base module into DKAN Core.
  - Removed row from migration map table when a dataset is deleted.

--- a/modules/dkan/dkan_harvest/README.md
+++ b/modules/dkan/dkan_harvest/README.md
@@ -297,7 +297,7 @@ public function __construct($arguments) {
   $this->itemUrl = drupal_realpath($this->dkanHarvestSource->getCacheDir()) .
     '/:id';
 
-  $this->source = new MigrateSourceList(
+  $this->source = new HarvestMigrateSourceList(
     new HarvestList($this->dkanHarvestSource->getCacheDir()),
     new MigrateItemJSON($this->itemUrl),
     array(),

--- a/modules/dkan/dkan_harvest/dkan_harvest.drush.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.drush.inc
@@ -22,6 +22,7 @@ function dkan_harvest_drush_command() {
       'skiphash' => 'Skip hash checking and update all the datasets available in the source.',
       'limit' => 'Limit on the length of each migration. Check migrate doc for more about this option.',
       'instrument' => 'Capture performance information (timer, memory, or all). Check migrate doc for more about this option.',
+      'idlist' => 'A comma delimited list of ids to import or rollback. Check migrate doc for more about this option.',
     ),
     'drupal dependencies' => array('dkan_harvest'),
   );
@@ -50,6 +51,7 @@ function dkan_harvest_drush_command() {
       'skiphash' => 'Skip hash checking and update all the datasets available in the source.',
       'limit' => 'Limit on the length of each migration. Check migrate doc for more about this option.',
       'instrument' => 'Capture performance information (timer, memory, or all). Check migrate doc for more about this option.',
+      'idlist' => 'A comma delimited list of ids to import or rollback. Check migrate doc for more about this option.',
     ),
     'drupal dependencies' => array('dkan_harvest'),
   );
@@ -61,6 +63,11 @@ function dkan_harvest_drush_command() {
     'callback' => 'dkan_harvest_drush_command_rollback',
     'arguments' => array(
       'source_machine_name' => 'The source machine name to run the harvest migration on. If not provided run the harvest ',
+    ),
+    'options' => array(
+      'limit' => 'Limit on the length of each migration. Check migrate doc for more about this option.',
+      'instrument' => 'Capture performance information (timer, memory, or all). Check migrate doc for more about this option.',
+      'idlist' => 'A comma delimited list of ids to import or rollback. Check migrate doc for more about this option.',
     ),
     'drupal dependencies' => array('dkan_harvest'),
   );
@@ -132,7 +139,7 @@ function dkan_harvest_drush_command_cache($source_machine_name) {
  *        Source machine name to migrate.
  */
 function dkan_harvest_drush_command_migrate($source_machine_name) {
-  $supported_options = array('limit', 'skiphash', 'instrument');
+  $supported_options = array('limit', 'skiphash', 'instrument', 'idlist');
   $options = array();
 
   // Gather harvest migration options. If parsing the arguments fails just relay
@@ -179,7 +186,7 @@ function dkan_harvest_drush_command_migrate($source_machine_name) {
  */
 function dkan_harvest_drush_command_rollback($source_machine_name) {
   $options = array();
-  $supported_options = array('limit', 'instrument');
+  $supported_options = array('limit', 'instrument', 'idlist');
 
   // Gather harvest migration options. If parsing the arguments fails just relay
   // on the parsing callback to oouput an appropriate message and stop.
@@ -343,6 +350,18 @@ function dkan_harvest_get_option_instrument($options) {
  */
 function dkan_harvest_get_option_skiphash($options) {
   $options['skiphash'] = drush_get_option('skiphash', FALSE);
+  return $options;
+}
+
+/**
+ * Helper function to parse the 'idlist' option.
+ *
+ * This is taken from migrate.drush.inc.
+ */
+function dkan_harvest_get_option_idlist($options) {
+  if ($idlist = drush_get_option('idlist', FALSE)) {
+    $options['idlist'] = $idlist;
+  }
   return $options;
 }
 

--- a/modules/dkan/dkan_harvest/dkan_harvest.drush.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.drush.inc
@@ -19,7 +19,9 @@ function dkan_harvest_drush_command() {
       'The source machine name to run the harvest caching on',
     ),
     'options' => array(
-      'skip-hash' => 'Skip hash checking and update all the datasets available in the source.',
+      'skiphash' => 'Skip hash checking and update all the datasets available in the source.',
+      'limit' => 'Limit on the length of each migration. Check migrate doc for more about this option.',
+      'instrument' => 'Capture performance information (timer, memory, or all). Check migrate doc for more about this option.',
     ),
     'drupal dependencies' => array('dkan_harvest'),
   );
@@ -45,7 +47,9 @@ function dkan_harvest_drush_command() {
       'source_machine_name' => 'The source machine name to run the harvest migration on. If not provided run the harvest ',
     ),
     'options' => array(
-      'skip-hash' => 'Skip hash checking and update all the datasets available in the source.',
+      'skiphash' => 'Skip hash checking and update all the datasets available in the source.',
+      'limit' => 'Limit on the length of each migration. Check migrate doc for more about this option.',
+      'instrument' => 'Capture performance information (timer, memory, or all). Check migrate doc for more about this option.',
     ),
     'drupal dependencies' => array('dkan_harvest'),
   );
@@ -128,25 +132,42 @@ function dkan_harvest_drush_command_cache($source_machine_name) {
  *        Source machine name to migrate.
  */
 function dkan_harvest_drush_command_migrate($source_machine_name) {
-  // Gather harvest migration options.
-  $options = array(
-    // TODO add supported default migrate import options.
-    'dkan_harvest_skip_hash' => drush_get_option('skip-hash', FALSE),
-  );
+  $supported_options = array('limit', 'skiphash', 'instrument');
+  $options = array();
 
+  // Gather harvest migration options. If parsing the arguments fails just relay
+  // on the parsing callback to oouput an appropriate message and stop.
+  $option_parsed = dkan_harvest_get_options($options, $supported_options);
+  if (!$option_parsed) {
+    return;
+  }
+
+  $sources = array();
   if (isset($source_machine_name)) {
-    if ($source = new HarvestSource($source_machine_name)) {
-      drush_log("Running the harvest migration on " . $source_machine_name, 'notice');
-      dkan_harvest_migrate_sources(array($source), $options);
+    $source = dkan_harvest_get_harvestsource($source_machine_name);
+
+    if (!$source) {
+      return FALSE;
     }
-    else {
-      drush_log("No source with machine name " . $source_machine_name . " found.", 'error');
-    }
+
+    drush_log("Running the harvest migration on " . $source_machine_name, 'notice');
+    $sources[] = $source;
   }
   else {
     drush_log("Running the harvest migration on all the available sources.", 'notice');
     $sources = dkan_harvest_sources_definition();
-    dkan_harvest_migrate_sources($sources);
+  }
+
+  dkan_harvest_migrate_sources($sources, $options);
+
+  // Print instrument info if set.
+  global $_migrate_track_memory, $_migrate_track_timer;
+  if ($_migrate_track_memory) {
+    drush_migrate_print_memory();
+  }
+
+  if ($_migrate_track_timer && !drush_get_context('DRUSH_DEBUG')) {
+    drush_print_timers();
   }
 }
 
@@ -157,34 +178,37 @@ function dkan_harvest_drush_command_migrate($source_machine_name) {
  *        Source machine name to migrate.
  */
 function dkan_harvest_drush_command_rollback($source_machine_name) {
+  $options = array();
+  $supported_options = array('limit', 'instrument');
 
-  // Gather harvest migration options.
-  $options = array(
-    // TODO add supported default migrate import options.
-  );
+  // Gather harvest migration options. If parsing the arguments fails just relay
+  // on the parsing callback to oouput an appropriate message and stop.
+  $option_parsed = dkan_harvest_get_options($options, $supported_options);
+  if (!$option_parsed) {
+    return;
+  }
+
+  $sources = array();
 
   if (!isset($source_machine_name)) {
-    $message = t("No source to rollback.");
-    drush_log($message, 'error');
-    return FALSE;
+    return drush_set_error(
+      dt("No source machine_name provided.")
+    );
+  }
+  else {
+    $source = dkan_harvest_get_harvestsource($source_machine_name);
+
+    if (!$source) {
+      return FALSE;
+    }
+
+    $message = t("Running the harvest rollback on %source_machine_name",
+      array('%source_machine_name' => $source_machine_name));
+    drush_log($message, 'notice');
+    $sources[] = $source;
   }
 
-  $source = new HarvestSource($source_machine_name);
-  if (!$source) {
-    $message = t("No source with machine name %source_machine_name found.",
-      array(
-        '%source_machine_name' => $source_machine_name,
-      ));
-    drush_log($message, 'error');
-    return FALSE;
-  }
-
-  $message = t("Running the harvest migration on %source_machine_name",
-    array(
-      '%source_machine_name' => $source_machine_name,
-    ));
-  drush_log($message, 'notice');
-  dkan_harvest_rollback_sources(array($source), $options);
+  dkan_harvest_rollback_sources($sources, $options);
 }
 
 /**
@@ -202,6 +226,7 @@ function dkan_harvest_drush_command_status() {
     'type' => 'Type',
   );
 
+  // Build table array.
   foreach ($harvest_sources as $harvest_source) {
     $rows[] = array(
       'machine name' => $harvest_source->machineName,
@@ -221,11 +246,16 @@ function dkan_harvest_drush_command_status() {
  *        Source machine name to migrate.
  */
 function dkan_harvest_drush_command_deregister($source_machine_name) {
-
   // Gather harvest migration options.
-  $options = array(
-    // TODO add supported default migrate import options.
-  );
+  $options = array();
+  $supported_options = array();
+
+  // Gather harvest migration options. If parsing the arguments fails just relay
+  // on the parsing callback to oouput an appropriate message and stop.
+  $option_parsed = dkan_harvest_get_options($options, $supported_options);
+  if (!$option_parsed) {
+    return;
+  }
 
   if (!isset($source_machine_name)) {
     $message = t("No source to deregister");
@@ -241,4 +271,97 @@ function dkan_harvest_drush_command_deregister($source_machine_name) {
   }
 
   dkan_harvest_deregister_sources(array($harvest_source), $options);
+}
+
+/**
+ * Wrapper for options parsing callbacks.
+ */
+function dkan_harvest_get_options(&$options, $lookup = array()) {
+  foreach ($lookup as $option) {
+    $options = call_user_func('dkan_harvest_get_option_' . $option, $options);
+    if ($options === FALSE) {
+      // Some argument parsing failed. escalate.
+      return drush_set_error(NULL, dt('unsupported or invalid use of the !option option.',
+      array('!option' => $option)));
+    }
+  }
+  return TRUE;
+}
+
+/**
+ * Helper function to parse the 'limit' option.
+ *
+ * This is taken from migrate.drush.inc.
+ */
+function dkan_harvest_get_option_limit($options) {
+  $limit = drush_get_option('limit');
+  if ($limit) {
+    $parts = explode(' ', $limit);
+    $options['limit']['value'] = $parts[0];
+    // Default unit.
+    if (!isset($parts[1])) {
+      $parts[1] = 'items';
+    }
+    $options['limit']['unit'] = $parts[1];
+    // Validation.
+    if (!in_array($options['limit']['unit'],
+      array('seconds', 'second', 'items', 'item'))) {
+      return drush_set_error(NULL, dt("Invalid limit unit '!unit'",
+      array('!unit' => $options['limit']['unit'])));
+    }
+  }
+  return $options;
+}
+
+/**
+ * Helper function to parse the 'instrument' option.
+ *
+ * This is taken from migrate.drush.inc.
+ */
+function dkan_harvest_get_option_instrument($options) {
+  $instrument = drush_get_option('instrument');
+  global $_migrate_track_memory, $_migrate_track_timer;
+  switch ($instrument) {
+    case 'timer':
+      $_migrate_track_timer = TRUE;
+      break;
+
+    case 'memory':
+      $_migrate_track_memory = TRUE;
+      break;
+
+    case 'all':
+      $_migrate_track_timer = TRUE;
+      $_migrate_track_memory = TRUE;
+      break;
+  }
+  return $options;
+}
+
+/**
+ * Helper function to parse the 'skiphash' option.
+ */
+function dkan_harvest_get_option_skiphash($options) {
+  $options['skiphash'] = drush_get_option('skiphash', FALSE);
+  return $options;
+}
+
+/**
+ * Return the HarvestSource from machine name.
+ */
+function dkan_harvest_get_harvestsource($source_machine_name) {
+  $source = NULL;
+
+  try {
+    $source = new HarvestSource($source_machine_name);
+  }
+  catch (Exception $exception) {
+    $message = dt("No source with machine name %source_machine_name found.",
+      array(
+        '%source_machine_name' => $source_machine_name,
+      ));
+    return drush_set_error(NULL, $message);
+  }
+
+  return $source;
 }

--- a/modules/dkan/dkan_harvest/dkan_harvest.info
+++ b/modules/dkan/dkan_harvest/dkan_harvest.info
@@ -68,3 +68,4 @@ files[] = includes/HarvestList.php
 files[] = includes/HarvestItem.php
 files[] = includes/HarvestCache.php
 files[] = includes/HarvestMigrateSQLMap.php
+files[] = includes/HarvestMigrateSourceList.php

--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -151,8 +151,7 @@ class HarvestMigration extends MigrateDKAN {
     parent::preImport();
 
     // Skip hash checking if required.
-    if (isset($this->arguments['dkan_harvest_skip_hash']) && $this->arguments['dkan_harvest_skip_hash']) {
-      // TODO add support for overridding the hash mecanisme.
+    if (isset($this->arguments['skiphash']) && $this->arguments['skiphash']) {
       $this->dkanHarvestOptSkipHash = TRUE;
       $this->map->getConnection()->update($this->map->getMapTable())
         ->fields(array('hash' => NULL))
@@ -229,6 +228,8 @@ class HarvestMigration extends MigrateDKAN {
    * Add common DkanHarvest prepare steps.
    */
   public function prepare($dataset_prepare, $row) {
+    migrate_instrument_start('HarvestMigration->prepare');
+
     // XXX copied from pod migration.
     if (isset($row->modified) && $row->modified != '') {
       $dataset_prepare->migration_changed_date = $row->modified;
@@ -239,13 +240,15 @@ class HarvestMigration extends MigrateDKAN {
     if (module_exists('dkan_dataset_metadata_source')) {
       $this->prepareMetadataSource($dataset_prepare, $row);
     }
+
+    migrate_instrument_stop('HarvestMigration->prepare');
   }
 
   /**
    * {@inheritdoc}
    */
   public function complete($dataset, $row) {
-
+    migrate_instrument_start('HarvestMigration->complete');
     // Create resources after the dataset was created.
     // If the creation of the dataset fails resources should not
     // be created. Also, we need the dataset to be created first
@@ -257,6 +260,8 @@ class HarvestMigration extends MigrateDKAN {
 
     // Save dataset.
     node_save($dataset);
+
+    migrate_instrument_stop('HarvestMigration->complete');
   }
 
   /**
@@ -527,6 +532,8 @@ class HarvestMigration extends MigrateDKAN {
   public function postImport() {
     parent::postImport();
 
+    migrate_instrument_start('HarvestMigration->postImport');
+
     // Check if sourceCount is 0.
     // Show and add an error to the message table.
     if ($this->sourceCount() == 0) {
@@ -599,6 +606,8 @@ class HarvestMigration extends MigrateDKAN {
         ));
       self::displayMessage($message, 'notice');
     }
+
+    migrate_instrument_stop('HarvestMigration->postImport');
   }
 
   /**
@@ -608,6 +617,7 @@ class HarvestMigration extends MigrateDKAN {
    * migrate operation but had the source restored.
    */
   private function postImportRestoredSource() {
+    migrate_instrument_start('HarvestMigration->postImportRestoredSource');
     // Remove HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE flag and publish
     // the datasets (and their related content) that had their source disappear
     // in a previous harvest migrate.
@@ -622,7 +632,6 @@ class HarvestMigration extends MigrateDKAN {
         // refactoring this code make sure to add the relevent checks.
         ->condition('sourceid1', $this->getIdList(), 'IN');
       $result = $query->execute();
-      migrate_instrument_stop('postImportRestoredSource-SELECTNOSOURCEPROCESSED');
 
       $rowRestoredSourceList = $result->fetchAllAssoc('destid1');
       if (!empty($rowRestoredSourceList)) {
@@ -658,12 +667,10 @@ class HarvestMigration extends MigrateDKAN {
           $dataset_emw->save();
 
           // Update the map table.
-          migrate_instrument_start('postImportRestoredSource-UPDATEPROCESSED');
           $results = $this->map->getConnection()->update($this->map->getMapTable())
             ->fields(array('needs_update' => MigrateMap::STATUS_IMPORTED))
             ->condition('destid1', $dataset_nid)
             ->execute();
-          migrate_instrument_stop('postImportRestoredSource-UPDATEPROCESSED');
 
           $message = t(
             'Dataset "@dataset_title"[@nid] and @related_count related content (Resources, ..) published.',
@@ -677,6 +684,7 @@ class HarvestMigration extends MigrateDKAN {
         }
       }
     }
+    migrate_instrument_stop('HarvestMigration->postImportRestoredSource');
   }
 
   /**
@@ -686,9 +694,9 @@ class HarvestMigration extends MigrateDKAN {
    * but were not processed in this run because the source is not available.
    */
   private function postImportMissingSource() {
+    migrate_instrument_start('HarvestMigration->postImportMissingSource');
     // Get rows NOT marked with HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE
     // and NOT part of the imported datasets imported.
-    migrate_instrument_start('postImportMissingSource-GetNotProcessed');
     $query = $this->map->getConnection()->select($this->map->getMapTable(), 'map')
       ->fields('map')
       ->condition("needs_update", HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE, '<>');
@@ -698,7 +706,6 @@ class HarvestMigration extends MigrateDKAN {
       }
     }
     $result = $query->execute();
-    migrate_instrument_stop('postImportMissingSource-GetNotProcessed');
 
     $rowNoSourceList = $result->fetchAllAssoc('destid1');
     if (!empty($rowNoSourceList)) {
@@ -742,12 +749,10 @@ class HarvestMigration extends MigrateDKAN {
         $dataset_emw->save();
 
         // Update the map table.
-        migrate_instrument_start('postImportMissingSource-UpdateNoSource');
         $results = $this->map->getConnection()->update($this->map->getMapTable())
           ->fields(array('needs_update' => HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE))
           ->condition('destid1', $nid)
           ->execute();
-        migrate_instrument_stop('postImportMissingSource-UpdateNoSource');
 
         $message = t(
           'Dataset "@dataset_title"[@nid] and @related_count related content (Resources, ..) unpublished.',
@@ -760,6 +765,7 @@ class HarvestMigration extends MigrateDKAN {
         self::displayMessage($message, 'warning');
       }
     }
+    migrate_instrument_stop('HarvestMigration->postImportMissingSource');
   }
 
   /**

--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -45,13 +45,6 @@ class HarvestMigration extends MigrateDKAN {
   protected $dkanHarvestMigrateSQLMapSourceOptions;
 
   /**
-   * Store the dataset ids processed to unpublish missing sources later.
-   *
-   * @var array
-   */
-  protected $idListImported = array();
-
-  /**
    * Extra Harvest argument.
    *
    * @var bool
@@ -227,7 +220,6 @@ class HarvestMigration extends MigrateDKAN {
    */
   public function prepareRow($row) {
     parent::prepareRow($row);
-    $this->idListImported[] = $row->dkan_harvest_object_id;
   }
 
   /**
@@ -548,7 +540,7 @@ class HarvestMigration extends MigrateDKAN {
     // current harvest they are missing from the source as well.
     // Look for those zombie dataset and clean them.
     $zombies = $this->map->lookupMapTable(HarvestMigrateSQLMap::STATUS_FAILED,
-      $this->idListImported, "NOT IN", NULL, NULL);
+      $this->getIdList(), "NOT IN", NULL, NULL);
 
     if (!empty($zombies)) {
       $zombies_sourceids = array();
@@ -621,15 +613,14 @@ class HarvestMigration extends MigrateDKAN {
     // in a previous harvest migrate.
     // Get rows marked with HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE
     // and part of the imported datasets imported.
-    if (is_array($this->idListImported) && !empty($this->idListImported)) {
-      migrate_instrument_start('postImportRestoredSource-SELECTNOSOURCEPROCESSED');
+    if (is_array($this->getIdList()) && !empty($this->getIdList())) {
       $query = $this->map->getConnection()->select($this->map->getMapTable(), 'map')
         ->fields('map')
         ->condition("needs_update", HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE)
         // This will throw an exception if $this->idListImported is empty. We
         // are doing that check before entring this code but if you are
         // refactoring this code make sure to add the relevent checks.
-        ->condition('sourceid1', $this->idListImported, 'IN');
+        ->condition('sourceid1', $this->getIdList(), 'IN');
       $result = $query->execute();
       migrate_instrument_stop('postImportRestoredSource-SELECTNOSOURCEPROCESSED');
 
@@ -701,9 +692,9 @@ class HarvestMigration extends MigrateDKAN {
     $query = $this->map->getConnection()->select($this->map->getMapTable(), 'map')
       ->fields('map')
       ->condition("needs_update", HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE, '<>');
-    if (is_array($this->idListImported) && !empty($this->idListImported)) {
+    if (is_array($this->getIdList()) && !empty($this->getIdList())) {
       foreach ($this->map->getSourceKeyMap() as $key_name) {
-        $query = $query->condition("map.$key_name", $this->idListImported, 'NOT IN');
+        $query = $query->condition("map.$key_name", $this->getIdList(), 'NOT IN');
       }
     }
     $result = $query->execute();
@@ -1193,6 +1184,13 @@ class HarvestMigration extends MigrateDKAN {
     return $this->logID;
   }
 
+  /**
+   * Return list of source items ids.
+   */
+  public function getIdList() {
+    return $this->source->getIdList();
+  }
+
 }
 
 /**
@@ -1210,7 +1208,7 @@ class XMLHarvestMigration extends HarvestMigration {
     $this->itemUrl = drupal_realpath($this->dkanHarvestSource->getCacheDir()) .
       '/:id.xml';
 
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
       new HarvestList($this->dkanHarvestSource->getCacheDir()),
       new MigrateItemXML($this->itemUrl),
       array(),

--- a/modules/dkan/dkan_harvest/includes/HarvestMigrateSQLMap.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestMigrateSQLMap.php
@@ -299,7 +299,7 @@ class HarvestMigrateSQLMap extends MigrateSQLMap {
    * More generic method to query the map table.
    */
   public function lookupMapTable($needs_update_value = HarvestMigrateSQLMap::STATUS_IMPORTED, $sourceid1_values = array(), $sourceid1_condition = "IN", $destid1_values = array(), $destid1_condition = "IN") {
-    migrate_instrument_stop('lookupMapTable');
+    migrate_instrument_start('HarvestMigrateSQLMap->lookupMapTable');
     $query = $this->connection->select($this->mapTable, 'map');
     $query->fields('map');
 
@@ -317,7 +317,7 @@ class HarvestMigrateSQLMap extends MigrateSQLMap {
 
     $result = $query->execute();
     $return = $result->fetchAllAssoc('sourceid1');
-    migrate_instrument_stop('lookupMapTable');
+    migrate_instrument_stop('HarvestMigrateSQLMap->lookupMapTable');
     return $return;
   }
 

--- a/modules/dkan/dkan_harvest/includes/HarvestMigrateSourceList.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestMigrateSourceList.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * HarvestMigrateSourceList class.
+ */
+
+/**
+ * Harvest implementation of the MigrateSourceList class.
+ *
+ * @class HarvestMigrateSourceList
+ */
+class HarvestMigrateSourceList extends MigrateSourceList {
+
+  /**
+   * Return List of IDs of the source items.
+   */
+  public function getIdList() {
+    return $this->listClass->getIdList();
+  }
+
+}

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -20,7 +20,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
     $this->itemUrl = drupal_realpath($this->dkanHarvestSource->getCacheDir()) .
       '/:id';
 
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
       new HarvestList($this->dkanHarvestSource->getCacheDir()),
       new MigrateItemJSON($this->itemUrl),
       array(),

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -620,7 +620,7 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
     // re-harvest an unchanged source we pass the 'dkan_harvest_skip_hash'
     // option.
     $options = array(
-      'dkan_harvest_skip_hash' => TRUE,
+      'skiphash' => TRUE,
     );
     dkan_harvest_cache_sources(array(self::getErrorTestSource()));
     dkan_harvest_migrate_sources(array(self::getErrorTestSource()), $options);


### PR DESCRIPTION
Issue: CIVIC-5160

## Description

This will make the Harvest Migration support the '--limit' option as provided by the base migrate class/module.
Also this improve support for the '--instruments' option to provide basic performances monitoring for the harvest cache and migrate steps.
This PR include some bug fixes for the drush commands provided by `dkan_harvest` (including '--skiphash' option).

## QA Tests
1.  Create a Harvest Source node (named Test) with data.json test endpoint.
2. Test updated `--skiphash` option:
i. Do a first harvest (either from drush or the GUI).
ii. Running the harvest from drush with the '--skiphash' option should disable source diff check and re-harvest and update every dataset previously harvested.
3. Test added `--limit` option:
i. Running a harvest from drush should only harvest the number of datasets passed in the '--limit' option.
```
$ ahoy drush dkan-hm test --limit="10"
..
Processed 10 (0 created, 10 updated, 0 failed, 0 ignored) in 123.9 sec (5/min) - done with 'dkan_harvest_migrate_test'
```
4. Test added '--instruments' option:
i. Running a harvest from drush with the '--instruments' options should display prefornace informations when done.
```
$ ahoy drush dkan-hm test  --instrument="all"

...

 Name                Cum (bytes)  Count  Avg (bytes)
 destination import  10905672     10     1090567

 Timer                                              Cum (sec)  Count  Avg (msec)
 page                                               126.088    1      126087.69
 destination import                                 123.832    10     12383.227
 HarvestMigration->complete                         88.241     10     8824.094
 drupal_http_request                                9.395      100    93.955
 node_save                                          6.365      10     636.47
 MigrateFieldsEntityHandler->prepare                0.101      10     10.09
 MigrateDestinationEntity->prepareFields            0.1        10     10.021
 HarvestMigration->postImport                       0.055      1      55.41
 MigrateFieldsEntityHandler->complete               0.034      10     3.448
 MigrateDestinationEntity->completeFields           0.034      10     3.36
 saveIDMapping                                      0.032      10     3.238
 MigrateTaxonomyTermReferenceFieldHandler->prepare  0.02       10     2.007
 HarvestMigration->postImportMissingSource          0.015      1      15.42
 HarvestMigrateSQLMap->lookupMapTable               0.014      1      14
 HarvestMigrateSourceList getNextRow                0.012      10     1.236
 MigrateTextFieldHandler->prepare                   0.012      110    0.11
 HarvestMigration->postImportRestoredSource         0.011      1      11.06
 mapRowBySource                                     0.009      10     0.916
 MigrateLinkFieldHandler->prepare                   0.002      30     0.07
 MigrateValueFieldHandler->prepare                  0.002      30     0.055
 MigrateStatisticsEntityHandler->complete           0.001      10     0.1
 DateMigrateFieldHandler->prepare                   0.001      10     0.098
 MigratePathEntityHandler->prepare                  0.001      10     0.096
 MigrateSource::hash                                0.001      10     0.093
 MigrateExtrasNodeFlagHandler->complete             0.001      10     0.091
 HarvestMigration->prepare                          0.001      10     0.083
 MigrateEntityReferenceFieldHandler->prepare        0.001      10     0.07
 MigrateGeoFieldHandler->prepare                    0.001      10     0.07
 DatajsonHarvestMigration prepareRow                0          10     0.046
 MigratePollEntityHandler->complete                 0          10     0.044
 HarvestMigrateSourceList performRewind             0          1      0.39
 PathautoMigrationHandler->prepare                  0          10     0.03
 MigratePathautoHandler->prepare                    0          10     0.029
```
5. Running a harvest from drush with the '--idlist' option should only re-harvest the datasets from the id list.
6. Running a harvest with a harvvest source machine_name that does not exits should not show an exception but an error message.

## PR dependencies
None.
