### PR TITLE
Update chosen configuration to exclude specific select fields.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@
  - #1832 Fallback to modified date for field_harvest_source_issued if not available during POD Harvest.
  - #1828 Field Frequency Harvest POD integration is missing support for "irregular" value.
  - #1820 Use "accessURL" during resources harvest if "downloadURL" field is not available.
+ - #1857 Fixed publishing options not accessible when dkan_workflow is enabled. 
 
 7.x-1.13.3-RC1
 --------------

--- a/dkan.install
+++ b/dkan.install
@@ -276,3 +276,11 @@ edit-menu-description
     ->condition('eid', '5')
     ->execute();
 }
+
+/**
+ * Update chosen_jquery_selector to avoid misuse.
+ */
+function dkan_update_7016() {
+  variable_set('chosen_jquery_selector',
+    '.page-node select.form-select:not([class*=“delta-order”]), .page-node select.form-select:not(name*=“workbench_moderation”])');
+}

--- a/dkan.install
+++ b/dkan.install
@@ -282,5 +282,5 @@ edit-menu-description
  */
 function dkan_update_7016() {
   variable_set('chosen_jquery_selector',
-    '.page-node select.form-select:not([class*=“delta-order”]), .page-node select.form-select:not(name*=“workbench_moderation”])');
+    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"])');
 }

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
@@ -108,7 +108,6 @@ features[variable][] = chosen_jquery_selector
 features[variable][] = chosen_minimum
 features[variable][] = chosen_minimum_multiple
 features[variable][] = chosen_minimum_single
-features[variable][] = chosen_minimum_width
 features[variable][] = date_format_iso_8601_date
 features[variable][] = field_bundle_settings_node__dataset
 features[variable][] = field_bundle_settings_node__resource

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
@@ -108,6 +108,7 @@ features[variable][] = chosen_jquery_selector
 features[variable][] = chosen_minimum
 features[variable][] = chosen_minimum_multiple
 features[variable][] = chosen_minimum_single
+features[variable][] = chosen_minimum_width
 features[variable][] = date_format_iso_8601_date
 features[variable][] = field_bundle_settings_node__dataset
 features[variable][] = field_bundle_settings_node__resource

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.page-node select.form-select:not([class*=“delta-order”]), .page-node select.form-select:not(name*=“workbench_moderation”])';
+  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"])';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_dataset_content_types.strongarm.inc
@@ -37,6 +38,13 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->name = 'chosen_minimum_single';
   $strongarm->value = '0';
   $export['chosen_minimum_single'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'chosen_minimum_width';
+  $strongarm->value = '200';
+  $export['chosen_minimum_width'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.node-form  select, .field-name-field-format select, .field-name-field-dataset-ref select';
+  $strongarm->value = '.page-node select.form-select:not([class*=“delta-order”]), .page-node select.form-select:not(name*=“workbench_moderation”])';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();
@@ -38,13 +38,6 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->name = 'chosen_minimum_single';
   $strongarm->value = '0';
   $export['chosen_minimum_single'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
-  $strongarm->name = 'chosen_minimum_width';
-  $strongarm->value = '200';
-  $export['chosen_minimum_width'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */


### PR DESCRIPTION
Description
===

REF CIVIC-5765

Trying to update the Moderation state property for moderable content types (by
default dataset and resources) is not possible because the Moderation combo box
is squashed.

QA Steps
==
- [x] The moderation state on datasets or resources should show the current moderation state of the content when dkan_workflow is enabled.