### PR TITLE
Fix menu source for dkan workflow roles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.12.14
+-----------
+- Fix menu source for dkan workflow roles
+
 7.x-1.12.13 2017-01-04
 ----------------------
 - Fix broken recline (resource CSV) preview embeds caused by how recline module loads bootstrap

--- a/dkan.install
+++ b/dkan.install
@@ -34,8 +34,19 @@ function dkan_update_7003() {
   features_revert(array('dkan_datastore' => array('field_base', 'field_instance')));
 }
 
+
 /**
- * Groups cannot be edited manually on resources anymore (they get the group from 
+ * Point source menu to the command menu center in
+ * dkan workflow roles.
+ */
+function dkan_update_7100() {
+  if (module_exists('dkan_workflow')) {
+    dkan_workflow_admin_menu_source();
+  }
+}
+
+/**
+ * Groups cannot be edited manually on resources anymore (they get the group from
  * their parent datasets) so this update hook was added in order to be sure
  * that all resources that do not have groups assigned are synchronized and
  * updated with the groups from the parent datasets.
@@ -51,7 +62,7 @@ function dkan_update_7004(&$sandbox) {
   $result = db_query("SELECT DISTINCT fdr.field_dataset_ref_target_id FROM {node} n LEFT JOIN {field_data_field_dataset_ref} fdr ON fdr.entity_id=n.nid LEFT JOIN {og_membership} og ON n.nid=og.etid WHERE n.type='resource' AND og.etid IS NULL AND fdr.field_dataset_ref_target_id IN (SELECT etid FROM {og_membership} WHERE etid IN (SELECT field_dataset_ref_target_id FROM {field_data_field_dataset_ref})) LIMIT 0,10");
 
   foreach ($result as $item) {
-    // Simulate a empty original. 
+    // Simulate a empty original.
     // The 'dkan_dataset_sync_groups' function synchronizes
     // the groups only when a change on the dataset is detected.
     $original = new stdClass();

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,7 +4,7 @@ core: 7.x
 includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
-- https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
+- https://raw.githubusercontent.com/NuCivic/dkan_workflow/civic-5267-visualization-menu-missing/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
@@ -51,7 +51,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_workflow.git
-      branch: release-1-12
+      branch: civic-5267-visualization-menu-missing
   visualization_entity:
     download:
       type: git


### PR DESCRIPTION
Issue: civic-5267

## Description
Admin menu source weren't properly configured for dkan_workflow roles. So we needed to add function to configure the source menu for those roles during the install. We also needed to create hook_update to fix this in the current instances.

## QA tests new installations
- [ ] Check all the workflow roles point to the command menu center in `/admin/config/administration/admin_menu/source`

## QA test old installations
- [ ] Make dkan using release-1-12
- [ ] Enable dkan_workflow
- [ ] Update dkan_worflow with branch civic-5267-visualization-menu-missing
- [ ] Run `drush updatedb`
- [ ] Check all the workflow roles point to the command menu center in `/admin/config/administration/admin_menu/source`

## PR dependencies
https://github.com/NuCivic/dkan_workflow/pull/52
