### PR TITLE
Add dependecy worbench moderation to views_dkan_workflow_tree

### DIFF
--- a/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.info
+++ b/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.info
@@ -3,5 +3,6 @@ description = A Views style plugin to display content lists for approval
 package = Views
 core = 7.x
 dependencies[] = views
+dependencies[] = workbench_moderation
 files[] = ViewsDkanWorkflowTreePluginStyle.inc
 stylesheets[all][] = views_dkan_workflow_tree.css


### PR DESCRIPTION

## Description

If we have enable views_dkan_workflow_tree we can have problems because use functions from workflow_moderation but isn't a dependecy module.


## How to reproduce

1.  Enable views_dkan_workflow_tree and workflow_moderation is disable.

## QA Steps

- [ ] Enable views_dkan_workflow_tree and workflow moderation should be enabled
