### PR TITLE
Add @no-main-menu tag to tests that require the main menu CIVIC-5746

### DIFF
--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -39,11 +39,9 @@ Feature: Resource
       | Resource 04 | Group 01  | csv    | Dataset 01 | Katie    | No        | Yes         |
       | Resource 05 | Group 01  | csv    | Dataset 02 | Celeste  | Yes       | Yes         |
 
-  @api @no-main-menu
+  @api
   Scenario: View published resource
-    Given I am on the homepage
-    And I follow "Datasets"
-    And I click "Dataset 01"
+    Given I am on "Dataset 01" page
     When I click "Resource 01"
     Then I am on the "Resource 01" page
 

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -39,7 +39,7 @@ Feature: Resource
       | Resource 04 | Group 01  | csv    | Dataset 01 | Katie    | No        | Yes         |
       | Resource 05 | Group 01  | csv    | Dataset 02 | Celeste  | Yes       | Yes         |
 
-  @api
+  @api @no-main-menu
   Scenario: View published resource
     Given I am on the homepage
     And I follow "Datasets"

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -135,6 +135,7 @@ Feature: Widgets
     And I wait for "First spot"
     Then I should see "First spot" in the "content"
 
+  @no-main-menu
   Scenario: Adds "New Submenu Widget" block to home page using panels ipe editor
     Given the cache has been cleared
     When I follow "Submenu"


### PR DESCRIPTION
Issue: CIVIC-5746

## Description

Clients that disable the main menu will fail two tests that require the main menu links, adding a tag so we can skip these tests when we need to.
