### PR TITLE
Point dkan dataset to branch fix_boostrap_loading_embed_civic_5152

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 ----------------------
  - Fix publisher token in open_data_schema_map_dkan - was showing only URL rather than publisher name
+ - Fix problem loading boostrap library on embed pages.
 
 7.x-1.12.12 2016-12-15
 ----------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@
 api: '2'
 core: 7.x
 includes:
-- https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
+- https://raw.githubusercontent.com/NuCivic/dkan_dataset/fix_boostrap_loading_embed_civic_5152/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
@@ -39,7 +39,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_dataset.git
-      branch: release-1-12
+      branch: fix_boostrap_loading_embed_civic_5152
   dkan_datastore:
     subdir: dkan
     download:


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5152
## Description

When you try to embed a csv resource we are getting white screen.


## How to reproduce

1.  Create a resource csv and click checkbox for embed.
2. Get url embed and check into browser you get a white screen.

## QA Tests

- [x]  Embed page should show the data from csv instead white screen. Use a example file attached 
[Foreclosures_0.csv.zip](https://github.com/NuCivic/dkan/files/676268/Foreclosures_0.csv.zip)


## PR dependencies

- [x] https://github.com/NuCivic/dkan_dataset/pull/294
- [x] https://github.com/NuCivic/recline/pull/81
