### PR TITLE
Security update for services module #CIVIC-5965

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.13.x
+ - #1783 Update services to 3.19
  - #1781 Update views to 3.15 and remove patch 1388684.
  - #1751 Add POD validation link to command center menu for site manager access.
  - #1762 Re-number update hooks that were mixed up during release integration.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -312,7 +312,7 @@ projects:
   select_or_other:
     version: '2.22'
   services:
-    version: '3.17'
+    version: '3.19'
   simple_gmap:
     version: '1.3'
   strongarm:


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5965

## Description

We need to update service to 3.19. The last version fix some problems with security. 

## QA Steps

- [ ] Check service module version is 3.19

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
