### PR TITLE
[CIVIC-5980] Remove description label for Harvest Source node view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1921 Drop the description label from the Harvest Source node view page.
  - #1917 Fixed 'ahoy dkan reinstall' command.
  - #1865 Removed old dkan_dataset_api module.
  - #1899 Override default error message on duplicate path aliases with more information.

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
@@ -303,7 +303,7 @@ function dkan_sitewide_panels_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'label' => 'above',
+    'label' => 'hidden',
     'formatter' => 'text_default',
     'delta_limit' => 0,
     'delta_offset' => '0',

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panels/dkan_sitewide_panels.pages_default.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_sitewide_panels.pages_default.inc


### PR DESCRIPTION
Issue: CIVIC-5980

## Description

There is a 'Description:' label on the Harvest Source view page. It is unnecessary and should be removed, especially since we don't use it on any other content type.

## QA Steps

1. Create Harvest Source Node with a description.
2. Go the "View" tab for the Harvest Source.

The description should not have a label.

## Merge process

- None needed.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
