### PR TITLE
Add a tag @defaultHomepage to make a topic test skippable.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Added a tag @defaultHomepage to a topic test which relies on homepage content.
  - #1719 Added site details to settings nuboot_radix to allow change site name, slogan, e-amail address for site manager.
  - #1717 Upgrading Drupal to 7.54
  - #1712 Added a filter in the workflow.feature to avoid issues for the amount of already existing nodes.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
-7.x-1.x
+7.x-1.13.x
 --------------------------
- - Added a tag @defaultHomepage to a topic test which relies on homepage content.
+ - #1728 Added a tag @defaultHomepage to a topic test which relies on homepage content.
+
+7.x-1.13
+--------------------------
  - #1719 Added site details to settings nuboot_radix to allow change site name, slogan, e-amail address for site manager.
  - #1717 Upgrading Drupal to 7.54
  - #1712 Added a filter in the workflow.feature to avoid issues for the amount of already existing nodes.

--- a/test/features/topics.feature
+++ b/test/features/topics.feature
@@ -13,7 +13,7 @@ Feature: Topics
       | name         | url                                        |
       | Add Topic    | /admin/structure/taxonomy/dkan_topics/add  |
 
-  @api @Topics
+  @api @Topics @defaultHomepage
   Scenario: See topics on the homepage as anonymous user
     When I am on the homepage
     Then I should see "Topic1"


### PR DESCRIPTION
Issue: 5771

## Description

Client sites that don't have the Featured Topics block in the homepage have this test failing: https://github.com/NuCivic/dkan/blob/7.x-1.x/test/features/topics.feature#L17

## QA Steps

- [ ] Tests pass.
