### PR TITLE
Update restws to 2.7

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 7.x-1.13.3
 ----------
  - #1863 Update restws module to v2.7
- - #1859 Fixe update hooks to correctly set jquery version and remove old modified source date field
+ - #1859 Fixed update hooks to correctly set jquery version and remove old modified source date field
  - #1864 Update media to 2.0 and remove patch 2534724. 
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.3
 ----------
+ - #1863 Update restws module to v2.7
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -300,7 +300,7 @@ projects:
       2406863: https://www.drupal.org/files/issues/rules-remove-cache-rebuild-log-2406863-21.patch
       2851567: https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch
   restws:
-    version: '2.6'
+    version: '2.7'
   roleassign:
     version: '1.1'
   safeword:


### PR DESCRIPTION
CIVIC-6226

Tests should pass and basic QA should reveal no issues. This should be a very low-impact change and we should try to remove restws completely in the next point release.