### PR TITLE
Update tests with @disablecaptcha tag  CIVIC-6415

### DIFF
--- a/test/features/data_dashboard.feature
+++ b/test/features/data_dashboard.feature
@@ -1,4 +1,5 @@
 # time:0m23.59s
+@disablecaptcha
 Feature: Data Dashboard
 
   Background:

--- a/test/features/data_story.author.feature
+++ b/test/features/data_story.author.feature
@@ -1,5 +1,5 @@
 # time:0m23.12s
-@api
+@api @disablecaptcha
 Feature: Data Stories
 
   Background:

--- a/test/features/dataset.admin.feature
+++ b/test/features/dataset.admin.feature
@@ -1,5 +1,5 @@
 # time:0m15.83s
-@api
+@api @disablecaptcha
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -1,5 +1,5 @@
 # time:2m56.53s
-@api
+@api @disablecaptcha
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor

--- a/test/features/dataset.editor.feature
+++ b/test/features/dataset.editor.feature
@@ -1,7 +1,7 @@
 # time:0m18.30s
 # The first scenario requires that the timezone be set to UTC.
 # @timezone will set the timezone for tests and restore the timezone afterwards.
-@api @timezone
+@api @timezone @disablecaptcha
 Feature: Dataset Features
   In order to realize a named business value
   As an explicit system actor

--- a/test/features/dataset_rest_api.feature
+++ b/test/features/dataset_rest_api.feature
@@ -1,4 +1,5 @@
 # time:0m32.86s
+@disablecaptcha
 Feature: DKAN Dataset REST API
 
   Background:

--- a/test/features/datastore.feature
+++ b/test/features/datastore.feature
@@ -1,5 +1,5 @@
 # time:0m28.91s
-@api
+@api @disablecaptcha
 Feature: Datastore
   In order to know the datastore is working
   As a website user

--- a/test/features/datastore_fast_import.feature
+++ b/test/features/datastore_fast_import.feature
@@ -1,4 +1,4 @@
-@api @enableFastImport @javascript
+@api @enableFastImport @javascript @disablecaptcha
 Feature: DKAN Datastore Fast Import
   Background:
     Given pages:

--- a/test/features/default_content.feature
+++ b/test/features/default_content.feature
@@ -27,7 +27,7 @@ Feature: Homepage
     # Pages should not get removed when the default content module is disabled.
     And all default content with type "node" and bundle "page" listed in "page" fixture should "be loaded"
 
-  @api
+  @api @disablecaptcha
   Scenario: Enable the default content module back
     Given I am logged in as a user with the "administrator" role
     Then I enable the module "dkan_default_content"

--- a/test/features/dkan_harvest.feature
+++ b/test/features/dkan_harvest.feature
@@ -1,5 +1,5 @@
 # time:3m30.05s
-@harvest_rollback
+@harvest_rollback @disablecaptcha
 Feature: Dkan Harvest
 
   @api @javascript

--- a/test/features/gravatar.feature.disabled
+++ b/test/features/gravatar.feature.disabled
@@ -1,6 +1,6 @@
 Feature: Gravatar
 
-  @api @javascript
+  @api @javascript @disablecaptcha
   Scenario: Test gravatar in user pictures.
     Given I am logged in as a user with the "content creator" role
     When I visit "user/"

--- a/test/features/group.admin.feature
+++ b/test/features/group.admin.feature
@@ -1,5 +1,5 @@
 # time:1m2.37s
-@api
+@api @disablecaptcha
 Feature: Site managers administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/group.author.feature
+++ b/test/features/group.author.feature
@@ -1,4 +1,5 @@
 # time:0m13.79s
+@disablecaptcha
 Feature: Site Manager administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -1,5 +1,5 @@
 # time:0m50.36s
-@api
+@api @disablecaptcha
 Feature: Site Manager administer groups
   In order to manage site organization
   As a Site Manager

--- a/test/features/groups.feature.disabled
+++ b/test/features/groups.feature.disabled
@@ -1,3 +1,4 @@
+@disablecaptcha
 Feature: Groups
   In order to know the groups are working
   As a website user

--- a/test/features/home.feature
+++ b/test/features/home.feature
@@ -1,4 +1,5 @@
 # time:0m11.86s
+@disablecaptcha
 Feature: Homepage
   In order to know the website is running
   As a website user

--- a/test/features/leaflet_draw_widget.feature
+++ b/test/features/leaflet_draw_widget.feature
@@ -1,5 +1,5 @@
 # time:0m11.71s
-@api @javascript
+@api @javascript @disablecaptcha
 Feature: Leaflet Map Widget
 
   Scenario: Adds "New Table Widget" block to home page using panels ipe editor

--- a/test/features/markdown_editor.feature
+++ b/test/features/markdown_editor.feature
@@ -1,5 +1,5 @@
 # time:1m32.15s
-@javascript @api
+@javascript @api @disablecaptcha
 Feature: Markdown Editor
   In order to create content
   As a user with edition permissions

--- a/test/features/page.editor.feature
+++ b/test/features/page.editor.feature
@@ -1,4 +1,5 @@
 # time:0m11s
+@disablecaptcha
 Feature: Page
 
   Background:

--- a/test/features/panels.feature
+++ b/test/features/panels.feature
@@ -1,4 +1,5 @@
 # time:0m21.02s
+@disablecaptcha
 Feature: Panels
 
   @api @javascript

--- a/test/features/pod.feature
+++ b/test/features/pod.feature
@@ -1,4 +1,5 @@
 # time:1m15.22s
+@disablecaptcha
 Feature: Project Open Data + Open Data Federal Extras
   In order to meet POD
   As a dataset creator

--- a/test/features/recline.feature
+++ b/test/features/recline.feature
@@ -1,5 +1,5 @@
 # time:1m5.66s
-@api
+@api @disablecaptcha
 Feature: Recline
   In order to know the recline preview is working
   As a website user

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -1,5 +1,5 @@
 # time:2m54.08s
-@api
+@api @disablecaptcha
 # in the resource tests, when it uses "Given resources:" it defines a property called 'datastore created' with either a 'yes' or 'no', which is used in some tests -  should I try to map that when creating the resource in resourceContext? @Frank
 Feature: Resource
 

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -1,4 +1,5 @@
 # time:0m21.63s
+@disablecaptcha
 Feature: Resource
 
   Background:

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -1,5 +1,5 @@
 # time:4m30.30s
-@api
+@api @disablecaptcha
 Feature: Resource
 
   Background:

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -1,5 +1,5 @@
 # time:3m12.22s
-@api
+@api @disablecaptcha
 Feature: Resource
 
   Background:

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -1,5 +1,5 @@
 # time:0m22s
-@api @javascript
+@api @javascript @disablecaptcha
 Feature: Theme
 
   Background:

--- a/test/features/topics.feature
+++ b/test/features/topics.feature
@@ -1,4 +1,5 @@
 # time:0m2.37s
+@disablecaptcha
 Feature: Topics
 
   Background:

--- a/test/features/user.access_denied.feature
+++ b/test/features/user.access_denied.feature
@@ -1,5 +1,5 @@
 # time:2m5.09s
-@api
+@api @disablecaptcha
 Feature: Users with Editor, Content Creator or Site Manager roles should not have access to administration pages.
 
   Background:

--- a/test/features/user.admin.feature
+++ b/test/features/user.admin.feature
@@ -1,5 +1,5 @@
 # time:0m45.62s
-@api
+@api @disablecaptcha
 Feature: User
 
   Background:

--- a/test/features/user.all.feature
+++ b/test/features/user.all.feature
@@ -1,5 +1,5 @@
 # time:0m23.59s
-@api
+@api @disablecaptcha
 Feature: User
 
   Background:

--- a/test/features/user.author.feature
+++ b/test/features/user.author.feature
@@ -1,4 +1,5 @@
 # time:0m6.21s
+@disablecaptcha
 Feature: User
 
   Background:

--- a/test/features/user.content_creator.feature
+++ b/test/features/user.content_creator.feature
@@ -1,5 +1,5 @@
 # time:0m14.99s
-@api
+@api @disablecaptcha
 Feature: User command center links for content creator role.
 
   Background:

--- a/test/features/user.editor.feature
+++ b/test/features/user.editor.feature
@@ -1,5 +1,5 @@
 # time:0m25.25s
-@api
+@api @disablecaptcha
 Feature: User command center links for editor role.
 
   Background:

--- a/test/features/user.site_manager.feature
+++ b/test/features/user.site_manager.feature
@@ -4,7 +4,7 @@
 # and visiting them using the visit step.
 # In that way we can remove the javascript part.
 ##
-@api @javascript
+@api @javascript @disablecaptcha
 Feature: User command center links for site manager role.
 
   Background:

--- a/test/features/vis_entity_embeds.feature.disabled
+++ b/test/features/vis_entity_embeds.feature.disabled
@@ -1,4 +1,4 @@
-@api @javascript
+@api @javascript @disablecaptcha
 Feature: Visualization entity embed test.
 
     #TODO: Works up until adding a visualization, where it cannot find the newly added VE Chart contnet.

--- a/test/features/widgets.feature
+++ b/test/features/widgets.feature
@@ -1,5 +1,5 @@
 # time:4m38.05s
-@api @javascript
+@api @javascript @disablecaptcha
 Feature: Widgets
 
   Background:

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -1,5 +1,5 @@
 # time:4m22.76s
-@api @enableDKAN_Workflow
+@api @enableDKAN_Workflow @disablecaptcha
 Feature:
   Workflow (Workbench) tests for DKAN Workflow Module
 

--- a/test/features/workflow_emails.feature
+++ b/test/features/workflow_emails.feature
@@ -1,4 +1,4 @@
-@api @enableDKAN_Workflow
+@api @enableDKAN_Workflow @disablecaptcha
 Feature:
   Workflow (Workbench) tests for emails related to DKAN Workflow Module
 


### PR DESCRIPTION
Issue: CIVIC-3478 CIVIC-6415

## Description

We want to run dkan tests on client sites, certain client sites are using debut_blog (and custom features) that require captcha so we can not temp disable it for tests. Adding the tag will disable the module for specific scenarios where we use `Given I am logged in as a user with the "<role>" role`

## QA Steps

- [x] tests pass

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
