### PR TITLE
Point leaflet draw to fix_export_polygon_to_geojson_civic_6072

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #1879 Fix problem using polygons with geojson export on leaflet.
  - #1853 Update chart documentation.
  - #1839 Add help text and improve UI on the chart form for better clarity.
  - #1827 Remove option to import TABed CSV files into datastore. 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -187,7 +187,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/leaflet_draw_widget.git'
-      branch: 'master'
+      branch: 'fix_export_polygon_to_geojson_civic_6072'
   libraries:
     version: '2.3'
   link:


### PR DESCRIPTION
CIVIC-6072

## Description

We have a problem when we create a polygon on the map (edit dataset) and change to geojson tab is showing null values instead points. 

## How to reproduce

1.  Create a dataset.
2. Try to add a polygon on the map.
3. Change to geojson tab you will see null values.

## QA Steps

- [ ] Try to add a polygon on the map (dataset edit form).
- [ ] Change to tab GeoJSON and you shouldn't see null values.

## Merge process

- [ ] https://github.com/NuCivic/leaflet_draw_widget/pull/19

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
