### PR TITLE
Better upgrade instructions for 1.13

### DIFF
--- a/docs/releases/notes/1.13.md
+++ b/docs/releases/notes/1.13.md
@@ -153,6 +153,12 @@ We have moved DKAN's technical documentation from the Drupal-based site where it
 
 ## Special Notes
 
+**Front Page** - [Upgrade Instructions](https://github.com/NuCivic/dkan/blob/7.x-1.x/modules/dkan/dkan_fixtures/modules/dkan_default_content/README.md)
+
+Front page configuration has been removed from features and the dkan_sitewide_demo_front feature has been deprecated. To save existing front page configuration, run the following command `drush php-eval "dkan_sitewide_convert_panel_page('<page-name>', TRUE);"` This will convert the front page to a panelized node.
+
+Also note that if you use any of the default DJAN blocks for your front page, some may dissapear after the upgrade. You should be able to restore them by editing the panel and finding them in the blocks list.
+
 **Added Modules**
 
   - DKAN Harvest
@@ -178,10 +184,6 @@ We have moved DKAN's technical documentation from the Drupal-based site where it
 To remove newly untracked files run:
 
   `git clean -f`
-
-**Front Page** - [Upgrade Instructions](https://github.com/NuCivic/dkan/blob/7.x-1.x/modules/dkan/dkan_fixtures/modules/dkan_default_content/README.md)
-
-Front page configuration has been removed from features and the dkan_sitewide_demo_front feature has been deprecated. To save existing front page configuration, run the following command `drush php-eval "dkan_sitewide_convert_panel_page(<page-name>);"` This will convert the front page to a panelized node
 
 ## Known issues
 

--- a/docs/releases/notes/1.13.md
+++ b/docs/releases/notes/1.13.md
@@ -157,7 +157,7 @@ We have moved DKAN's technical documentation from the Drupal-based site where it
 
 Front page configuration has been removed from features and the dkan_sitewide_demo_front feature has been deprecated. To save existing front page configuration, run the following command `drush php-eval "dkan_sitewide_convert_panel_page('<page-name>', TRUE);"` This will convert the front page to a panelized node.
 
-Also note that if you use any of the default DJAN blocks for your front page, some may dissapear after the upgrade. You should be able to restore them by editing the panel and finding them in the blocks list.
+Also note that if you use any of the default DJAN blocks for your front page, some may dissapear after the upgrade. A user with the administrator role should be able to restore them by editing the panel and finding them in the Miscellaneous list.
 
 **Added Modules**
 

--- a/docs/releases/notes/1.13.md
+++ b/docs/releases/notes/1.13.md
@@ -157,7 +157,7 @@ We have moved DKAN's technical documentation from the Drupal-based site where it
 
 Front page configuration has been removed from features and the dkan_sitewide_demo_front feature has been deprecated. To save existing front page configuration, run the following command `drush php-eval "dkan_sitewide_convert_panel_page('<page-name>', TRUE);"` This will convert the front page to a panelized node.
 
-Also note that if you use any of the default DJAN blocks for your front page, some may dissapear after the upgrade. A user with the administrator role should be able to restore them by editing the panel and finding them in the Miscellaneous list.
+Also note that if you use any of the default DKAN blocks for your front page, some may dissapear after the upgrade. A user with the administrator role should be able to restore them by editing the panel and finding them in the Miscellaneous list.
 
 **Added Modules**
 


### PR DESCRIPTION
CIVIC-5798 

Upgrading DKAN to 1.13 can cause certain front page blocks to disspear, as their machine names have changed. It's unlikely that anyone is using these in their front page in production, as they're just default content, but improving the upgrade instructions just in case.

Also adding quote marks and the TRUE parameter to the "conversion function" to more closely reflect usage for front page conversion.