### PR TITLE
[CIVIC-6141] Use last day of year (December 31) for 4 digits end year during temporal POD field import

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 7.x-1.13.x
 ----------
  - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
- - #1834 Use last day of the year for end date during temporal POD field import.
+ - #1834 Use last day of year (December 31) for 4 digits end year during temporal POD field import.
  - #1832 Fallback to modified date for field_harvest_source_issued if not available during POD Harvest.
  - #1828 Field Frequency Harvest POD integration is missing support for "irregular" value.
  - #1820 Use "accessURL" during resources harvest if "downloadURL" field is not available.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.13.x
 ----------
  - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
+ - #1834 Use last day of the year for end date during temporal POD field import.
 
 
 7.x-1.13.3-RC1

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -126,8 +126,16 @@ class DatajsonHarvestMigration extends HarvestMigration {
         // Support 4 digits year time strings.
         elseif (preg_match("@^\d{4}$@", $value)) {
           $value_date = new DateTime();
-          $value_date->setDate($value, 1, 1)
-            ->setTime(0, 0);
+
+          // If this is from the second argument set to the end of the year.
+          if ($key == 1) {
+            $value_date->setDate($value, 12, 31);
+          }
+          else {
+            $value_date->setDate($value, 1, 1);
+          }
+
+          $value_date->setTime(0, 0);
         }
         // Fallback to full date/time format.
         else {

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -108,7 +108,9 @@ class DatajsonHarvestMigration extends HarvestMigration {
     // class, we just need to set the properties.
     if (isset($row->temporal)) {
       $date = explode("/", $row->temporal);
-
+      
+      // The first key is the start date of the 'temporal coverage' and the second key is the
+      // end date of the 'temporal coverage'.
       foreach ($date as $key => &$value) {
         // Check if this is a time interval on the second Argument.
         if ($key == 1
@@ -134,10 +136,11 @@ class DatajsonHarvestMigration extends HarvestMigration {
         elseif (preg_match("@^\d{4}$@", $value)) {
           $value_date = new DateTime();
 
-          // If this is from the second argument set to the end of the year.
+          // If this is the end date then set it to the last day of the year.
           if ($key == 1) {
             $value_date->setDate($value, 12, 31);
           }
+          // If this is the start date then set it to the first day of the year.
           else {
             $value_date->setDate($value, 1, 1);
           }

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -521,7 +521,7 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
     $expected_temporal = array(
       "Ambulance Fee Schedule Public Use Files" => array(
         'value' => "2005-01-01 00:00:00",
-        'value2' => "2016-01-01 00:00:00",
+        'value2' => "2016-12-31 00:00:00",
       ),
       'Acute IPPS - Readmissions Reduction Program' => array(
         'value' => "2013-01-01 00:00:00",

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -125,7 +125,7 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
    */
   public function testTemporal($dataset) {
     $value = new DateTime("2011-01-01 00:00:00");
-    $value2 = new DateTime("2015-01-01 00:00:00");
+    $value2 = new DateTime("2015-12-31 00:00:00");
     $this->assertEquals($value->getTimestamp(), $dataset->field_temporal_coverage->value->value());
     $this->assertEquals($value2->getTimestamp(), $dataset->field_temporal_coverage->value2->value());
   }


### PR DESCRIPTION
Issue: CIVIC-6141

## Description
The POD schema specification allows for 4 digit year in the temporal field start and end dates. To have a full date consumable by the `field_temporal_coverage` field we have some logic to set the month and day to January 1st for this type of temporal data. This workaround works well for start date but leads to data loss when applied on end dates.

The fix would be to use the last day of the year (December 31) for end four digits dates.

## How to reproduce

1.  Create a harvest source. One of the source dataset should have the same 4 digits year as start and end dates.
2. Harvest the source.

**Expected**: The 4 digits year is represented correctly on the start and end dates on the `field_temporal_coverage` display.
**Actual**: Only the first start date is represented.

## Acceptance Criteria
1. Use last day of the year for temporal field end 4 digits year representation.

## Test Updates
Update the current 

## Documenation Updates
None needed.

## Merge process
None needed.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
