### PR TITLE
Remove project=dkan from dkan_sitewide.info

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.info
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.info
@@ -2,7 +2,6 @@ name = DKAN Sitewide
 description = Sitewide elements for DKAN.
 core = 7.x
 package = DKAN
-project = "dkan"
 dependencies[] = colorizer
 dependencies[] = conditional_styles
 dependencies[] = ctools


### PR DESCRIPTION
Issue: CIVIC-6049
Issue: CIVIC-5774
## Description

When the update module is enabled we have undefined index errors on the dkan modules.

## Merge process

This can be merged after https://github.com/NuCivic/jenkins_release_n_update_builds/pull/19

