### PR TITLE
Apply jQuery update correctly on upgrade

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.3
 ----------
+ - #1859 Fixe update hooks to correctly set jquery version and remove old modified source date field
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset.

--- a/dkan.install
+++ b/dkan.install
@@ -255,10 +255,19 @@ function dkan_update_7013() {
 /**
 * Drop the 'field_modified_source_date' field.
 */
-function dkan_dataset_update_7004() {
+function dkan_update_7014() {
   // Mark the field for deletion.
   field_delete_field('field_modified_source_date');
   // Run the batch process to actually delete the field.
   $batch_size = 1;
   field_purge_batch($batch_size);
+}
+
+/**
+ * Update the default jquery library to 1.10 (again).
+ */
+function dkan_update_7015() {
+  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
+    variable_set('jquery_update_jquery_version', '1.10');
+  }
 }


### PR DESCRIPTION
CIVIC-6221

This fixes DKAN sites that did not get their jQuery versions set to 1.10 as expected after upgrading to 1.13. It also removes the `field_modified_source_date` field, which was not removed as expected on some upgrades. 

## QA Tests

1. Build DKAN from 1.12.
2. Set jquery version to 1.7.
3. Update to this branch (`113-update-fixes`) HEAD
4. Check jQuery version; should now be 1.10
5. Check to make sure `field_modified_source_date` is not there