### PR TITLE
Point open data schema map to alter_dcat_language_CIVIC-6063

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -245,7 +245,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/open_data_schema_map.git
-      tag: 7.x-1.13.3-RC1
+      tag: alter_dcat_language_CIVIC-6063
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION
issue: CIVIC-6063

## Description
1. DCAT validation fails on the language field, it is expecting a key value and is getting the label value.
2. The keys that exist are using underscores and the validator is expecting dashes. (i.e. `en_US`  should be `en-US`)

## Related PRs
https://github.com/NuCivic/open_data_schema_map/pull/89

