### PR TITLE
Update tests for client site issues CIVIC-4888

### DIFF
--- a/test/features/user.site_manager.feature
+++ b/test/features/user.site_manager.feature
@@ -108,9 +108,6 @@ Feature: User command center links for site manager role.
     And I click "Menus"
     Then I should see "Main menu"
     When I hover over the admin menu item "Site Configuration"
-    And I click "Fonts"
-    Then I should see "No fonts enabled yet, please enable some fonts first."
-    When I hover over the admin menu item "Site Configuration"
     And I click "Taxonomy"
     Then I should see "Taxonomy"
     When I hover over the admin menu item "Site Configuration"
@@ -127,3 +124,10 @@ Feature: User command center links for site manager role.
     Then I hover over the admin menu item "Taxonomy"
     And I click "Topics" in the "admin menu" region
     Then I should see "Topics"
+
+  @customizable
+  Scenario: Site manager role can configure custom fonts
+    Given I am logged in as "John"
+    When I hover over the admin menu item "Site Configuration"
+    And I click "Fonts"
+    Then I should see "No fonts enabled yet, please enable some fonts first."

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -43,6 +43,7 @@ Feature: Widgets
     And I wait for "Configure new File"
     And I attach the drupal file "dkan/actionplan.pdf" to "files[field_basic_file_file_und_0]"
     And I press "Finish"
+    And I wait for "2" seconds 
     And I wait and press "Save"
     And I wait for "Customize this page"
     Then I should see "actionplan.pdf"
@@ -59,6 +60,7 @@ Feature: Widgets
     And I press "Next"
     And I wait and press "Save"
     And I wait and press "Finish"
+    And I wait for "2" seconds
     And I wait and press "Save"
     And I wait for "Customize this page"
     Then I should see "dkan logo image test"


### PR DESCRIPTION
Issue: CIVIC-4888

## Description

1. **widgets.feature** - still two scenarios failing do to speed of CircleCI, need to add 'Wait' 
2. **user.site_manager.feature** - client sites may be using the custom fonts option so separating the test out as customizable to be skipped on client sites

## QA Steps

- [ ] tests pass