### PR TITLE
[CIVIC-6108] Field Frequency Harvest POD integration is missing support for "irregular" value

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 7.x-1.13.x
 ----------
  - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
-
+ - #1828 Field Frequency Harvest POD integration is missing support for "irregular" value.
 
 7.x-1.13.3-RC1
 --------------

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -187,6 +187,7 @@ function dkan_dataset_content_types_iso_frecuency_map() {
     'R/P0.5M' => 18,
     'R/P4M' => 17,
     'R/P1W' => 1,
+    'irregular' => 5,
   );
 }
 

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -131,6 +131,17 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
+   * Test accrualPeriodicity field.
+   *
+   * @depends testDatasetCount
+   */
+  public function testAccrualPeriodicity($dataset) {
+    $optionsList = $dataset->field_frequency->optionsList();
+    $frequency_key = $dataset->field_frequency->value();
+    $this->assertEquals('Irregularly', $optionsList[$frequency_key]);
+  }
+
+  /**
    * Test resources.
    *
    * @depends testDatasetCount

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_original.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_original.json
@@ -53,6 +53,7 @@
         "@type": "org:Organization",
         "name": "TEST - State Economic Council"
       },
+      "accrualPeriodicity": "irregular",
       "title": "TEST - State Workforce by Generation (2011-2015)"
     }
   ]


### PR DESCRIPTION
Issue: CIVIC-6108

## Description
As defined by the [POD specification|https://project-open-data.cio.gov/v1.1/schema/#accrualPeriodicity], in addition of the standard ISO 8601 periodical values the `accrualPeriodicity` field can also have the **irregular** value which maps to an undetermined period.

## Steps to Reproduce
1. Create a POD Harvest Source. The source should have dataset(s) with the `accrualPeriodicity` field set to `irregular`.
2. Harvest the source.
3. **Expected**: The dataset imported should have the correct `field_frequency` value.
**Actual**: `field_frequency` is not correctly set.

## Acceptance Criteria
* `field_frequency` import during POD harvest should correctly support the `irregular` value.

## Test Updates
* Add tests for the `accrualPeriodicity` POD field import.

## Documenation Updates
None that should be needed.

## Merge process
None.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
