### PR TITLE
Add validation check on the API or Website URL field CIVIC-6157

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.13.4
 ----------
- - #1861 Add validation check on the API or Website URL field to require a full url.
+ - #1862 Add validation check on the API or Website URL field to require a full url.
  - #1846 Adds a hook_update to exclude the data dictionary field from using the markdown toolbar. 
  - #1813 Update the groups page view to sort alphabetically rather than by post date.
  - NuCivic/recline#89 Only load previews for resources using files; API/website links should always display iframe.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1861 Add validation check on the API or Website URL field to require a full url.
  - #1846 Adds a hook_update to exclude the data dictionary field from using the markdown toolbar. 
  - #1813 Update the groups page view to sort alphabetically rather than by post date.
  - NuCivic/recline#89 Only load previews for resources using files; API/website links should always display iframe.

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -558,7 +558,7 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
     }
   }
   // Ensure that only one type of resource is uploaded or linked to.
-  if(count(array_filter(array($link_fid,$api,$upload_fid))) != 1) {
+  if (count(array_filter(array($link_fid, $api, $upload_fid))) != 1) {
     if ($link_fid) {
       $remote_error = t('<strong>Remote file</strong> is populated - only one resource type can be used at a time.');
       form_set_error('field_link_remote_file', $remote_error);

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -334,7 +334,7 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
 
     // Get langcode for field_link_api.
     $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');
-    $form['field_link_api'][$field_link_api_langcode][0]['#description'] = t('Link to a public API or information source.');
+    $form['field_link_api'][$field_link_api_langcode][0]['#description'] = t('Full url to a public API or information source (http://example.com).');
 
     // Get langcode for field_format.
     $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_format');
@@ -645,6 +645,11 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
       $form_state['values']['field_format'][$field_format_langcode][0]['tid'] = 'autocreate';
       $form_state['values']['field_format'][$field_format_langcode][0]['name'] = $type;
     }
+  }
+  if (isset($api) && !valid_url($api, TRUE)) {
+    // Require full url if using the API or Website URL option.
+    $api_url_error = t('Please enter a full url (include http:// or https://)');
+    form_set_error('field_link_api', $api_url_error);
   }
 }
 

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -151,7 +151,7 @@ Feature: Resource
     Then I should see the local preview link
     And I should see "CartoDB"
 
-  @api @here
+  @api
   Scenario: Hide "Back to dataset" button on resources without dataset
     Given resources:
       | title                    | publisher | format | dataset | author | published | description |

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -73,6 +73,16 @@ Feature: Resource
     And I press "Save"
     Then I should see "Resource Resource 06 has been created"
 
+  @noworkflow
+  Scenario: See warning if full url not given when using the api/url option.
+    Given I am logged in as "Katie"
+    And I am on the "Content" page
+    And I click "Resource"
+    And I fill in "edit-field-link-api-und-0-url" with "api.tiles.mapbox.com/v3/tmcw.map-gdv4cswo/markers.geojson"
+    When I fill in "Title" with "Resource api"
+    And I press "Save"
+    Then I should see "Please enter a full url"
+
   @noworkflow @javascript
   Scenario: Create resource with too many sources.
     Given I am logged in as "Katie"


### PR DESCRIPTION
Issue: CIVIC-6157

## Description

A full url is needed when adding an api or website link to a resource. If a full url with http:// isn't added, POD validation will fail and a preview won't be displayed. We want to add validation and help text to make sure a full url is used.

## QA Steps

- [ ] Edit a resource, use the **API or Website URL** option
- [ ] Enter `api.louisvilleky.gov/Reporting/HansenReportViewer.aspx?reportName=ProjectReport` and save
- [ ] Confirm that you get a warning
- [ ] Confirm the help text for field is improved to let people know the url should be a full url

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [X] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
