### PR TITLE
Updates to drupal 7.53

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.52'
+    version: '7.53'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5507
release PR #1689 

## Description

The drupal 7.50 -> 7.51 introduced conflicts between drupal core tabledrag's functionality and newer jquery versions set via jquery_update.

## QA

- [ ] Go to the DKAN Featured Groups Page
- [ ] You should be able to reorder the groups
- [ ] Go to any Drupal Content Types Fields admin
- [ ] You should be able to reorder the fields
- [ ] Same for every tabledrag in dkan
