### PR TITLE
Update t() arguments naming scheme

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.x
 ----------
+ - #1829 Improve waring message for missing properties during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset
  - #1726 Fixed broken links in search results to nodes without aliases

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.13.x
 ----------
- - #1829 Improve waring message for missing properties during datajson harvest cache.
+ - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset
  - #1726 Fixed broken links in search results to nodes without aliases

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -32,12 +32,12 @@ function dkan_harvest_datajson_harvest_source_types() {
  * dkan_harvest source types.
  *
  * @param HarvestSource $source
- *        The source object from a datajson endpoint to cache.
+ *   The source object from a datajson endpoint to cache.
  * @param int $harvest_updatetime
- *        Last harvest update time.
+ *   Last harvest update time.
  *
  * @return HarvestCache
- *         A harvest cache object.
+ *   A harvest cache object.
  */
 function dkan_harvest_datajson_cache(HarvestSource $source, $harvest_updatetime) {
   // This is needed for remote uri.
@@ -79,16 +79,16 @@ function dkan_harvest_datajson_cache(HarvestSource $source, $harvest_updatetime)
  * Set a nested value inside an array.
  *
  * @param array &$obj
- *        Original array.
+ *   Original array.
  * @param string $path
- *        Path to the value (path.to.the.0.value).
+ *   Path to the value (path.to.the.0.value).
  * @param object $value
- *        Value to set.
+ *   Value to set.
  * @param bool $override
- *        If should or shouldn't override an existing value.
+ *   If should or shouldn't override an existing value.
  *
  * @return array
- *         Modified array.
+ *   Modified array.
  */
 function dkan_harvest_datajson_set_value(&$obj, $path, $value, $override = FALSE) {
   $updated = FALSE;
@@ -100,7 +100,9 @@ function dkan_harvest_datajson_set_value(&$obj, $path, $value, $override = FALSE
       $branch = &$branch[$key];
     }
     else {
-      drupal_set_message(t("Key @path was automatically generated because doesn't exists in the dataset @title. Make sure you want to modify the key @path", array('path' => $path, 'title' => $obj['title'])), 'warning');
+      drupal_set_message(t('Key "@path" was automatically generated because doesn\'t exists in the dataset "@title". Make sure you want to modify the key "@path".',
+        array('@path' => $path, '@title' => $obj['title'])),
+      'warning');
       $branch[$key] = array();
       $branch = &$branch[$key];
     }
@@ -124,7 +126,7 @@ function dkan_harvest_datajson_set_value(&$obj, $path, $value, $override = FALSE
  *   Path to the value (path.to.the.0.value).
  *
  * @return mixed
- *         Modified array
+ *   Modified array
  */
 function dkan_harvest_datajson_get_value($obj, $path) {
   $keys = explode('.', $path);
@@ -146,11 +148,11 @@ function dkan_harvest_datajson_get_value($obj, $path) {
  * Cache the datajson_1_1_json datasets.
  *
  * @param array $data
- *        Harvested data.
+ *   Harvested data.
  * @param HarvestSource $source
- *        Harvest source instance.
+ *   Harvest source instance.
  * @param int $harvest_updatetime
- *        Last harvest update time.
+ *   Last harvest update time.
  *
  * @return HarvestCache
  *   HarvestCache object


### PR DESCRIPTION
## Description
Update argument variable names to match template string.

This updates the argument variable names to match the t() template naming. The argument are missing the "@" sign which is generating messaging like this:

> Key **@license** was automatically generated because doesn't exists in the dataset **@Nursing Home Compare**. Make sure you want to modify the key **@license**


Instead of the expected message:

> Key **license** was automatically generated because doesn't exists in the dataset **Nursing Home Compare**. Make sure you want to modify the key **license**