### PR TITLE
Added trailing comma (,) to array.

### DIFF
--- a/docs/apis/rest-api.rst
+++ b/docs/apis/rest-api.rst
@@ -205,7 +205,7 @@ Create a Dataset
       'title' => 'Example dataset',
       'status' => 1,
       'body[und][0][value]' => 'The description',
-      'field_resources[und][0][target_id]' => 'Madison Polling Places (5)' // Resource title plus node id
+      'field_resources[und][0][target_id]' => 'Madison Polling Places (5)', // Resource title plus node id
       'field_author[und][0][value]' => 'Bob Lafollette'
   );
   $dataset_data = http_build_query($dataset_data);


### PR DESCRIPTION
Issue: link_to_jira_github_issue

## Description

Line 208 `'field_resources[und][0][target_id]' => 'Madison Polling Places (5)'` was returning a syntax error due to no trailing comma.

## User story

I can copy and paste all the examples into a PHP script and run it, and everything will work fine (after only having to change end point urls) with no syntax errors.

## How to reproduce

1. Collate all examples into one script:
  - [Log In and get the Session Cookie](http://dkan.readthedocs.io/en/latest/apis/rest-api.html#log-in-and-get-the-session-cookie)
  - [Get the CSRF Token](http://dkan.readthedocs.io/en/latest/apis/rest-api.html#get-the-csrf-token)
  - [Create a Resource](http://dkan.readthedocs.io/en/latest/apis/rest-api.html#create-a-resource)
  - [Attach a file to a resource](http://dkan.readthedocs.io/en/latest/apis/rest-api.html#attach-a-file-to-a-resource)
  - [Create a Dataset](http://dkan.readthedocs.io/en/latest/apis/rest-api.html#create-a-dataset)
2. Run script.