### PR TITLE
update Groups page view to sort alphabetically

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -1076,6 +1076,16 @@ function dkan_dataset_groups_views_default_views() {
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
   $handler->display->display_options['defaults']['hide_admin_links'] = FALSE;
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Title */
+  $handler->display->display_options['sorts']['title']['id'] = 'title';
+  $handler->display->display_options['sorts']['title']['table'] = 'node';
+  $handler->display->display_options['sorts']['title']['field'] = 'title';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
   $handler->display->display_options['path'] = 'groups';
   $export['groups_page'] = $view;
 


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5990

## Description

Currently the Groups page sorts groups by the date when they were last added, which may be appropriate for a 'recently added groups' block but not for a page that lists all groups on the website. In NCS-490, Louisville expressly asked for the groups page to sort alphabetically. I think this should be the standard way that groups are sorted in DKAN.

- [ ] The groups page lists groups in an order that is intuitively understandable to site visitors.
- [ ] The groups page lists groups in alphabetical order.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
