### PR TITLE
Use state into element group for resource nodes to allow select group when dataset ref is empty

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -135,6 +135,7 @@ DKAN Dataset:
  - Add patch to remote_stream_wrapper to fix memory exhausted errors.
  - Renamed 'filefield_remotefile' as 'filefield_dkan_remotefile'.
  - Add patch to field_group to avoid DOM-based cross-site scripting vulnerabilities.
+ - Use state for show or hide group field into resources nodes
 DKAN Topics:
  - Added a test for creating a topic term.
  - Make the icon field required if the icon type is set to 'font'.

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -11,3 +11,5 @@ projects:
       1903010: 'https://www.drupal.org/files/issues/drupal-undefinedindex_fileupload-1903010-4.patch'
       # Warning: filesize(): stat failed
       628094: 'https://www.drupal.org/files/issues/file.remote-file_save.628094.22.patch'
+      #State error with select multiple
+      2844358: 'https://www.drupal.org/files/issues/drupal_bug_multiple_values_select_states.patch'

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -346,9 +346,14 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     $form['field_link_api'][$field_link_api_langcode][0]['#title'] = '';
     $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['#title'] = '';
 
-    // Resources inherit groups from parent dataset.
-    // Hide field so users cannot manually modify that information.
-    $form['og_group_ref']['#access'] = FALSE;
+    // Use state to show or hide field group.
+      $form['og_group_ref']['#states'] = array(
+      'visible' => array(
+        array(':input[name="field_dataset_ref[und][]"]' => array('value' => array('_none'))),
+        '[OR/XOR]',
+        array(':input[name="field_dataset_ref[und][]"]' => array('value' => array())),
+      ),
+    );
 
     if ($query = drupal_get_query_parameters()) {
       if (isset($query['dataset'])) {


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5087

## Description

We need to allow select groups when a resource is created without dataset related.

## How to reproduce

1.  Try to create a resource without dataset related and you can't select a group.

## QA Tests

- [ ] Select none value on resource create page and you can select a group to associate with it.

