### PR TITLE
Upgrade autocomplete_deluxe to fix security vulnerability

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -16,7 +16,7 @@ projects:
   adminrole:
     version: '1.1'
   autocomplete_deluxe:
-    version: '2.1'
+    version: '2.2'
     patch:
       2833824: 'https://www.drupal.org/files/issues/autocomplete-deluxe-2833824-4.patch'
   beautytips:


### PR DESCRIPTION
This addresses DKAN security alert [DRUPAL-SA-CONTRIB-2017-003 ](https://www.drupal.org/node/2842730) on the dev (1.13) branch

## QA Tests

* Autocomplete deluxe field (the keywords in dataset) behaves as normal
* WAVE 508 tests still pass on dataset form