### PR TITLE
Restore original user on moderated content

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@
  - #1839 Add help text and improve UI on the chart form for better clarity.
  - #1827 Remove option to import TABed CSV files into datastore. 
  - #1807 Add admin_views module for enhanced content and file filtering. 
+ DKAN Workflow:
+ - #1919 Restored original user on moderated content.
 
 7.x-1.13.x
 ----------

--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -440,3 +440,27 @@ function dkan_workflow_mail_alter(&$message) {
     $message['send'] = $dkan_email_proxy->send();
   }
 }
+
+/**
+ * Restore original user on node revisions.
+ */
+function dkan_workflow_restore_user($node) {
+  db_update('node_revision')
+    ->fields(array('uid' => $node->uid))
+    ->condition('nid', $node->nid)
+    ->condition('vid', $node->vid)
+    ->execute();
+}
+
+/**
+ * Implements hook_workbench_moderation_transition().
+ */
+function dkan_workflow_workbench_moderation_transition($node, $previous_state, $new_state) {
+  // When a node is updated through moderation the original author of the
+  // node gets replaced by the user that moderated the content.
+  // This code was added in order to fix that and restore the original user.
+  if (isset($node->nid) && isset($node->vid) && isset($node->uid)) {
+    dkan_workflow_restore_user($node);
+  }
+}
+

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -445,3 +445,30 @@ Feature:
     And I press "Finish"
     And I click "View draft"
     Then I should see "Dataset draft title"
+
+  @api @javascript @globalUser
+  Scenario: As a user I should be able to see my content back on "My Drafts" section if it was rejected
+    # Submit a dataset to Needs Review
+    Given I am logged in as "Contributor"
+    And datasets:
+      | title              | author      | moderation | moderation_date | date created  |
+      | My Draft Dataset   | Contributor | draft      | Jul 21, 2015    | Jul 21, 2015  |
+    When I am on the "My Drafts" page
+    Then I should see the button "Submit for review"
+    And I should see "My Draft Dataset"
+    When I check the box "Select all items on this page"
+    And I press "Submit for review"
+    And I wait for "Performed Submit for review"
+    And I am on the "My Drafts" page
+    Then I should not see "My Draft Dataset"
+    # Reject dataset
+    Given I am logged in as "Supervisor"
+    When I am on the "Needs Review" page
+    Then I should see "My Draft Dataset"
+    When I check the box "Select all items on this page"
+    And I press "Reject"
+    Then I wait for "Performed Reject"
+    # Check that the dataset is back
+    Given I am logged in as "Contributor"
+    When I am on the "My Drafts" page
+    Then I should see "My Draft Dataset"


### PR DESCRIPTION
Issue: CIVIC-6220

## Description

When a piece of content is rejected by an Editor or Supervisor using DKAN Workflow the content returns to the "My drafts" tab but the one belonging to the user that moderated the content. The original user does not get the content back.

## How to reproduce

- [ ] Log in as Workflow Contributor
- [ ] Create a piece of content
- [ ] Submit the content from Draft to Needs Review
- [ ] Logout
- [ ] Log in as Workflow Supervidor
- [ ] Go to My Workbench and reject the content created by the Workflow Contributor
- [ ] Notive how the rejected content appears on the "My drafts" tab of Workflow Supervisor
- [ ] Log out
- [ ] Log in with the Workflow Contributor user again
- [ ] Go to My Workbench and confirm that you do not have the content back on "My drafts" tab after it was rejected.

## QA Steps

- [ ] Log in as Workflow Contributor
- [ ] Create a piece of content
- [ ] Submit the content from Draft to Needs Review
- [ ] Logout
- [ ] Log in as Workflow Supervidor
- [ ] Go to My Workbench and reject the content created by the Workflow Contributor
- [ ] Notive how the rejected content appears on the "My drafts" tab of Workflow Supervisor
- [ ] Log out
- [ ] Log in with the Workflow Contributor user again
- [ ] Go to My Workbench and confirm that you have the content back on "My drafts" tab after it was rejected.

## Reminders
- [x] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
