### PR TITLE
Removed required status from the Rights field if the public access level is set to 'none' CIVIC-6137

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1882 Removed required status from the Rights field if the public access level is set to 'none'.
  - #1871 Better handling of remote resources with BOM.
  - #1873 Fix dkan_workflow_permissions: Allow Workflow Contributors and Workflow Moderators to view stale drafts and Workflow Moderators to view stale reviews.
  - #1858 Fixed default panelizer setting for page node title.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.13.4
 ----------
- - #1882 Removed required status from the Rights field if the public access level is set to 'none'.
+ - #1883 Removed required status from the Rights field if the public access level is set to 'none'.
  - #1871 Better handling of remote resources with BOM.
  - #1873 Fix dkan_workflow_permissions: Allow Workflow Contributors and Workflow Moderators to view stale drafts and Workflow Moderators to view stale reviews.
  - #1858 Fixed default panelizer setting for page node title.

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -494,7 +494,7 @@ function dkan_dataset_dataset_node_form_validate($form, &$form_state) {
   $public_access_level = $form_state['values']['field_public_access_level'][$field_public_access_level_langcode][0]['value'];
   $field_rights_langcode = dkan_dataset_form_field_language($form, 'field_rights');
   $rights = $form_state['values']['field_rights'][$field_rights_langcode][0]['value'];
-  if ($public_access_level != 'public' && empty($rights)) {
+  if (isset($public_access_level) && $public_access_level != 'public' && empty($rights)) {
     form_set_error('field_rights', 'Rights field is required.');
   }
 }
@@ -558,7 +558,7 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
     }
   }
   // Ensure that only one type of resource is uploaded or linked to.
-  if(count(array_filter(array($link_fid,$api,$upload_fid))) != 1) {
+  if (count(array_filter(array($link_fid, $api, $upload_fid))) != 1) {
     if ($link_fid) {
       $remote_error = t('<strong>Remote file</strong> is populated - only one resource type can be used at a time.');
       form_set_error('field_link_remote_file', $remote_error);

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -1155,7 +1155,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     'bundle' => 'dataset',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => 'If you set your dataset to a public access level other than "public", you must provide an explanation for why this dataset cannot be made fully public. Include any useful information regarding access or restrictions based on privacy, security, or other policies. See <a href="https://project-open-data.cio.gov/v1.1/schema/#rights">Rights on Project Open Data</a>.',
+    'description' => 'If you set your dataset to a public access level other than "public" or "none", you must provide an explanation for why this dataset cannot be made fully public. Include any useful information regarding access or restrictions based on privacy, security, or other policies. See <a href="https://project-open-data.cio.gov/v1.1/schema/#rights">Rights on Project Open Data</a>.',
     'display' => array(
       'default' => array(
         'label' => 'hidden',
@@ -1854,7 +1854,7 @@ uk-ogl|UK Open Government Licence (OGL)',
   t('Harvest Source Issued');
   t('Harvest Source Modified');
   t('Homepage URL');
-  t('If you set your dataset to a public access level other than "public", you must provide an explanation for why this dataset cannot be made fully public. Include any useful information regarding access or restrictions based on privacy, security, or other policies. See <a href="https://project-open-data.cio.gov/v1.1/schema/#rights">Rights on Project Open Data</a>.');
+  t('If you set your dataset to a public access level other than "public" or "none", you must provide an explanation for why this dataset cannot be made fully public. Include any useful information regarding access or restrictions based on privacy, security, or other policies. See <a href="https://project-open-data.cio.gov/v1.1/schema/#rights">Rights on Project Open Data</a>.');
   t('Is Part Of');
   t('Language');
   t('License');

--- a/test/features/dataset.admin.feature
+++ b/test/features/dataset.admin.feature
@@ -80,3 +80,11 @@ Feature: Dataset Features
     And I should not see "Rights on Project Open Data"
     Then I select "Restricted" from "edit-field-public-access-level-und"
     And I should see "Rights on Project Open Data"
+
+  @javascript
+  Scenario: DEBUG Should not see Rights field if public access level = none
+    Given I am logged in as "Gabriel"
+    And I am on "Dataset 01" page
+    When I click "Edit"
+    Then I select "- None -" from "edit-field-public-access-level-und"
+    And I should not see "Rights on Project Open Data"

--- a/test/features/dataset.admin.feature
+++ b/test/features/dataset.admin.feature
@@ -82,7 +82,7 @@ Feature: Dataset Features
     And I should see "Rights on Project Open Data"
 
   @javascript
-  Scenario: DEBUG Should not see Rights field if public access level = none
+  Scenario: Should not see Rights field if public access level = none
     Given I am logged in as "Gabriel"
     And I am on "Dataset 01" page
     When I click "Edit"


### PR DESCRIPTION
Issue: CIVIC-6137

## Description

Removed required status from the Rights field if the public access level is set to 'none'

## QA Steps

- [ ] Edit a dataset and set the public access level to 'none' and save
- [ ] Confirm that you do not see a warning the the Rights field is required.
- [ ] Edit again and set the public access level to 'restricted' and save
- [ ] Confirm that you do see a warning that the Rights field is required.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
