### PR TITLE
Update front page test on topics.feature

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.13.x
+ - #1795 Update front page test on topics.feature with @customizable.
  - #1794 Update visualization_entity to 1.1
  - #1781 Update views to 3.15 and remove patch 1388684.
  - #1751 Add POD validation link to command center menu for site manager access.

--- a/test/features/topics.feature
+++ b/test/features/topics.feature
@@ -13,7 +13,7 @@ Feature: Topics
       | name         | url                                        |
       | Add Topic    | /admin/structure/taxonomy/dkan_topics/add  |
 
-  @api @Topics @defaultHomepage
+  @api @Topics @defaultHomepage @customizable
   Scenario: See topics on the homepage as anonymous user
     When I am on the homepage
     Then I should see "Topic1"


### PR DESCRIPTION
Issue: CIVIC-5746

## Description

topics front page test fails if client site is not using the featured topics block on the front page.

## QA Steps

- [x] tests pass.
