### PR TITLE
Fix bug procession data dictionary on data.json endpoint

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #1870 Fixed bug on open_data_schema_map for process data dictionary field.
  - #1853 Update chart documentation.
  - #1839 Add help text and improve UI on the chart form for better clarity.
  - #1827 Remove option to import TABed CSV files into datastore. 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@ api: '2'
 core: 7.x
 includes:
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
+  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/fix_bug_with_text_process_data_dictionary_CIVIC_6155/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
 projects:
@@ -250,7 +250,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/open_data_schema_map.git'
-      branch: 7.x-1.x
+      branch: fix_bug_with_text_process_data_dictionary_CIVIC_6155
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION

Issue: CIVIC-6155

## Description

When you use a text for example "test http://example.com" on data dictionary field (dataset) when you access to data.json endpoint the data is incorrect (// test.com)

## How to reproduce

1.  Create a dataset with data dictionary value (test http://example.com \n test2 http://example2.com)
2. Access to data.json. And you should see for field describedBy the value "(test http://example.com \n test2 http://example2.com" ) and is showing another value.

## QA Steps

- [ ] Create a dataset with data dictionary value (test http://example.com \n test2 http://example2.com
- [ ] Access to data.json and on describedBy you should see "(test http://example.com \n test2 http://example2.com)"

## Merge process

- [ ] https://github.com/NuCivic/open_data_schema_map/pull/88

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
