### PR TITLE
Fix shapes in the GeoJSON extent field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1927 Fixed adding shapes to the spatial geographic coverage area field.
  - #1924 Fixed dkan_update_7012, if a site is still using a deprecated module, the data is not stripped from the db.
  - #1921 Drop the description label from the Harvest Source node view page.
  - #1912 Added 'ahoy dkan unittests' command.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -183,7 +183,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/leaflet_draw_widget.git'
-      branch: 'master'
+      branch: 'fix_export_polygon_to_geojson_civic_6072'
   libraries:
     version: '2.3'
   link:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -183,7 +183,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/leaflet_draw_widget.git'
-      branch: 'fix_export_polygon_to_geojson_civic_6072'
+      branch: 'master'
   libraries:
     version: '2.3'
   link:


### PR DESCRIPTION
Issue: CIVIC-6072

## Description

When adding the Spatial/Geographic Coverage Area for a Dataset in 1.13 the user will run into an error if they follow these steps:

- Add a polygon to the map
- Switches to the GeoJSON and you'll see just null values recorded
- If you switch back to the map it will not display a map

## QA Steps

- [x] Try to add a polygon on the map (dataset edit form).
- [x] Change to tab GeoJSON and you shouldn't see null values.
- [x] Switch back to the map and confirm that you see the map.

## Merge process

- [x] Merge https://github.com/NuCivic/leaflet_draw_widget/pull/19
- [x] Revert the leaflet_draw_widget branch on this PR.
- [x] Merge this PR.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
