### PR TITLE
Add hook_update to fix markdown toolbar on data dictionary field CIVIC-6057

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.13.4
 ----------
- - #1813 Update the groups page view to sort alphabetically rather than by post date.
+ - #1846 Adds a hook_update to exclude the data dictionary field from using the markdown toolbar. - #1813 Update the groups page view to sort alphabetically rather than by post date.
  - NuCivic/recline#89 Only load previews for resources using files; API/website links should always display iframe.
  - #1841 Fixed mis-named function on dkan_dataset_content_types.api.php
  - #1814 Update dkan_workflow_permissions to rebuild permissions on enable/disable.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.13.4
 ----------
- - #1846 Adds a hook_update to exclude the data dictionary field from using the markdown toolbar. - #1813 Update the groups page view to sort alphabetically rather than by post date.
+ - #1846 Adds a hook_update to exclude the data dictionary field from using the markdown toolbar. 
+ - #1813 Update the groups page view to sort alphabetically rather than by post date.
  - NuCivic/recline#89 Only load previews for resources using files; API/website links should always display iframe.
  - #1841 Fixed mis-named function on dkan_dataset_content_types.api.php
  - #1814 Update dkan_workflow_permissions to rebuild permissions on enable/disable.

--- a/dkan.install
+++ b/dkan.install
@@ -253,8 +253,8 @@ function dkan_update_7013() {
 }
 
 /**
-* Drop the 'field_modified_source_date' field.
-*/
+ * Drop the 'field_modified_source_date' field.
+ */
 function dkan_dataset_update_7004() {
   // Mark the field for deletion.
   field_delete_field('field_modified_source_date');

--- a/dkan.install
+++ b/dkan.install
@@ -262,3 +262,17 @@ function dkan_dataset_update_7004() {
   $batch_size = 1;
   field_purge_batch($batch_size);
 }
+
+/**
+ * Add data dictionary textarea id to bueditor excludes list.
+ */
+function dkan_update_7014() {
+  db_update('bueditor_editors')
+    ->fields(array(
+      'excludes' => 'edit-log
+edit-menu-description
+*data-dictionary*',
+    ))
+    ->condition('eid', '5')
+    ->execute();
+}


### PR DESCRIPTION
Re-roll of #1847 

Issue: CIVIC-6057

## Description
Existing sites are seeing the markdown toolbar on the data dictionary field after upgrading to 1.13

## QA Steps

- [ ] Go to `admin/config/content/bueditor/5` and delete the values under Visibility Settings: Hide the editor for specific textareas
- [ ] run `drush updb`
- [ ] Edit a dataset, confirm that the data dictionary field does not use the markdown toolbar.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
