### PR TITLE
[CIVIC-6112] Set fallback in case of issued field is not provided during POD Harvest

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 7.x-1.13.x
 ----------
  - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
-
+ - #1832 Fallback to modified date for field_harvest_source_issued if not available during POD Harvest.
 
 7.x-1.13.3-RC1
 --------------

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -83,6 +83,13 @@ class DatajsonHarvestMigration extends HarvestMigration {
   public function prepareRow($row) {
     parent::prepareRow($row);
 
+    // The issued field is not required. When missing, use the modified field to
+    // have consistent dataset display.
+    // https://project-open-data.cio.gov/v1.1/schema#issued
+    if (!isset($row->issued)) {
+      $row->issued = $row->modified;
+    }
+
     if (property_exists($row, 'accrualPeriodicity')) {
       $row->accrualPeriodicity = dkan_dataset_content_types_iso2frequency($row->accrualPeriodicity);
     }

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -593,7 +593,6 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * drops some taxonomies which will make following tests fail.
    */
   public function testHarvestError() {
-    return;
     // Delete the format vocabulary.
     $vocab_format = taxonomy_vocabulary_machine_name_load('format');
     if ($vocab_format) {

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_noissued.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_noissued.json
@@ -1,0 +1,41 @@
+{
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@id": "http://demo.getdkan.com/data.json",
+    "@type": "dcat:Catalog",
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "dataset": [
+        {
+            "@type": "dcat:Dataset",
+            "accessLevel": "public",
+            "contactPoint": {
+                "fn": "admin",
+                "hasEmail": "mailto:admin@example.com"
+            },
+            "description": "<p>Polling places in the state of Wisconsin</p>",
+            "distribution": [
+                {
+                    "@type": "dcat:Distribution",
+                    "description": "No description provided",
+                    "downloadURL": "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv",
+                    "format": "csv",
+                    "mediaType": "text/csv"
+                }
+            ],
+            "identifier": "90a2b708-7fea-4b92-8aee-43c4cfdd5f48",
+            "keyword": [
+                "election"
+            ],
+            "language": [
+                "en"
+            ],
+            "license": "http://opendefinition.org/licenses/cc-by/",
+            "modified": "2015-07-11",
+            "publisher": {
+                "@type": "org:Organization",
+                "name": "Geospatial Data Explorer Examples"
+            },
+            "title": "Wisconsin Polling Places TEST"
+        }
+    ],
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json"
+}


### PR DESCRIPTION
Issue: CIVIC-6112

## Description
As per the [POD schema documentation](https://project-open-data.cio.gov/v1.1/schema/#issued), the `issued` field is not required. Missing this field from a source dataset will not break the harvest process and will not generate any user facing errors. But can lead to a very confusing dataset view page where the `Release Date` will be the date this dataset is harvested which is more recent then the `Modified Date` as parsed from the POD `modified` field.


## Steps to Reproduce
1. Create a Harvest Source. One of the source dataset should not have the optional {{issued}} POD field.
2. Harvest the source.
3. **Expected**: The destination dataset on Dkan have a `Modified Date` that is equal or more recent then the `Release Date`.
**Actual**: The destination dataset have the `Release Date` more recent then the `Modified Date`.

## Acceptance Criteria
1. The harvest should fallback to the `modified` date as the `Release Date` when the optional `issued` POD field is missing.

## Test Updates
1. Add PHPUnit tests for the specific case of missing `issued` POD field.

## Documentation Updates
None needed.

## Merge process
None needed.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
