### PR TITLE
Add patch for workbench_moderation  CIVIC-4889

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added patch for workbench_moderation: Invalid argument supplied for foreach() 2360973.
  - Added a function in dkan_sitewide to check if a specific page is the front page.
  - Improve module and user cleanup inside dkan workflow context after run tests
  - Update leaflet library to v1.0.2 and leaflet markercluster to v1.0.0. Unift leaflet libraries (was using a separate version for recline module)

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -354,6 +354,8 @@ projects:
     version: '3.11'
   workbench_moderation:
     version: '3.0'
+    patch:
+      2360973: 'https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch'
   drafty:
     version: '1.0-beta3'
 libraries:


### PR DESCRIPTION
Issue: CIVIC-4889

## Description

workbench_moderation_states_features_rebuild() and workbench_moderation_transitions_features_rebuild() call features_get_default() and pass the result directly to a foreach. However, features_get_default() can return boolean FALSE instead of an array, causing the following notice:

**Invalid argument supplied for foreach() in workbench_moderation.features.inc**

## How to reproduce

1. Enable dkan_workflow
2. Disable dkan_workflow and workbench_moderation
3. Enable dkan_workflow, notice the error 

![modules___dkan](https://cloud.githubusercontent.com/assets/314172/22485528/a62e0d6e-e7cb-11e6-94cb-1c94be500587.png)


## QA Steps

- [ ] Running the steps above does not display the error above.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
