### PR TITLE
Fix error message on front page after 1.13 upgrade

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.x
 --------------------------
+ - #1730 Fix logic error for front page in theme causing error messages on homepage
  - #1728 Added a tag @defaultHomepage to a topic test which relies on homepage content.
 
 7.x-1.13

--- a/themes/nuboot_radix/includes/panel.inc
+++ b/themes/nuboot_radix/includes/panel.inc
@@ -40,6 +40,7 @@ function nuboot_radix_preprocess(&$variables, $hook) {
 
   // Front page vars.
   $front_url = drupal_get_normal_path(variable_get('site_frontpage', 'node'));
+  $front_nid = NULL;
   $front = explode('/', $front_url);
   if( $front[0]=='node' && ctype_digit($front[1]) ) {
     $front_nid = $front[1];


### PR DESCRIPTION
Issue: CIVIC-5564

Fixes an error that appears on the front page after an upgrade to 1.13, observed on Pantheon.

UDPATE: confirmed on other invironments.

h2. To reproduce:

1. Build DKAN from a 1.12 tag (say, `7.x-1.12.13`)
2. Check out tag 7.x-1.13 and rebuild (if using ahoy, `git checkout 7.x-1-13`, `ahoy drush remake`
3. Run `drush updatedb`
4. Navigate to the front page. You should see an error message about `$front_nid` not being a declared variable

h2. QA steps

* Reproduce using steps above
* Check out this branch. Error should be gone