### PR TITLE
Update bad hook update

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -213,29 +213,43 @@ function dkan_update_7011() {
  * Deprecated modules: Conditional Fields, Entity RDF, RDF UI, RDF Extensions.
  */
 function dkan_update_7012() {
-  $modules = array(
-    'conditional_fields',
-    'entity_rdf',
-    'rdfui',
-    'rdfx',
-  );
-  db_delete('system')
-    ->condition('name', $modules, 'IN')
-    ->condition('type', 'module')
-    ->execute();
+  if (!module_exists('conditional_fields')) {
+    db_delete('system')
+      ->condition('name', 'conditional_fields')
+      ->condition('type', 'module')
+      ->execute();
+    db_drop_table('conditional_fields');
+  }
+  if (!module_exists('entity_rdf')) {
+    db_delete('system')
+      ->condition('name', 'entity_rdf')
+      ->condition('type', 'module')
+      ->execute();
+  }
+  if (!module_exists('rdfui')) {
+    db_delete('system')
+      ->condition('name', 'rdfui')
+      ->condition('type', 'module')
+      ->execute();
+  }
+  if (!module_exists('rdfx')) {
+    db_delete('system')
+      ->condition('name', 'rdfx')
+      ->condition('type', 'module')
+      ->execute();
 
-  db_drop_table('conditional_fields');
-  db_drop_table('rdfx_namespaces');
-  db_drop_table('rdfx_term_details');
-  db_drop_table('rdfx_term_domains');
-  db_drop_table('rdfx_term_inverses');
-  db_drop_table('rdfx_term_ranges');
-  db_drop_table('rdfx_term_superclasses');
-  db_drop_table('rdfx_term_superproperties');
-  db_drop_table('rdfx_term_types');
-  db_drop_table('rdfx_terms');
-  db_drop_table('rdfx_vocabulary_details');
-  db_drop_table('rdfx_vocabulary_graphs');
+    db_drop_table('rdfx_namespaces');
+    db_drop_table('rdfx_term_details');
+    db_drop_table('rdfx_term_domains');
+    db_drop_table('rdfx_term_inverses');
+    db_drop_table('rdfx_term_ranges');
+    db_drop_table('rdfx_term_superclasses');
+    db_drop_table('rdfx_term_superproperties');
+    db_drop_table('rdfx_term_types');
+    db_drop_table('rdfx_terms');
+    db_drop_table('rdfx_vocabulary_details');
+    db_drop_table('rdfx_vocabulary_graphs');
+  }
 }
 
 /**
@@ -253,8 +267,8 @@ function dkan_update_7013() {
 }
 
 /**
-* Drop the 'field_modified_source_date' field.
-*/
+ * Drop the 'field_modified_source_date' field.
+ */
 function dkan_update_7014() {
   // Mark the field for deletion.
   field_delete_field('field_modified_source_date');


### PR DESCRIPTION
## Description

Fix dkan_update_7012 so that if a site is still using a deprecated module, the data is not stripped from the db.

## Important
Using this for a patch do not remove until client site is upgraded to 1.13.4