### PR TITLE
Disable dkan dataset api and enable open data schema #CIVIC-5550

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.x
 --------------------------
- - Disable  dkan_dataset_api if is enable because is deprecated in favor open_data_schema_map.
+ - Disable/uninstall  dkan_dataset_api if is enable because is deprecated in favor open_data_schema_map.
  - Update resource tests to work on sites without zip in their format terms.
  - Moved functions from FeatureContext to DKANExtension.
  - Added patch for workbench_moderation: Invalid argument supplied for foreach() 2360973.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Disable  dkan_dataset_api if is enable because is deprecated in favor open_data_schema_map.
  - Update resource tests to work on sites without zip in their format terms.
  - Moved functions from FeatureContext to DKANExtension.
  - Added patch for workbench_moderation: Invalid argument supplied for foreach() 2360973.

--- a/dkan.install
+++ b/dkan.install
@@ -237,15 +237,6 @@ function dkan_update_7009() {
 function dkan_update_7010() {
   if (module_exists('dkan_dataset_api')) {
     module_disable(array('dkan_dataset_api'));
-
-    //Clear endpoint cache.
     module_enable(array('open_data_schema_map'));
-    //Clear cache after disable dkan_dataset_api
-    $apis = array('data_json_1_1', 'data_json');
-    foreach($apis as $api) {
-      $api = open_data_schema_map_api_load($api);
-      $filename = open_data_schema_map_file_cache_name_helper($api);
-      file_unmanaged_delete($filename);
-    }
   }
 }

--- a/dkan.install
+++ b/dkan.install
@@ -230,3 +230,22 @@ function dkan_update_7009() {
   colorizer_clearcache();
   cache_clear_all();
 }
+
+/**
+ * Disable deprecated dkan_dataset_api and enable open_data_schema_map.
+ */
+function dkan_update_7010() {
+  if (module_exists('dkan_dataset_api')) {
+    module_disable(array('dkan_dataset_api'));
+
+    //Clear endpoint cache.
+    module_enable(array('open_data_schema_map'));
+    //Clear cache after disable dkan_dataset_api
+    $apis = array('data_json_1_1', 'data_json');
+    foreach($apis as $api) {
+      $api = open_data_schema_map_api_load($api);
+      $filename = open_data_schema_map_file_cache_name_helper($api);
+      file_unmanaged_delete($filename);
+    }
+  }
+}

--- a/dkan.install
+++ b/dkan.install
@@ -232,11 +232,12 @@ function dkan_update_7009() {
 }
 
 /**
- * Disable deprecated dkan_dataset_api and enable open_data_schema_map.
+ * Disable/uninstall deprecated dkan_dataset_api and enable open_data_schema_map.
  */
 function dkan_update_7010() {
   if (module_exists('dkan_dataset_api')) {
     module_disable(array('dkan_dataset_api'));
+    drupal_uninstall_modules(array('dkan_dataset_api'));
     module_enable(array('open_data_schema_map'));
   }
 }


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5550

## Description

Module dkan dataset api is obsolote we need to disable and enable open data schema map.



## How to reproduce

1.  Enable dkan dataset api and open data schema map. We have conflicts between both modules.

## QA Steps

- [ ] Enable dkan dataset api.
- [ ] Execute updates and should be disable and enable open data schema map.

