### PR TITLE
Added validation on axis tick settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #1888 Added validation on axis tick settings on visualization_entity.
  - #1725 Fix `ahoy dkan uli` output login link.
  - #1881 Fix yaml syntaxt to make it standard. 
  - #1853 Update chart documentation.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/6041_chart_axis_range/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -352,7 +352,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: 7.x-1.x
+      branch: 6041_chart_axis_range
     type: module
   workbench:
     version: '1.2'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -352,7 +352,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: 6041_chart_axis_range
+      branch: 7.x-1.x
     type: module
   workbench:
     version: '1.2'


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-6041

## Description

Adding a large range for axis values can crash the browser if the step value is comparatively small. Example:
- Set range from 0 - 50,000
- Step value is set to 1
- The browser will try to draw 50,000 values on the axis

## Acceptance test

- [ ] Go to the QA site and create a chart
- [ ] Play with different values on the tick configurations on all the axis. If the number of ticks ((ToValue - FromValue) / StepValue) is higher than 100 then an error should be displayed to the user.

## Merging process

- [ ] Merge the PR: https://github.com/NuCivic/recline.view.nvd3.js/pull/41.
- [ ] Revert the recline.view.nvd3.js branch on: https://github.com/NuCivic/visualization_entity/pull/70
- [ ] Merge the PR: https://github.com/NuCivic/visualization_entity/pull/70
- [ ] Revert the visualization_entity branch on this PR.
- [ ] Merge this PR.