### PR TITLE
Move the roleassign_roles variable update to dkan_workflow.install  CIVIC-5641

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -111,6 +111,7 @@ DKAN Migrate Base:
  - Added DKAN Migrate Base module into DKAN Core.
  - Removed row from migration map table when a dataset is deleted.
 DKAN Workflow:
+ - Moved the update of the roleassign_roles variable from dkan_workflow_permissions to dkan_workflow.
  - Fixed panels-related bug where, if a dataset had both a "published" and "draft" version, the published would show in the draft tab.
  - Updated DKAN workflow vbo customizations to not affect other vbo forms.
  - Updated workbench_email from 3.9 to 3.11

--- a/modules/dkan/dkan_workflow/dkan_workflow.install
+++ b/modules/dkan/dkan_workflow/dkan_workflow.install
@@ -40,10 +40,10 @@ function dkan_workflow_enable() {
 
   variable_set('dkan_workflow_content_types', $dkan_workflow_content_types);
 
-  //Revert dkan sitewide menu to add links to command center.
+  // Revert dkan sitewide menu to add links to command center.
   features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 
-  //Assign role supervisor to editor users.
+  // Assign role supervisor to editor users.
   $uids = array();
   $supervisor = user_role_load_by_name("Workflow Supervisor");
   $site_manager = user_role_load_by_name("site manager");
@@ -57,11 +57,29 @@ function dkan_workflow_enable() {
   }
   dkan_workflow_admin_menu_source();
 
+  // Add dkan workflow roles to roleassign config.
+  $roleassign_roles = variable_get('roleassign_roles', array());
+  $roles_rids = array_flip(user_roles());
+
+  $add_roles = array(
+    'Workflow Contributor',
+    'Workflow Moderator',
+    'Workflow Supervisor',
+  );
+
+  foreach ($add_roles as $role) {
+    if (isset($roles_rids[$role])) {
+      $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
+    }
+  }
+  variable_set('roleassign_roles', $roleassign_roles);
+
 }
 
-
 /**
- * This helper function sets up the admin_menu_source module's configuration.
+ * Helper function.
+ *
+ * This sets up the admin_menu_source module's configuration.
  * We want the content creator and editor roles to have the "command center"
  * menu rather than the whole admin menu in the top bar. We can't rely on the
  * rid to be the same on every site so not using features.

--- a/modules/dkan/dkan_workflow/dkan_workflow.install
+++ b/modules/dkan/dkan_workflow/dkan_workflow.install
@@ -109,3 +109,23 @@ function dkan_workflow_admin_menu_source() {
   $admin_menu_source_settings = array_replace($previous_settings, $admin_menu_source_settings);
   variable_set('admin_menu_source_settings', $admin_menu_source_settings);
 }
+
+/**
+ * Implements hook_disable().
+ */
+function dkan_workflow_disable() {
+  // Remove workflow roles from roleassign_roles variable.
+  $roleassign_roles = variable_get('roleassign_roles', array());
+  $roles_rids = array_flip(user_roles());
+  $remove_roles = array(
+    'Workflow Contributor',
+    'Workflow Moderator',
+    'Workflow Supervisor',
+  );
+
+  foreach ($remove_roles as $role) {
+    unset($roleassign_roles[$roles_rids[$role]]);
+  }
+
+  variable_set('roleassign_roles', $roleassign_roles);
+}

--- a/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
+++ b/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
@@ -87,23 +87,3 @@ function _dkan_workflow_permissions_setup_admin_menu_source() {
   );
   variable_set('admin_menu_source_settings', $admin_menu_source_settings);
 }
-
-/**
- * Implements hook_disable().
- */
-function dkan_workflow_permissions_disable() {
-  // Remove workflow roles from roleassign_roles variable.
-  $roleassign_roles = variable_get('roleassign_roles', array());
-  $roles_rids = array_flip(user_roles());
-  $remove_roles = array(
-    'Workflow Contributor',
-    'Workflow Moderator',
-    'Workflow Supervisor',
-  );
-
-  foreach ($remove_roles as $role) {
-    unset($roleassign_roles[$roles_rids[$role]]);
-  }
-
-  variable_set('roleassign_roles', $roleassign_roles);
-}

--- a/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
+++ b/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Installation procedures for dkan_workflow_permissions.
@@ -11,29 +12,11 @@ function dkan_workflow_permissions_enable() {
   features_revert(array('dkan_workflow_permissions' => array('role_permission')));
   drupal_flush_all_caches();
 
-  // Add dkan workflow roles to roleassign config.
-  $roleassign_roles = variable_get('roleassign_roles', array());
-  $roles_rids = array_flip(user_roles());
-
-  $add_roles = array(
-    'Workflow Contributor',
-    'Workflow Moderator',
-    'Workflow Supervisor',
-  );
-
-  foreach ($add_roles as $role) {
-    if (isset($roles_rids[$role])) {
-      $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
-    }
-  }
-  variable_set('roleassign_roles', $roleassign_roles);
-
   // Set up source for the admin menu.
   _dkan_workflow_permissions_setup_admin_menu_source();
   drupal_flush_all_caches();
   features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 }
-
 
 /**
  * This helper function sets up the admin_menu_source module's configuration.


### PR DESCRIPTION
Issue:  CIVIC-5641

## Description

A client site was not passing workflow tests due to the roleassign_roles variable not getting updated from the hook_enable in dkan_workflow_permissions, moving the code to dkan_workflow fixes this issue.

## QA Steps

- [x] Tests pass (workflow.feature)

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
