### PR TITLE
Add patch to field_group to avoid DOM-based cross-site scripting Civic 4866 (DEV)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -131,6 +131,7 @@ DKAN Dataset:
  - Fix 508 compilance issues for leafleat draw widget 
  - Add patch to remote_stream_wrapper to fix memory exhausted errors.
  - Renamed 'filefield_remotefile' as 'filefield_dkan_remotefile'.
+ - Add patch to field_group to avoid DOM-based cross-site scripting vulnerabilities.
 DKAN Topics:
  - Added a test for creating a topic term.
  - Make the icon field required if the icon type is set to 'font'.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -117,6 +117,7 @@ projects:
     version: '1.5'
     patch:
       2042681: 'http://drupal.org/files/issues/field-group-show-ajax-2042681-8.patch'
+      2831815: 'https://www.drupal.org/files/issues/hash-location-sanitization.diff'
   field_group_table:
     download:
       type: git

--- a/test/features/dkan_harvest.feature
+++ b/test/features/dkan_harvest.feature
@@ -271,6 +271,7 @@ Feature: Dkan Harvest
     And I fill in "edit-created-min" with "06/01/2016"
     And I fill in "edit-created-max" with "06/30/2016"
     And I press "Apply"
+    And I wait for "3" seconds
     Then I should see "Florida Bike Lanes Harvest"
     And I should see a table with a class name "views-table"
     Then the table with the class name "views-table" should have 1 rows


### PR DESCRIPTION
Issue: Civic 4866

## Description
DOM-based cross-site scripting arises when a script writes controllable data into the HTML document in an unsafe way. 

## QA Steps
1. Log in and open a dataset form
2. Confirm the field_group fields function properly (ie click on "Upload", "API")