### PR TITLE
Point to 1.13.4 for external modules

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -245,7 +245,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/open_data_schema_map.git
-      tag: 1.13.4
+      branch: 1.13.4
   panelizer:
     version: '3.4'
   panels:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,10 +2,10 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/1.13.4/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/1.13.4/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
-  - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
+  - "https://raw.githubusercontent.com/NuCivic/recline/1.13.4/recline.make"
 projects:
   admin_menu:
     version: '3.0-rc5'
@@ -245,7 +245,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/open_data_schema_map.git
-      tag: 7.x-1.13.3-RC1
+      tag: 1.13.4
   panelizer:
     version: '3.4'
   panels:
@@ -275,7 +275,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      branch: 1.13.4
   ref_field:
     download:
       type: git


### PR DESCRIPTION
A bunch of the external modules -- particularly recline -- are still not pointing to the 1.13.4 branch in the makefile for 1.13.4. Let's get them all synced up.