### PR TITLE
Switch access to featured groups sort order view from role to permission

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.13.x
+ - #1803 Fix broken access to featured groups sort order view. 
  - #1796 Fix Harvest support for contact name and contact email.
  - #1795 Update front page test on topics.feature with @customizable.
  - #1783 Update services to 3.19

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -185,10 +185,8 @@ function dkan_dataset_groups_views_default_views() {
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Featured Groups Sort Order';
   $handler->display->display_options['defaults']['access'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'role';
-  $handler->display->display_options['access']['role'] = array(
-    4 => '4',
-  );
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'administer DKAN configuration';
   $handler->display->display_options['defaults']['pager'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'none';
   $handler->display->display_options['pager']['options']['offset'] = '0';


### PR DESCRIPTION
Release glitch

## Description

Client sites may have various role ids for the site manager role. The featured groups sort order view has access control set to the role, which will break if the role id is not 4. Need to switch back to a permission.

## Acceptance Critera
Tests pass on client site
