### PR TITLE
CIVIC-4887: Added a function to check if a page is the frontpage.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added a function in dkan_sitewide to check if a specific page is the front page.
  - Improve module and user cleanup inside dkan workflow context after run tests
  - Update leaflet library to v1.0.2 and leaflet markercluster to v1.0.0. Unift leaflet libraries (was using a separate version for recline module)
  - Upgraded to new 1.0 release of Visualization Entity module

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -380,7 +380,7 @@ function dkan_sitewide_update_panel_page_status($page_name, $status = FALSE) {
 }
 
 /**
- * Check if the page passed is already the frontpage.
+ * Check if given page manager page is already the frontpage.
  *
  * @param string $page
  *   page The administrative name of the page.

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -380,7 +380,10 @@ function dkan_sitewide_update_panel_page_status($page_name, $status = FALSE) {
 }
 
 /**
- * Check if the page passed is the already the frontpage.
+ * Check if the page passed is already the frontpage.
+ *
+ * @param string $page
+ *   page The administrative name of the page.
  */
 function dkan_sitewide_page_is_frontpage($page) {
   $frontpage = variable_get('site_frontpage', 'node');

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -378,3 +378,20 @@ function dkan_sitewide_update_panel_page_status($page_name, $status = FALSE) {
   $function($page, $status);
   menu_rebuild();
 }
+
+/**
+ * Check if the page passed is the already the frontpage.
+ */
+function dkan_sitewide_page_is_frontpage($page) {
+  $frontpage = variable_get('site_frontpage', 'node');
+
+  module_load_include('inc', 'page_manager', 'plugins/tasks/page');
+  $page = page_manager_page_load($page);
+
+  if ($page->path === $frontpage) {
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
+}


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-4887

## Description

The upgrade script fails on a conversion step for some sites depending on whether a page is already the frontpage; so here we add a function to check that.
