### PR TITLE
[CIVIC-6096] Use "accessURL" during resources harvest if "downloadURL" field is not available

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.13.x
 ----------
  - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
+ - #1820 Use "accessURL" during resources harvest if "downloadURL" field is not available.
 
 
 7.x-1.13.3-RC1

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -185,7 +185,13 @@ class DatajsonHarvestMigration extends HarvestMigration {
     $resources = array();
 
     foreach ($resources_row_data as $resource_row_data) {
-      $resource = $this->prepareResourceHelper($resource_row_data->downloadURL,
+      // Fallback to the accessURL if the downloadURL is not available.
+      $url = $resource_row_data->downloadURL;
+      if (empty($url)) {
+        $url = $resource_row_data->accessURL;
+      }
+
+      $resource = $this->prepareResourceHelper($url,
         $resource_row_data->format,
         $resource_row_data->title,
         NULL,

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -558,6 +558,32 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
+   * Test harvest source with resource with accessURL only.
+   */
+  public function testResourceAccessUrl() {
+    // Harvest the source.
+    dkan_harvest_cache_sources(array(self::getResourceAccessUrl()));
+    dkan_harvest_migrate_sources(array(self::getResourceAccessUrl()));
+
+    $migration = dkan_harvest_get_migration(self::getResourceAccessUrl());
+    $migrationMap = $this->getMapTableFromMigration($migration);
+
+    $dest_ids = array_map(function ($mapRecord) {
+      return $mapRecord->destid1;
+    }, $migrationMap);
+
+    $this->assertEquals(1, count($dest_ids));
+
+    $dataset = entity_metadata_wrapper('node', array_pop($dest_ids));
+
+    $this->assertEquals(1, count($dataset->field_resources));
+    $resource_ids = $dataset->field_resources->value();
+    $resource_emw = entity_metadata_wrapper('node', array_pop($resource_ids));
+    $this->assertEmpty($resource_emw->field_link_remote_file->value());
+    $this->assertEquals("http://demo.getdkan.com/", $resource_emw->field_link_api->url->value());
+  }
+
+  /**
    * Check Error logging for the harvest.
    *
    * Ticket: https://jira.govdelivery.com/browse/CIVIC-4498
@@ -712,6 +738,13 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    */
   public static function getResourceTemporal() {
     return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_temporal.json');
+  }
+
+  /**
+   * Test Harvest Source.
+   */
+  public static function getResourceAccessUrl() {
+    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_resource_accessurl.json');
   }
 
   /**

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_resource_accessurl.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_resource_accessurl.json
@@ -1,0 +1,42 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://demo.getdkan.com/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "@type": "dcat:Dataset",
+      "accessLevel": "public",
+      "contactPoint": {
+        "fn": "Stefanie Gray",
+        "hasEmail": "mailto:stefanie@nucivic.com"
+      },
+      "description": "<p>Information about the state workforce, broken down into four generational cohorts.</p> <p><strong>Note:</strong> This dataset has been given a vague name because it is anonymized demo data, not actual state data.</p> ",
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "accessURL": "http://demo.getdkan.com/",
+          "mediaType": "text/csv",
+          "format": "csv",
+          "description": "<p>Population of state employees broken down into Gen X, Gen Y, Baby Boomers and Over 65+.</p> ",
+          "title": "TEST - Workforce By Generation (2011-2015)"
+        }
+      ],
+      "identifier": "95f8eac4-fd1f-4b35-8472-5c87e9425dfa",
+      "keyword": [
+        "demographics",
+        "socioeconomic",
+        "workforce"
+      ],
+      "license": "http://opendefinition.org/licenses/gfdl/",
+      "modified": "2016-07-21",
+      "temporal": "2011/2015",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "TEST - State Economic Council"
+      },
+      "title": "TEST - State Workforce by Generation (2011-2015)"
+    }
+  ]
+}


### PR DESCRIPTION
Issue: CIVIC-6096

## Description
The POD schema specification states that each distribution should contain one `accessURL` or `downloadURL`. But currently for POD harvest we only expecting a `downloadURL` and drop the resource from the import if it is not specified. The resource import code have a fully featured URL type detection logic and will manage to properly classify any URL that we pass to be it an `accessURL` or the `downloadURL`.

## Steps to Reproduce
1. Create a Harvest Source. The Source POD should have resource(s) with only the {{accessURL}} is set.
2. Run harvest on the source.
**Expected**: Dataset created with all the associated resources.
**Actual**: Dataset is created, but the resources with only {{accessURL}} defined are not imported.

## Acceptance Criteria
1. The harvest should fallback to the {{accessURL}} field if the {{downloadURL}} is not available.

## Test Updates
1. Add test coverage for the case of missing {{downloadURL}} on the resource distribution.

## Documentation Updates
No documentation update needed at first glance.

## Merge process
None

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
