### PR TITLE
Fixing link styling.

### DIFF
--- a/docs/apis/datastore-api.rst
+++ b/docs/apis/datastore-api.rst
@@ -5,8 +5,7 @@ DKAN offers a Datastore API as a custom endpoint for the Drupal Services
 module.
 
 This API is designed to be as compatible as possible with the [CKAN
-Datastore API]
-(http://ckan.readthedocs.org/en/latest/maintaining/datastore.html).
+Datastore API](http://ckan.readthedocs.org/en/latest/maintaining/datastore.html).
 
 Parameters
 ----------

--- a/docs/apis/datastore-api.rst
+++ b/docs/apis/datastore-api.rst
@@ -4,8 +4,8 @@ Datastore API
 DKAN offers a Datastore API as a custom endpoint for the Drupal Services
 module.
 
-This API is designed to be as compatible as possible with the [CKAN
-Datastore API](http://ckan.readthedocs.org/en/latest/maintaining/datastore.html).
+This API is designed to be as compatible as possible with the `CKAN
+Datastore API <http://ckan.readthedocs.org/en/latest/maintaining/datastore.html>`_.
 
 Parameters
 ----------


### PR DESCRIPTION
There was a space between the link text and the url, breaking the markdown styling.