### PR TITLE
Add Support for Contact Name and Email import in Harvest

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.13.x
+ - #1796 Fix Harvest support for contact name and contact email.
  - #1783 Update services to 3.19
  - #1794 Update visualization_entity to 1.1
  - #1781 Update views to 3.15 and remove patch 1388684.

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -80,64 +80,6 @@ class DatajsonHarvestMigration extends HarvestMigration {
   }
 
   /**
-   * Creates list of fields for Data.json Dataset.
-   */
-  public function getDataJsonDatasetFields($version = '1.1') {
-    $common_fields = array(
-        // “Common Core” Required Fields.
-      "title" => "Title",
-      "description" => "Description",
-      "keyword" => "Tags",
-      "modified" => "Last Update",
-      "publisher" => "Publisher",
-      "contactPoint" => "Contact Name",
-      "identifier" => "Unique Identifier",
-      "accessLevel" => "Public",
-        // “Common Core” Required-if-Applicable Fields.
-      "bureauCode" => " Bureau Code",
-      "programCode" => "Program Code",
-      "license" => "License",
-      "spatial" => "Spatial",
-      "temporal" => " Temporal",
-        // Beyond Common Core.
-      "dataQuality" => " Data Quality",
-      "distribution" => "Distribution",
-      "issued" => "Release Date",
-      "language" => " Language",
-      "references" => " Related Documents ",
-      "systemOfRecords" => " System of Records",
-    );
-    if ($version == '1.0') {
-      return $common_fields + array(
-        "mbox" => "Contact Email",
-        "accessLevelComment" => " Access Level Comment",
-        "accessURL" => "Download",
-        "webService" => " Endpoint ",
-        "format" => " Format",
-        // Beyond Common Core.
-        "theme" => "Category",
-        "dataDictionary" => "Data Dictionary",
-        "accrualPeriodicity" => "Frequency",
-        "landingPage" => "Homepage",
-        "PrimaryITInvestmentUII" => "Primary IT Investment",
-      );
-    }
-    elseif ($version == '1.1') {
-      return $common_fields + array(
-        "rights" => " Rights",
-        "accrualPeriodicity" => " Frequency",
-        "conformsTo" => " Data Standard URI",
-        "describedBy" => "Data Dictionary",
-        "describedByType" => "Data",
-        "isPartOf" => " Collection",
-        "landingPage" => "Homepage",
-        "primaryITInvestmentUII" => "Primary",
-        "theme" => "Theme",
-      );
-    }
-  }
-
-  /**
    * Implements prepareRow.
    */
   public function prepareRow($row) {

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -41,8 +41,6 @@ class DatajsonHarvestMigration extends HarvestMigration {
     $this->addFieldMapping('changed', 'modified');
     $this->addFieldMapping('created', 'issued');
     $this->addFieldMapping('field_public_access_level', 'accessLevel');
-    $this->addFieldMapping('field_contact_name', 'contactPointName');
-    $this->addFieldMapping('field_contact_email', 'mbox');
     $this->addFieldMapping('uuid', 'identifier');
     $this->addFieldMapping('field_license', 'license');
     $this->addFieldMapping('field_spatial_geographical_cover', 'spatial');
@@ -146,6 +144,16 @@ class DatajsonHarvestMigration extends HarvestMigration {
     parent::prepareRow($row);
     if (property_exists($row, 'accrualPeriodicity')) {
       $row->accrualPeriodicity = dkan_dataset_content_types_iso2frequency($row->accrualPeriodicity);
+    }
+
+    // Process contact name and email.
+    if (is_object($row->contactPoint)
+      && $row->contactPoint->hasEmail) {
+      $row->contact_email = str_replace("mailto:", "", $row->contactPoint->hasEmail) ? str_replace("mailto:", "", $row->contactPoint->hasEmail) : $row->contactPoint->hasEmail;
+      $row->contact_name = isset($row->contactPoint->fn) ? $row->contactPoint->fn : '';
+      if (!filter_var($row->contact_email, FILTER_VALIDATE_EMAIL)) {
+        $row->contact_email = '';
+      }
     }
   }
 

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -90,6 +90,17 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("95f8eac4-fd1f-4b35-8472-5c87e9425dfa", $dataset->uuid->value());
   }
 
+
+  /**
+   * Test Contact.
+   *
+   * @depends testDatasetCount
+   */
+  public function testContact($dataset) {
+    $this->assertEquals("Stefanie Gray", $dataset->field_contact_name->value());
+    $this->assertEquals("stefanie@nucivic.com", $dataset->field_contact_email->value());
+  }
+
   /**
    * Test resources.
    *


### PR DESCRIPTION
Issue: CIVIC-5989

h2. Description
Harvesting a POD source is not correctly importing the contact name and contact email.

h2. Acceptance Criteria
1. Fix the harvest to make contact name and contact email supported.
2. Add unit tests for importing contact name and email.

## How to reproduce

1. Create a harvest source.
2. Harvest
3. **Expected**: Contact name and email are imported in destination dataset.
**Actual**: No contact name and email imported.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
