### PR TITLE
CIVIC-6137: Fix UX so it is clear that Public Access Field is required

### DIFF
--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -495,7 +495,7 @@ function dkan_dataset_dataset_node_form_validate($form, &$form_state) {
   $field_rights_langcode = dkan_dataset_form_field_language($form, 'field_rights');
   $rights = $form_state['values']['field_rights'][$field_rights_langcode][0]['value'];
   if ($public_access_level != 'public' && empty($rights)) {
-    form_set_error('field_rights', 'Rights field is required.');
+    form_set_error('field_rights', 'Public Access Level field must be specified.');
   }
 }
 

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -1026,7 +1026,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     'entity_type' => 'node',
     'field_name' => 'field_public_access_level',
     'label' => 'Public Access Level',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'user_register_form' => FALSE,
     ),


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-6137

## Description

Users who try to edit existing datasets sometimes see a confusing message that says, "Rights field is required." In fact, there is no "Rights" field, since this field has been renamed "Public Access Level."

## How to reproduce

1. See Jira ticket

## QA Steps

1. See Jira ticket.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
