### PR TITLE
[CIVIC-5631] Site Managers should be able to check POD validation

### DIFF
--- a/test/features/pod.feature
+++ b/test/features/pod.feature
@@ -73,3 +73,11 @@ Feature: Project Open Data + Open Data Federal Extras
     #Cleanup configuration
     Given I "disable" the "Strict POD validation" on DKAN Dataset Forms
 
+  @api @here
+  Scenario: Site Manager role should have access to the validation page
+    Given pages:
+      | name           | url                                     |
+      | POD Validation | /admin/config/services/odsm/validate/pod |
+    And I am logged in as a user with the "site manager" role
+    When I am on the "POD Validation" page
+    Then I should not see "Access Denied"


### PR DESCRIPTION
Issue: CIVIC-5631

## Description

Site Managers don't have a menu item for checking the POD Validation.

Tested on current 1.13 dev branch and VA user QA beta test site.

## Steps to Reproduce
- Given I am logged in as a Site Manager
- When I look at the 'Site Configuration' > 'Open Data Schema Mapper' menu
- Then I should see a 'Project Open Data validation' item

## Acceptance Criteria
- Site Managers should be able to use the POD validator via a menu item.

## QA Steps
- [ ] You should not be able to reproduce the issue.

## Merge process
- [ ] This only contain the behat test. Need [[CIVIC-5631] Site Managers should be able to check POD validation #86](https://github.com/NuCivic/open_data_schema_map/pull/86) to be merged first.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
