### PR TITLE
Point open data schema map to alter_dcat_language_CIVIC-6063

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -250,7 +250,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/open_data_schema_map.git'
-      branch: 7.x-1.x
+      branch: alter_dcat_language_CIVIC-6063
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION
issue: CIVIC-6063

## Description
1. DCAT validation fails on the language field, it is expecting a key value and is getting the label value.
2. The keys that exist are using underscores and the validator is expecting dashes. (i.e. `en_US`  should be `en-US`)

## Related PRs
https://github.com/NuCivic/open_data_schema_map/pull/89

