### PR TITLE
Update visualization_entity to 1.1 CIVIC-2768

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.13.x
+ - #1794 Update visualization_entity to 1.1
  - #1781 Update views to 3.15 and remove patch 1388684.
  - #1751 Add POD validation link to command center menu for site manager access.
  - #1762 Re-number update hooks that were mixed up during release integration.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.1/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -345,7 +345,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: 7.x-1.0
+      tag: 7.x-1.1
     type: module
   workbench:
     version: '1.2'


### PR DESCRIPTION
Issue: CIVIC-2768 CIVIC-5964

## Description

Update visualization entity to 7.x-1.1

Both 1.12 and 1.13 will use visualization_entity 1.1, once dkan 1.14 is released we will switch to using the same tag name as the dkan core tag

## QA Steps

- [x] visualization_entity is using 1.1

1. Create a chart
2. Under Load Data, the source type field should only display CSV and Google Spreadsheet as options. 

![add_chart___dkan](https://cloud.githubusercontent.com/assets/314172/23805039/f087a45a-0581-11e7-86ac-f09bc3335cfb.png)
## Merge process

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
