### PR TITLE
Add a filter in workflow.feature to avoid issues in sites where there are nodes that already exists.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added a filter in the workflow.feature to avoid issues for the amount of already existing nodes.
  - Added css for chart visualizaitons, fixes issue in IE.
  - Upgrade better_exposed_filters to v3.4.
  - Update branding.

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -125,21 +125,23 @@ Feature:
     Given I am logged in as "Contributor"
     And datasets:
       | title                       | author       | published | moderation_date   | date created  |
-      | Stale Dataset Needs Review  | Contributor  | No        | Jul 21, 2015      | Jul 21, 2015  |
-      | Fresh Dataset Needs Review  | Contributor  | No        | Jul 21, 2015      | Jul 21, 2015  |
+      | Stale Dataset DKAN Test Needs Review  | Contributor  | No        | Jul 21, 2015      | Jul 21, 2015  |
+      | Fresh Dataset DKAN Test Needs Review  | Contributor  | No        | Jul 21, 2015      | Jul 21, 2015  |
     And resources:
       | title                        | author       | dataset                    | format |  published |
-      | Stale Resource Needs Review  | Contributor  | Stale Dataset Needs Review | csv    |  no        |
-    And I update the moderation state of "Stale Dataset Needs Review" to "Needs Review" on date "30 days ago"
-    And I update the moderation state of "Stale Resource Needs Review" to "Needs Review" on date "30 days ago"
-    And I update the moderation state of "Fresh Dataset Needs Review" to "Needs Review" on date "20 days ago"
+      | Stale Resource DKAN Test Needs Review  | Contributor  | Stale Dataset DKAN Test Needs Review | csv    |  no        |
+    And I update the moderation state of "Stale Dataset DKAN Test Needs Review" to "Needs Review" on date "30 days ago"
+    And I update the moderation state of "Stale Resource DKAN Test Needs Review" to "Needs Review" on date "30 days ago"
+    And I update the moderation state of "Fresh Dataset DKAN Test Needs Review" to "Needs Review" on date "20 days ago"
     Given I am logged in as "Supervisor"
     And I visit the "Stale Reviews" page
     And I should see the button "Reject"
     And I should see the button "Publish"
-    And I should see "Stale Dataset Needs Review"
-    And I should see "Stale Resource Needs Review"
-    And I should not see "Fresh Resource Needs Review"
+    When I fill in "edit-title" with "DKAN Test"
+    And I press "Filter"
+    Then I should see "Stale Dataset DKAN Test Needs Review"
+    And I should see "Stale Resource DKAN Test Needs Review"
+    And I should not see "Fresh Resource DKAN Test Needs Review"
     And I check the box "Select all items on this page"
     When I press "Publish"
     Then I wait for "Performed Publish on 3 items"


### PR DESCRIPTION
Issue: CIVIC-5625.

## Description

In workflow.feature we have a test with the step: `Then I wait for "Performed Publish on 3 items" ` it could potentially fail in siteswhere there already exists nodes marked as Stale Review.

What we did to fix it was:
- Change nodes names to include a test word to filter by it.
- Add steps for filtering the results and make appear an specific amount of items (in this case just those three).

## Acceptance criteria

- [ ] Tests passes.