### PR TITLE
Add a BeforeSuite function for deleting all the existing nodes.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added new BeforeSuite function for deleting all the existing nodes before running DKAN tests.
  - Added css for chart visualizaitons, fixes issue in IE.
  - Upgrade better_exposed_filters to v3.4.
  - Update branding.

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -68,6 +68,22 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
   }
 
   /**
+   * @BeforeSuite
+   */
+  public static function removeAllNodes(BeforeSuiteScope $scope) {
+    $skip = array('page');
+    $nodes = entity_load('node');
+    $nodes_to_delete = array_reduce($nodes, function($accum, $node) use ($skip){
+      if(!in_array($node->type, $skip)) {
+        $accum[] = $node->nid;
+      }
+      return $accum;
+    }, array());
+    $nodes_to_delete = array_values($nodes_to_delete);
+    node_delete_multiple($nodes_to_delete);
+  }
+
+  /**
    * @AfterSuite
    */
   public static function enableAdminMenuCache(AfterSuiteScope $scope) {


### PR DESCRIPTION
## Description

When in a site with dkan_workflow, there are nodes already marked as "Stale Review", one of the tests from workflow.feature fails in the step `Then I wait for "Performed Publish on 3 items`.
As a solution for this issue, we created a new function as BeforeSuite in order to delete all the nodes existing right before starting to run the tests.

## QA Steps

- [ ] Tests passes.
