### PR TITLE
Allow users to skip login tests.

### DIFF
--- a/test/features/user.all.feature
+++ b/test/features/user.all.feature
@@ -38,6 +38,7 @@ Feature: User
       | Dataset 01 | Group 01  | Katie   | Yes              | world    | Test        |
       | Dataset 02 | Group 01  | Katie   | Yes              | world    | Test        |
 
+  @login
   Scenario: Login
     Given I am on the homepage
     When I follow "Log in"
@@ -46,6 +47,7 @@ Feature: User
     And I press "Log in"
     Then I should see the "John" user page
 
+  @login
   Scenario: Logout
     Given I am logged in as "John"
     And I am on the homepage
@@ -65,7 +67,7 @@ Feature: User
     Then I should see "Thank you for applying for an account."
     And I should see "Your account is currently pending approval by the site administrator."
 
-  @mail
+  @mail @login
   Scenario: Request new password
     Given I am on the homepage
     When I follow "Log in"


### PR DESCRIPTION
REF CIVIC-6115

Adds tags to the tests that require a "log in" link in the toolbar, as this is often hidden.