### PR TITLE
Fix dkan extent block with revised library name CIVIC-5775

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -160,7 +160,7 @@ function dkan_sitewide_data_extent_block() {
     $wrapper = entity_metadata_wrapper('node', $node);
     $spatial = $wrapper->field_spatial->value();
     if ($spatial && $spatial['wkt']) {
-      drupal_add_library('leaflet_widget', 'leaflet_core');
+      drupal_add_library('leaflet_widget', 'leaflet');
       $features = array(leaflet_widget_geojson_feature($spatial['wkt']));
       $geojson = drupal_json_encode(leaflet_widget_geojson_feature_collection($features));
       $output = "var dataExtent = " . $geojson;


### PR DESCRIPTION
Issue: CIVIC-5775

## Description

Error: `Uncaught ReferenceError: L is not defined`

Change in the library name causing the data extent block to not function properly.

## How to reproduce

1. View a dataset with a geographical spacial value (dataset/london-deprivation-index)

## QA Steps

- [ ] Confirm the Data Extent block is working
https://ba15eb9d-e36c-48e4-821f-df693ed795d7--pr-1731.probo.build/dataset/london-deprivation-index

## Reminders
- [ ] There is test for the issue. >> test will be a separate ticket
- [ ] CHANGELOG updated. >> fixes bug not exposed to users yet
- [x] Coding standards checked. 
