### PR TITLE
Update DKAN api link to use the RTD documentation page.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.x
 --------------------------
+ - #1747 Update DKAN API link to use the RTD documentation page.
  - #1730 Fix logic error for front page in theme causing error messages on homepage
  - #1728 Added a tag @defaultHomepage to a topic test which relies on homepage content.
  - #5807 Fix panelizer permissions to hide 'Customize Display' button

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -434,7 +434,7 @@ function dkan_sitewide_other_access() {
       ),
       'dkan_api' => array(
         '#type' => 'markup',
-        '#markup' => '<p><small>' . t('via the  <a href="http://dkan.readthedocs.io">DKAN API</a>') . '</small></p>',
+        '#markup' => '<p><small>' . t('via the  <a href="http://docs.getdkan.com/en/latest/apis/index.html">DKAN API</a>') . '</small></p>',
       ),
     );
 

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -434,7 +434,7 @@ function dkan_sitewide_other_access() {
       ),
       'dkan_api' => array(
         '#type' => 'markup',
-        '#markup' => '<p><small>' . t('via the  <a href="http://docs.getdkan.com">DKAN API</a>') . '</small></p>',
+        '#markup' => '<p><small>' . t('via the  <a href="http://dkan.readthedocs.io">DKAN API</a>') . '</small></p>',
       ),
     );
 


### PR DESCRIPTION
Issue: CIVIC-4456

## Description

Updated DKAN api link to use the RTD documentation page instead of the docs.getdkan.com

## How to reproduce

1.  Go to a dataset page like dataset/wisconsin-polling-places
2. Look in the 'Other access' box in the sidebar left
3. Click on the link "DKAN API"
4. You'll be redirected to the page docs.getdkan.com

## QA Steps

1.  Go to a dataset page like dataset/wisconsin-polling-places
2. Look in the 'Other access' box in the sidebar left
3. Click on the link "DKAN API"
4. You'll be redirected to the page dkan.readthedocs.io
