### PR TITLE
Fixed data preview for geojson files on resources #CIVIC-5642

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Fix data preview with geojson files on resources
  - Added a filter in the workflow.feature to avoid issues for the amount of already existing nodes.
  - Added css for chart visualizaitons, fixes issue in IE.
  - Upgrade better_exposed_filters to v3.4.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,7 +4,7 @@ includes:
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
-  - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
+  - "https://raw.githubusercontent.com/NuCivic/recline/load_leaflet_geojson/recline.make"
 projects:
   admin_menu:
     version: '3.0-rc5'
@@ -276,7 +276,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      branch: load_leaflet_geojson
   ref_field:
     download:
       type: git


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5642

## Description

When you create a new resource with a geojson file the data preview fail and console show multiple errors.

## How to reproduce

1.  Go to create a new resource with geojson file for example https://s3.amazonaws.com/dkan-default-content-files/files/USA.geo.json. The data preview fail to load.

## QA Steps

- [ ] Go to create a new resource with geojson file https://s3.amazonaws.com/dkan-default-content-files/files/USA.geo.json
- [ ] On node view you should see a map with points from geojson file.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.

## PR related

- [ ] https://github.com/NuCivic/recline/pull/88
