### PR TITLE
Updates to drupal 7.53

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+- Updates drupal core to 7.53
+
 7.x-1.12.13 2017-01-04
 ----------------------
 - Fix validation on resource forms when multiple resource type fields are populated

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.52'
+    version: '7.53'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5507
dev PR #1688 

## Description

The drupal 7.50 -> 7.51 introduced conflicts between drupal core tabledrag's functionality and newer jquery versions set via jquery_update.

## QA

- [x] Go to the DKAN Featured Groups Page
- [x] You should be able to reorder the groups
- [x] Go to any Drupal Content Types Fields admin
- [x] You should be able to reorder the fields
- [ ] Same for every tabledrag in dkan
