### PR TITLE
Update tests to account for client site variations CIVIC-5434

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -219,3 +219,14 @@ function dkan_update_7008() {
     dkan_workflow_admin_menu_source();
   }
 }
+
+/**
+ * Flush client site colorizer file to grab new updates.
+ */
+function dkan_update_7009() {
+  $theme = $GLOBALS['theme'];
+  $instance = $theme;
+  variable_del('colorizer_' . $instance . '_files');
+  colorizer_clearcache();
+  cache_clear_all();
+}

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -55,13 +55,13 @@ Feature: Dataset Features
       | Dataset 08 |           | Katie   | Yes              | election1 |             |
       | Dataset 09 | Group 02  | Katie   | Yes              | election1 |             |
     And resources:
-      | title       | publisher | format | author | published | dataset    | description |
-      | Resource 01 | Group 01  | csv    | Katie  | Yes       | Dataset 01 |             |
-      | Resource 02 | Group 01  | zip    | Katie  | Yes       | Dataset 01 |             |
-      | Resource 03 | Group 01  | zip    | Katie  | Yes       | Dataset 02 |             |
-      | Resource 04 |           | csv    | Katie  | Yes       |            |             |
-      | Resource 05 |           | csv    | Katie  | Yes       | Dataset 08 |             |
-      | Resource 06 | Group 02  | csv    | Katie  | Yes       | Dataset 09 |             |
+      | title       | publisher | author | published | dataset    | description |
+      | Resource 01 | Group 01  | Katie  | Yes       | Dataset 01 |             |
+      | Resource 02 | Group 01  | Katie  | Yes       | Dataset 01 |             |
+      | Resource 03 | Group 01  | Katie  | Yes       | Dataset 02 |             |
+      | Resource 04 |           | Katie  | Yes       |            |             |
+      | Resource 05 |           | Katie  | Yes       | Dataset 08 |             |
+      | Resource 06 | Group 02  | Katie  | Yes       | Dataset 09 |             |
 
   @noworkflow
   Scenario: Create dataset as content creator

--- a/test/features/dataset.editor.feature
+++ b/test/features/dataset.editor.feature
@@ -45,10 +45,10 @@ Background:
     | Dataset 04 | Group 02  | Celeste | No               | Gov      | Test        | 2015-01-02           |  -5 year     |
     | Dataset 05 | Group 01  | Katie   | No               | Gov      | Test        | 2015-01-02           |  -5 year     |
   And resources:
-    | title       | publisher | format | author | published | dataset    | description |
-    | Resource 01 | Group 01  | csv    | Katie  | Yes       | Dataset 01 |             |
-    | Resource 02 | Group 01  | zip    | Katie  | Yes       | Dataset 01 |             |
-    | Resource 03 | Group 01  | zip    | Katie  | Yes       | Dataset 02 |             |
+    | title       | publisher | author | published | dataset    | description |
+    | Resource 01 | Group 01  | Katie  | Yes       | Dataset 01 |             |
+    | Resource 02 | Group 01  | Katie  | Yes       | Dataset 01 |             |
+    | Resource 03 | Group 01  | Katie  | Yes       | Dataset 02 |             |
 
   @noworkflow
   Scenario: Replace node changed date with modified source date for harvested datasets

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -37,12 +37,12 @@ Feature: Resource
       | Dataset 01 | Group 01  | Gabriel | Yes              | world    | Test        |
       | Dataset 02 | Group 01  | Gabriel | Yes              | results  | Test        |
     And resources:
-      | title       | publisher | format | dataset    | author   | published | description |
-      | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
-      | Resource 02 | Group 01  | zip    | Dataset 01 | Katie    | Yes       | No          |
-      | Resource 03 | Group 01  | zip    | Dataset 02 | Celeste  | No        | Yes         |
-      | Resource 04 | Group 01  | csv    | Dataset 01 | Katie    | No        | Yes         |
-      | Resource 05 | Group 01  | zip    | Dataset 02 | Celeste  | Yes       | Yes         |
+      | title       | publisher | dataset    | author   | published | description |
+      | Resource 01 | Group 01  | Dataset 01 | Katie    | Yes       | No          |
+      | Resource 02 | Group 01  | Dataset 01 | Katie    | Yes       | No          |
+      | Resource 03 | Group 01  | Dataset 02 | Celeste  | No        | Yes         |
+      | Resource 04 | Group 01  | Dataset 01 | Katie    | No        | Yes         |
+      | Resource 05 | Group 01  | Dataset 02 | Celeste  | Yes       | Yes         |
 
   @noworkflow
   Scenario: Edit any resource

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -34,10 +34,10 @@ Feature: Resource
     And resources:
       | title       | publisher | format | dataset    | author   | published | description |
       | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | Old Body    |
-      | Resource 02 | Group 01  | zip    | Dataset 01 | Katie    | Yes       | No          |
-      | Resource 03 | Group 01  | zip    | Dataset 02 | Celeste  | No        | Yes         |
+      | Resource 02 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
+      | Resource 03 | Group 01  | csv    | Dataset 02 | Celeste  | No        | Yes         |
       | Resource 04 | Group 01  | csv    | Dataset 01 | Katie    | No        | Yes         |
-      | Resource 05 | Group 01  | zip    | Dataset 02 | Celeste  | Yes       | Yes         |
+      | Resource 05 | Group 01  | csv    | Dataset 02 | Celeste  | Yes       | Yes         |
 
   @api
   Scenario: View published resource

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -38,9 +38,9 @@ Feature: Search
       | edumication  |
       | dazzling     |
     And datasets:
-      | title           | publisher | author  | published | tags         | topics      | description |
-      | Test Dataset 01 |           | Gabriel | Yes       | something01  | edumication | Test 01     |
-      | Test Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
+      | title              | publisher | author  | published | tags         | topics      | description |
+      | ooftaya Dataset 01 |           | Gabriel | Yes       | something01  | edumication | Test 01     |
+      | ooftaya Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
 
   Scenario: Searching datasets
     Given I am on the "Dataset Search" page
@@ -50,7 +50,7 @@ Feature: Search
 
   Scenario: See number of datasets on search page
     Given I am on the "Dataset Search" page
-    When I search for "Test"
+    When I search for "ooftaya"
     Then I should see "2" search results shown on the page
     And I should see "2 results"
 

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -23,7 +23,7 @@ Feature: Theme
     Then I wait for "3" seconds
     Then I should see "The configuration options have been saved"
 
-  @noworkflow
+  @noworkflow @customizable
   Scenario: Add custom hero image
     Given I am logged in as "John"
     And I am on "Settings" page


### PR DESCRIPTION
Issue: CIVIC-5434

## Description

We need tests to pass on both DKAN OOB and client sites. 
1. **theme.admin.feature**
Since client sites may have custom hero images, add the @customizable tag to Scenario: Add custom hero image
2. **dataset.author.feature** / **dataset.editor.feature**
Client sites (cadepttech) may not have the 'zip' format in their list of terms, remove the format column in backgrounds where it is not needed and simplify with more common formats when it is
3. **resource.admin.feature** / **resource.all.feature**
Only one test on resource.all.feature requires a csv format
4. **search.feature**
See number of datasets on search page (change test to use a search term no client site would be using)

## QA Tests

- [x] Tests pass
- [x] 1.13 client QA branches