### PR TITLE
1.12.x updates CIVIC-5955

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 - Added css for chart visualizaitons, fixes issue in IE.
 - Updates drupal core to 7.53
+- Upgrade visualization_entity to 7.x-1.1
 
 7.x-1.12.13 2017-01-04
 ----------------------

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -161,7 +161,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: CIVIC-5955
+      branch: release-1-12
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -161,7 +161,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/nuboot_radix.git
-      branch: release-1-12
+      branch: CIVIC-5955
     type: theme
   radix:
     type: theme

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -5,7 +5,7 @@ includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
-- https://raw.githubusercontent.com/NuCivic/visualization_entity/CIVIC-5964/visualization_entity.make
+- https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.1/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
 projects:
@@ -56,7 +56,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: CIVIC-5964
+      tag: 7.x-1.x
     type: module
   admin_menu:
     version: 3.0-rc5

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -56,7 +56,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: 7.x-1.x
+      tag: 7.x-1.1
     type: module
   admin_menu:
     version: 3.0-rc5

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -56,7 +56,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: CIVIC-5964
+      branch: CIVIC-5964
     type: module
   admin_menu:
     version: 3.0-rc5

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -5,7 +5,7 @@ includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
 - https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
-- https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
+- https://raw.githubusercontent.com/NuCivic/visualization_entity/CIVIC-5964/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
 - modules/dkan/dkan_topics/dkan_topics.make
 projects:
@@ -56,7 +56,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: 7.x-1.0-beta1
+      tag: CIVIC-5964
     type: module
   admin_menu:
     version: 3.0-rc5

--- a/modules/dkan/dkan_topics/dkan_topics.make
+++ b/modules/dkan/dkan_topics/dkan_topics.make
@@ -17,9 +17,6 @@ projects[entity_path][version] = 1.x-dev
 projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff
 projects[globalredirect][version] = 1.5
 
-; Patches
-projects[views][patch][1388684] = https://www.drupal.org/files/views_taxonomy_entity_uri-1388684-15.patch
-
 ; Libraries
 libraries[spectrum][type] = libraries
 libraries[spectrum][download][type] = git

--- a/test/features/home.feature
+++ b/test/features/home.feature
@@ -24,7 +24,7 @@ Feature: Homepage
   @customizable
   Scenario: Viewing footer
     Given I am on the homepage
-    Then I should see "Powered by DKAN, a project of NuCivic"
+    Then I should see "Powered by DKAN, a project of Granicus"
 
   @customizable
   Scenario: Viewing tags


### PR DESCRIPTION
Issue: CIVIC-5955 & CIVIC-5964

## Description

1. Fix branding on the 1.12 branch
2. Remove dataproxy option from chart source type field
3. Update test on copyright
4. Remove patch for views, no longer applies after views upgrade to 3.15 https://github.com/NuCivic/dkan_dataset/pull/298

## CIVIC-5955 QA Steps
Confirm the copyright line says `Powered by DKAN, a project of Granicus` and the links are correct

## CIVIC-5964 QA steps
1. Create a chart
2. Under Load Data, the source type field should only display CSV and Google Spreadsheet as options. 

![add_chart___dkan](https://cloud.githubusercontent.com/assets/314172/23806129/1e235d38-0586-11e7-9dcb-98dd4f1e8f31.png)

## Merge process
- [x] Merge https://github.com/NuCivic/visualization_entity/pull/59
- [x] Merge https://github.com/NuCivic/nuboot_radix/pull/104
- [x] Update drupal-org.make to restore `release-1-12` branch for nuboot_radix and `7.x-1.0-beta1` (or 7.x-1.0) for visualization_entity
- [x] Merge this PR for the test change

- [ ] cut a new release....?

