### PR TITLE
Add maintenance mode before enabling a module

### DIFF
--- a/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -33,6 +33,7 @@ class WorkflowContext extends RawDKANContext {
       'link_badges',
       'dkan_workflow_permissions'
     ));
+    drupal_flush_all_caches();
   }
 
   /**
@@ -56,6 +57,7 @@ class WorkflowContext extends RawDKANContext {
     // Clean users and disable modules.
     entity_delete_multiple('user', $users_to_delete);
     module_disable(array_values($modules_to_disable));
+    drupal_uninstall_modules(array_values($modules_to_disable));
     drupal_flush_all_caches();
   }
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -22,11 +22,17 @@ class WorkflowContext extends RawDKANContext {
   {
     self::$modules_before_feature = module_list(TRUE);
     self::$users_before_feature = array_keys(entity_load('user'));
-
+    define('MAINTENANCE_MODE', 'update');
     @module_enable(array(
-      'dkan_workflow'
+      'dkan_workflow',
+      'drafty',
+      'workbench_moderation',
+      'workbench_email', 'workbench',
+      'views_dkan_workflow_tree',
+      'menu_badges',
+      'link_badges',
+      'dkan_workflow_permissions'
     ));
-    drupal_flush_all_caches();
   }
 
   /**


### PR DESCRIPTION
## Description
This fix issues we were experiencing in some client sites with workflow tests. Workflow was not "cleaning up" after itself correctly, modules need to be more properly enabled and disabled.