### PR TITLE
Update branches on recline, visualization_entity and ODSM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1904 Updated branches on recline, visualization_entity and open_data_schema_map.
  - #1887 Removed unnecessary 'Select' button from the remote file input field on the resource form.
  - #1869 Add validation check on the API or Website URL field to require a full url.
  - #1883 Removed required status from the Rights field if the public access level is set to 'none'.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,10 +2,10 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/1.13.4/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/1.13.4/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
-  - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
+  - "https://raw.githubusercontent.com/NuCivic/recline/1.13.4/recline.make"
 projects:
   admin_menu:
     version: '3.0-rc5'
@@ -245,7 +245,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/open_data_schema_map.git
-      tag: 7.x-1.13.3-RC1
+      tag: 1.13.4
   panelizer:
     version: '3.4'
   panels:
@@ -275,7 +275,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      branch: 1.13.4
   ref_field:
     download:
       type: git


### PR DESCRIPTION
Issue: None

## Description

1. There were mismatched branches for visualization_entity and open_data_schema_map. The branches were different on the makefiles section than on the projects section.
2. Recline has a 1.13.4 branch but it was pointing to 7.x-1.x.

## QA Steps

- [ ] Tests should pass.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
