### PR TITLE
[CIVIC-5348] "node/%nid/draft" and "node/%nid/revision" link does not show the corrcet node revision 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -96,6 +96,7 @@ DKAN Migrate Base:
  - Added DKAN Migrate Base module into DKAN Core.
  - Removed row from migration map table when a dataset is deleted.
 DKAN Workflow:
+ - Fixed panels-related bug where, if a dataset had both a "published" and "draft" version, the published would show in the draft tab.
  - Updated DKAN workflow vbo customizations to not affect other vbo forms.
  - Updated workbench_email from 3.9 to 3.11
  - Fixed admin menu source when dkan_workflow is enabled.

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -169,16 +169,17 @@ function dkan_sitewide_data_extent_block() {
  */
 function dkan_sitewide_license_block() {
   $node = menu_get_object();
-  if (!isset($node->type)) {
-    return '';
-  }
-  elseif ($node->type != 'dataset') {
+  if (!isset($node->type) || $node->type != 'dataset') {
     return '';
   }
   else {
-    if (isset($node->field_license) && $node->field_license) {
-      $key = (isset($node->field_license[$node->language][0])) ? $node->field_license[$node->language][0] : $node->field_license[LANGUAGE_NONE][0];
-      $key = $key['value'];
+    // Sometimes the node object returned from the menu_get_object will not be
+    // fully standard with all fields information. This is usually due to the
+    // alteration done by the panels page_manager. A potential workaround is to
+    // re-load the actual node with node_load.
+    $node_emw = entity_metadata_wrapper('node', node_load($node->nid, $node->vid));
+    if (isset($node_emw->field_license)) {
+      $key = $node_emw->field_license->value();
       $subscribed_values = dkan_dataset_content_types_license_subscribed_values();
       if (isset($subscribed_values[$key])) {
         $license = $subscribed_values[$key];

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
@@ -654,21 +654,18 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();
-  $pane->pid = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+  $pane->pid = 'new-dbba36e8-a75c-4fec-b189-d8c3cae601e9';
   $pane->panel = 'contentmain';
-  $pane->type = 'node';
+  $pane->type = 'entity_view';
   $pane->subtype = 'node';
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'nid' => '%1',
-    'links' => 1,
-    'leave_node_title' => 0,
-    'identifier' => '',
-    'build_mode' => 'full',
-    'link_node_title' => 0,
-    'override_title' => 0,
-    'override_title_text' => '',
+    'view_mode' => 'full',
+    'context' => 'argument_entity_id:node_1',
+    'override_title' => 1,
+    'override_title_text' => '%node:title',
+    'override_title_heading' => 'h2',
   );
   $pane->cache = array();
   $pane->style = array(
@@ -678,9 +675,9 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $pane->extras = array();
   $pane->position = 0;
   $pane->locks = array();
-  $pane->uuid = '5771913e-f897-497d-9d56-f76f6b207b18';
-  $display->content['new-5771913e-f897-497d-9d56-f76f6b207b18'] = $pane;
-  $display->panels['contentmain'][0] = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+  $pane->uuid = 'dbba36e8-a75c-4fec-b189-d8c3cae601e9';
+  $display->content['new-dbba36e8-a75c-4fec-b189-d8c3cae601e9'] = $pane;
+  $display->panels['contentmain'][0] = 'new-dbba36e8-a75c-4fec-b189-d8c3cae601e9';
   $pane = new stdClass();
   $pane->pid = 'new-25ca95bb-18cd-4175-8cbd-5d44b3b08e20';
   $pane->panel = 'sidebar';
@@ -792,7 +789,7 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $display->content['new-a3d3ba71-c2c5-4eb0-8ac8-77b7709264a8'] = $pane;
   $display->panels['sidebar'][4] = 'new-a3d3ba71-c2c5-4eb0-8ac8-77b7709264a8';
   $display->hide_title = PANELS_TITLE_PANE;
-  $display->title_pane = 'new-5771913e-f897-497d-9d56-f76f6b207b18';
+  $display->title_pane = 'new-dbba36e8-a75c-4fec-b189-d8c3cae601e9';
   $handler->conf['display'] = $display;
   $export['node_view_panel_context'] = $handler;
 

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -16,10 +16,10 @@ Feature:
       | All Recent Content | /admin/workbench/content/all         |
       | Create User        | /admin/people/create                 |
     Given Users:
-      | name         | mail                | status | roles                             |
-      | Contributor  | WC@fakeemail.com    | 1      | Workflow Contributor, Content Creator            |
-      | Moderator    | WM@fakeemail.com    | 1      | Workflow Moderator, Editor          |
-      | Supervisor   | WS@fakeemail.com    | 1      | Workflow Supervisor, Site Manager|
+      | name        | mail             | status | roles                                 |
+      | Contributor | WC@fakeemail.com | 1      | Workflow Contributor, Content Creator |
+      | Moderator   | WM@fakeemail.com | 1      | Workflow Moderator, Editor            |
+      | Supervisor  | WS@fakeemail.com | 1      | Workflow Supervisor, Site Manager     |
     Given groups:
       | title    | author     | published |
       | Group 01 | Supervisor | Yes       |
@@ -63,10 +63,10 @@ Feature:
     And I should see the link "My Edits"
     And I should see the link "All Recent Content"
     Examples:
-      | workbench roles                       |
+      | workbench roles      |
       | Workflow Contributor |
-      | Workflow Moderator |
-      | Workflow Supervisor |
+      | Workflow Moderator   |
+      | Workflow Supervisor  |
 
   @api @javascript @globalUser
   Scenario Outline: As a user with any Workflow role, I should be able to upgrade my own draft content to needs review.
@@ -167,11 +167,11 @@ Feature:
   Scenario Outline: As a user with Workflow Roles, I should be able to see draft content I authored in 'My Drafts'
     Given I am logged in as "<user>"
     And datasets:
-      | title       | author | moderation |
-      | My Dataset  | <user>  | draft        |
+      | title      | author | moderation |
+      | My Dataset | <user> | draft      |
     And resources:
-      | title        | author | dataset    | format |  moderation |
-      | My Resource  | <user>  | My Dataset | csv    |  draft        |
+      | title       | author | dataset    | format | moderation |
+      | My Resource | <user> | My Dataset | csv    | draft      |
     And I visit the "My Drafts" page
     And I should see "My Resource"
     And I should see "My Dataset"
@@ -185,11 +185,11 @@ Feature:
   Scenario Outline: As a user with Workflow Roles, I should not be able to see Published content I authored in workbench pages
     Given I am logged in as "Contributor"
     And datasets:
-      | title       | author  | published |
-      | My Dataset  | Contributor   | No        |
+      | title      | author      | published |
+      | My Dataset | Contributor | No        |
     And resources:
-      | title        | author | dataset       | format |  published |
-      | My Resource  | Contributor  | My Dataset    | csv    |  Yes       |
+      | title       | author      | dataset    | format | published |
+      | My Resource | Contributor | My Dataset | csv    | Yes       |
     And I update the moderation state of "My Dataset" to "Needs Review"
     And I update the moderation state of "My Resource" to "Needs Review"
     And "Moderator" updates the moderation state of "My Dataset" to "Published"
@@ -211,11 +211,11 @@ Feature:
   Scenario Outline: As a user with Workflow Roles, I should not be able to see Needs Review resources I authored in 'My Drafts'
     Given I am logged in as a user with the "<workbench roles>" role
     And datasets:
-      | title       | author | published |
-      | My Dataset  | Contributor  | No        |
+      | title      | author      | published |
+      | My Dataset | Contributor | No        |
     And resources:
-      | title        | author |  dataset       | format |  published |
-      | My Resource  | Contributor  | My Dataset    | csv    |  no        |
+      | title       | author      | dataset    | format | published |
+      | My Resource | Contributor | My Dataset | csv    | no        |
     And I update the moderation state of "My Dataset" to "Needs Review"
     And I update the moderation state of "My Resource" to "Needs Review"
     And I visit the "My Drafts" page
@@ -231,11 +231,11 @@ Feature:
   Scenario: As a user with the Workflow Contributor, I should be able to see Needs Review contents I authored in 'Needs Review'
     Given I am logged in as "Contributor"
     And datasets:
-      | title       | author | moderation |
-      | My Dataset  | Contributor | draft      |
+      | title      | author      | moderation |
+      | My Dataset | Contributor | draft      |
     And resources:
-      | title        | author | dataset       | format |  moderation |
-      | My Resource  | Contributor | My Dataset    | csv    |  draft      |
+      | title       | author      | dataset    | format | moderation |
+      | My Resource | Contributor | My Dataset | csv    | draft      |
     And I update the moderation state of "My Dataset" to "Needs Review"
     And I update the moderation state of "My Resource" to "Needs Review"
     And I visit the "Needs Review" page
@@ -249,11 +249,11 @@ Feature:
       | name            | roles                                 |
       | some-other-user | Workflow Contributor, content creator |
     And datasets:
-      | title           | author          | moderation |
-      | Not My Dataset  | some-other-user | draft        |
+      | title          | author          | moderation |
+      | Not My Dataset | some-other-user | draft      |
     And resources:
-      | title            | dataset           | author          | format |  moderation |
-      | Not My Resource  | Not My Dataset    | some-other-user | csv    |  draft         |
+      | title           | dataset        | author          | format | moderation |
+      | Not My Resource | Not My Dataset | some-other-user | csv    | draft      |
 
     And "some-other-user" updates the moderation state of "Not My Dataset" to "Needs Review"
     And "some-other-user" updates the moderation state of "Not My Resource" to "Needs Review"
@@ -364,7 +364,7 @@ Feature:
     Given users:
       | name             | mail                       | status | roles                                 |
       | Administrator    | admin@test.com             | 1      | administrator                         |
-      | Contributor C1G1 | contributor-c1g1@test.com  | 1      | Workflow Contributor, content creator |
+      | Contributor C0G1 | contributor-c1g1@test.com  | 1      | Workflow Contributor, content creator |
       | Contributor C2G1 | contributor-c2g1@test.com  | 1      | Workflow Contributor, content creator |
       | Moderator M1G1   | moderator-m1g1@test.com    | 1      | Workflow Moderator, editor            |
       | Moderator M2G1   | moderator-m2g1@test.com    | 1      | Workflow Moderator, editor            |
@@ -542,3 +542,22 @@ Feature:
     When I click "Moderator RolePairing"
     And I click "Edit"
     Then the checkbox "editor" should be checked
+
+  @ok
+  # https://jira.govdelivery.com/browse/CIVIC-5348
+  Scenario: "View draft" should display the draft dataset and not the published revision.
+    Given users:
+      | name                 | roles                                 |
+      | workflow_contributor | Workflow Contributor, content creator |
+    And datasets:
+      | title         | author               | published | moderation |
+      | Dataset title | workflow_contributor | Yes       | published  |
+    Given I update the moderation state of "Dataset title" to "Published"
+    Given I am logged in as "workflow_contributor"
+    And I am on "Dataset title" page
+    Then I should see the text "Dataset title"
+    When I click "Edit draft"
+    And for "title" I enter "Dataset draft title"
+    And I press "Finish"
+    And I click "View draft"
+    Then I should see "Dataset draft title"

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -364,7 +364,7 @@ Feature:
     Given users:
       | name             | mail                       | status | roles                                 |
       | Administrator    | admin@test.com             | 1      | administrator                         |
-      | Contributor C0G1 | contributor-c1g1@test.com  | 1      | Workflow Contributor, content creator |
+      | Contributor C1G1 | contributor-c1g1@test.com  | 1      | Workflow Contributor, content creator |
       | Contributor C2G1 | contributor-c2g1@test.com  | 1      | Workflow Contributor, content creator |
       | Moderator M1G1   | moderator-m1g1@test.com    | 1      | Workflow Moderator, editor            |
       | Moderator M2G1   | moderator-m2g1@test.com    | 1      | Workflow Moderator, editor            |

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -176,10 +176,10 @@ Feature:
     And I should see "My Resource"
     And I should see "My Dataset"
     Examples:
-      | user |
+      | user        |
       | Contributor |
-      | Moderator  |
-      | Supervisor |
+      | Moderator   |
+      | Supervisor  |
 
   @ok @globalUser
   Scenario Outline: As a user with Workflow Roles, I should not be able to see Published content I authored in workbench pages


### PR DESCRIPTION
Issue: CIVIC-5348

## Description
The *View draft* tab on moderated datasets (ie dkan_workflow enabled) is not working correctly and displays the published dataset node in place of the expected draft.
This is due to the pane used by the `node_view` panel page is discarting the current node revision and only using the node id to render the node.

## How to reproduce

1. Enable `dkan_workflow` module.
2. From a node that already have a published revision. Create a new draft revision.
3. Click on the *View draft* tab. (Or use node/%nid/draft).
*Expected*:
1. The updated content is shown.
*Actual*
1. The published node revision is displayed.
This behavior is not affecting the node edit page.