### PR TITLE
Allow change site information info on theme settings page 5648

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added site details to settings nuboot_radix to allow change site name, slogan, e-amail address for site manager.
  - Added a filter in the workflow.feature to avoid issues for the amount of already existing nodes.
  - Added css for chart visualizaitons, fixes issue in IE.
  - Upgrade better_exposed_filters to v3.4.

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_roles_perms/dkan_sitewide_roles_perms.features.user_permission.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_roles_perms/dkan_sitewide_roles_perms.features.user_permission.inc
@@ -402,6 +402,7 @@ function dkan_sitewide_roles_perms_user_default_permissions() {
     'name' => 'administer site configuration',
     'roles' => array(
       'administrator' => 'administrator',
+      'site manager' => 'site manager',
     ),
     'module' => 'system',
   );

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_roles_perms/dkan_sitewide_roles_perms.features.user_permission.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_roles_perms/dkan_sitewide_roles_perms.features.user_permission.inc
@@ -402,7 +402,6 @@ function dkan_sitewide_roles_perms_user_default_permissions() {
     'name' => 'administer site configuration',
     'roles' => array(
       'administrator' => 'administrator',
-      'site manager' => 'site manager',
     ),
     'module' => 'system',
   );

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -36,7 +36,7 @@ Feature: Theme
     Then I should see "The configuration options have been saved"
 
   @noworkflow 
-  Scenario: Add custom logo
+  Scenario: Add custom site information
     Given I am logged in as "Site Manager"
     Then I am on "Settings" page
     And I should see "E-mail address"
@@ -46,6 +46,3 @@ Feature: Theme
     When I press "Save configuration"
     Then I wait for "3" seconds
     Then I should see "The configuration options have been saved"
-    Then I should see "sitename test"
-    Then I should see "slogan test"
-    Then I should see "test@example.com"

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -39,7 +39,7 @@ Feature: Theme
   Scenario: Add custom logo
     Given I am logged in as "Site Manager"
     Then I am on "Settings" page
-    And I should see "E-amil address"
+    And I should see "E-mail address"
     And I fill in "Site name" with "sitename test"
     And I fill in "Slogan" with "slogan test"
     And I fill in "E-mail address" with "test@example.com"

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -10,6 +10,7 @@ Feature: Theme
     Given users:
       | name    | mail                | roles                |
       | John    | john@example.com    | administrator         |
+      | Site Manager | sitemanager@example.com | site manager |
   
   @noworkflow 
   Scenario: Add custom logo
@@ -33,3 +34,18 @@ Feature: Theme
     When I press "Save configuration"
     Then I wait for "3" seconds
     Then I should see "The configuration options have been saved"
+
+  @noworkflow 
+  Scenario: Add custom logo
+    Given I am logged in as "Site Manager"
+    Then I am on "Settings" page
+    And I should see "E-amil address"
+    And I fill in "Site name" with "sitename test"
+    And I fill in "Slogan" with "slogan test"
+    And I fill in "E-mail address" with "test@example.com"
+    When I press "Save configuration"
+    Then I wait for "3" seconds
+    Then I should see "The configuration options have been saved"
+    Then I should see "sitename test"
+    Then I should see "slogan test"
+    Then I should see "test@example.com"

--- a/themes/nuboot_radix/theme-settings.php
+++ b/themes/nuboot_radix/theme-settings.php
@@ -81,7 +81,32 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
     ),
   );
 
+  $form['site_information'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Site details'),
+  );
+  $form['site_information']['site_name'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Site name'),
+    '#default_value' => variable_get('site_name', 'Drupal'),
+    '#required' => TRUE
+  );
+  $form['site_information']['site_slogan'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Slogan'),
+    '#default_value' => variable_get('site_slogan', ''),
+    '#description' => t("How this is used depends on your site's theme."),
+  );
+  $form['site_information']['site_mail'] = array(
+    '#type' => 'textfield',
+    '#title' => t('E-mail address'),
+    '#default_value' => variable_get('site_mail', ini_get('sendmail_from')),
+    '#description' => t("The <em>From</em> address in automated e-mails sent during registration and new password requests, and other notifications. (Use an address ending in your site's domain to help prevent this e-mail being flagged as spam.)"),
+    '#required' => TRUE,
+  );
+
   $form['#submit'][] = $theme . '_hero_system_theme_settings_form_submit';
+  $form['#submit'][] = $theme . '_site_information_theme_settings_form_submit';
 
   // Return the additional form widgets.
   return $form;
@@ -109,6 +134,15 @@ function _background_option_setting($element, &$form, &$form_state) {
       form_error($element, t('Must be a valid hexadecimal CSS color value.'));
     }
   }
+}
+
+/**
+ * Submit function for theme settings form information.
+ */
+function nuboot_radix_site_information_theme_settings_form_submit(&$form, &$form_state) {
+  variable_set('site_name', $form_state['values']['site_name']);
+  variable_set('site_slogan', $form_state['values']['site_slogan']);
+  variable_set('site_mail', $form_state['values']['site_mail']);
 }
 
 /**

--- a/themes/nuboot_radix/theme-settings.php
+++ b/themes/nuboot_radix/theme-settings.php
@@ -81,6 +81,8 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
     ),
   );
 
+  //Allow alter basic site information instead use admin/config/system/site-information
+  //We have a lot information into page site-information we don't want to show site managers
   $form['site_information'] = array(
     '#type' => 'fieldset',
     '#title' => t('Site details'),


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5648

## Description

Site manager can't change settings about site information.


## How to reproduce

1. Try to access to admin/config/system/site-information to change site information fields (site name, slogan, e-mail address)

## QA Steps

- [ ] Site manager can access to admin/appearance/settings/nuboot_radix and see a section for site information fields (site name, slogan, e-mail address).
- [ ] Site manager can change these fields and are showed on the site.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
