### PR TITLE
Fix yaml syntaxt to make it standard

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #1881 Fix yaml syntaxt to make it standard. 
  - #1853 Update chart documentation.
  - #1839 Add help text and improve UI on the chart form for better clarity.
  - #1827 Remove option to import TABed CSV files into datastore. 

--- a/test/behat.circleci.yml
+++ b/test/behat.circleci.yml
@@ -1,12 +1,12 @@
 imports:
-  -  behat.yml
+  - behat.yml
 
 default:
   extensions:
     Behat\MinkExtension:
-      base_url: http://127.0.0.1:8888
+      base_url: "http://127.0.0.1:8888"
       selenium2:
-        wd_host: http://127.0.0.1:4444/wd/hub
+        wd_host: "http://127.0.0.1:4444/wd/hub"
     Drupal\DrupalExtension:
       drupal:
-        drupal_root: %paths.base%/../../docroot
+        drupal_root: "%paths.base%/../../docroot"

--- a/test/behat.docker.yml
+++ b/test/behat.docker.yml
@@ -1,12 +1,12 @@
 imports:
-  -  behat.yml
+  - behat.yml
 
 default:
   extensions:
     Behat\MinkExtension:
-      base_url: http://web
+      base_url: "http://web"
       selenium2:
-        wd_host: http://browser:4444/wd/hub
+        wd_host: "http://browser:4444/wd/hub"
     Drupal\DrupalExtension:
       drupal:
-        drupal_root: %paths.base%/../../docroot
+        drupal_root: "%paths.base%/../../docroot"

--- a/test/behat.local.demo.yml
+++ b/test/behat.local.demo.yml
@@ -4,11 +4,11 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
-      files_path: '/Users/Username/path/to/vagrant/machine/www/dkan/test/files/'
-      base_url: http://dkan.local
-      browser_name: chrome
+      files_path: "/Users/Username/path/to/vagrant/machine/www/dkan/test/files/"
+      base_url: "http://dkan.local"
+      browser_name: "chrome"
       selenium2:
-        wd_host: http://33.33.33.1:4444/wd/hub
+        wd_host: "http://33.33.33.1:4444/wd/hub"
         capabilities:
           extra_capabilities:
             chromeOptions:
@@ -16,6 +16,6 @@ default:
                 - "--disable-web-security"
     Drupal\DrupalExtension:
       drupal:
-        drupal_root: '/var/www/dkan/webroot'
+        drupal_root: "/var/www/dkan/webroot"
       drush:
-        root: '/var/www/dkan/webroot'
+        root: "/var/www/dkan/webroot"

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -21,21 +21,21 @@ default:
           - Drupal\DKANExtension\Context\SearchAPIContext:
               search_forms:
                 default:
-                  form_css: '#dkan-sitewide-dataset-search-form'
-                  form_field: 'edit-search'
-                  form_button: 'edit-submit'
-                  results_css: '.view-dkan-datasets'
-                  result_item_css: '.views-row'
+                  form_css: "#dkan-sitewide-dataset-search-form"
+                  form_field: "edit-search"
+                  form_button: "edit-submit"
+                  results_css: ".view-dkan-datasets"
+                  result_item_css: ".views-row"
                 harvest_source:
-                  results_css: '.view-dkan-harvest-source-search'
-                  result_item_css: '.views-row'
+                  results_css: ".view-dkan-harvest-source-search"
+                  result_item_css: ".views-row"
           - Drupal\DKANExtension\Context\ResourceContext
           - Drupal\DKANExtension\Context\ServicesContext
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\DatastoreContext
           - Drupal\DrupalExtension\Context\DrushContext
           - Devinci\DevinciExtension\Context\DebugContext:
-              asset_dump_path: %paths.base%/assets
+              asset_dump_path: "%paths.base%/assets"
           - Devinci\DevinciExtension\Context\JavascriptContext:
               maximum_wait: 30
   formatters:
@@ -49,16 +49,16 @@ default:
     Behat\MinkExtension:
       goutte: ~
       selenium2: ~
-      default_session: 'goutte'
-      javascript_session: 'selenium2'
+      default_session: "goutte"
+      javascript_session: "selenium2"
       browser_name: chrome
-      files_path: %paths.base%/files
+      files_path: "%paths.base%/files"
     Drupal\DrupalExtension:
       blackbox: ~
       drupal:
         #TODO Abstract this out.
-        drupal_root: %paths.base%/../../docroot
-      api_driver: 'drupal'
+        drupal_root: "%paths.base%/../../docroot"
+      api_driver: "drupal"
       # @todo fixup these regions for use with new theme. Updated navigation only
       region_map:
         content: ".region-content"
@@ -70,52 +70,52 @@ default:
         right header: "#header-right"
         right sidebar: "#column-right"
         dashboards: ".view-data-dashboards table tbody"
-        navigation: '.navigation-wrapper'
-        breadcrumb: '.breadcrumb'
-        left_sidebar: '.panel-col-first'
-        dataset title: '.pane-node .pane-title'
-        dataset resource list: '#data-and-resources'
-        dataset body: '.field-name-body'
-        dataset edit body: '#edit-body'
-        dataset spatial: '#edit-field-spatial'
-        resource title: '.pane-node .pane-title'
-        resource groups: '#edit-groups'
-        search_area: '.panel-col-last'
-        dropdown_links: '.comment-main .links.inline.dropdown-menu'
-        comment: '.comment-main'
-        navigation: '.navigation-wrapper'
-        primary tabs: '.tabs--primary'
-        group subscribe: '.group-subscribe-message'
-        group block: '.pane-views-group-block-block'
-        group members: '.view-id-dkan_og_extras_group_members'
-        facet container: '.radix-layouts-sidebar'
-        filter by resource format: '.facetapi-facet-field-resourcesfield-format'
-        filter by author: '.facetapi-facet-author'
-        filter by topics: '.facetapi-facet-field-topic'
-        filter by tag: '.facetapi-facet-field-tags'
-        filter by date changed: '.facetapi-facet-changed'
-        social: '.pane-dkan-sitewide-dkan-sitewide-social'
-        other access: '.pane-dkan-sitewide-dkan-sitewide-other-access'
-        datasets: '.view-dkan-datasets'
-        user profile: '.pane-dkan-sitewide-panels-dkan-user-summary'
-        results: '.view-header'
-        user page: '.main'
-        user command center: '.pane-dkan-sitewide-profile-page-dkan-user-summary'
-        tabs: '.field-group-htabs-wrapper'
-        content: '.view-content'
-        groups: '.view-content'
-        search content results: '.content'
-        user content: '.view-user-profile-search'
-        content search: '.form-item-query'
-        user block: '.pane-views-user-profile-fields-block'
-        admin menu: '#admin-menu'
-        harvest datasets: '.view-dkan-harvest-datasets'
+        navigation: ".navigation-wrapper"
+        breadcrumb: ".breadcrumb"
+        left_sidebar: ".panel-col-first"
+        dataset title: ".pane-node .pane-title"
+        dataset resource list: "#data-and-resources"
+        dataset body: ".field-name-body"
+        dataset edit body: "#edit-body"
+        dataset spatial: "#edit-field-spatial"
+        resource title: ".pane-node .pane-title"
+        resource groups: "#edit-groups"
+        search_area: ".panel-col-last"
+        dropdown_links: ".comment-main .links.inline.dropdown-menu"
+        comment: ".comment-main"
+        navigation: ".navigation-wrapper"
+        primary tabs: ".tabs--primary"
+        group subscribe: ".group-subscribe-message"
+        group block: ".pane-views-group-block-block"
+        group members: ".view-id-dkan_og_extras_group_members"
+        facet container: ".radix-layouts-sidebar"
+        filter by resource format: ".facetapi-facet-field-resourcesfield-format"
+        filter by author: ".facetapi-facet-author"
+        filter by topics: ".facetapi-facet-field-topic"
+        filter by tag: ".facetapi-facet-field-tags"
+        filter by date changed: ".facetapi-facet-changed"
+        social: ".pane-dkan-sitewide-dkan-sitewide-social"
+        other access: ".pane-dkan-sitewide-dkan-sitewide-other-access"
+        datasets: ".view-dkan-datasets"
+        user profile: ".pane-dkan-sitewide-panels-dkan-user-summary"
+        results: ".view-header"
+        user page: ".main"
+        user command center: ".pane-dkan-sitewide-profile-page-dkan-user-summary"
+        tabs: ".field-group-htabs-wrapper"
+        content: ".view-content"
+        groups: ".view-content"
+        search content results: ".content"
+        user content: ".view-user-profile-search"
+        content search: ".form-item-query"
+        user block: ".pane-views-user-profile-fields-block"
+        admin menu: "#admin-menu"
+        harvest datasets: ".view-dkan-harvest-datasets"
       text:
         log_out: "Log out"
         log_in: "Log in"
       selectors:
-        message_selector: '.alert'
-        error_message_selector: '.alert.alert-error'
-        success_message_selector: '.alert.alert-success'
+        message_selector: ".alert"
+        error_message_selector: ".alert.alert-error"
+        success_message_selector: ".alert.alert-success"
     Drupal\DKANExtension:
-      some_param: test
+      some_param: "test"


### PR DESCRIPTION
## Description

Yaml syntax present within behat configuration files are not respecting
the behat spec so if you try to use ruby to parse it, parser complains 
about the percentage sign and other characters starting scalar values.

## QA Steps

- [x] Tests should pass.