### PR TITLE
Fix windows delimiter for datastore_fast_import.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1898 Add validation to field data dictionary when strict POD validation is enabled.
  - #1920 Update Bureau codes for Open Data Federal Extras.
  - #1927 Fixed adding shapes to the spatial geographic coverage area field.
  - #1924 Fixed dkan_update_7012, if a site is still using a deprecated module, the data is not stripped from the db.

--- a/dkan.install
+++ b/dkan.install
@@ -347,3 +347,12 @@ function dkan_update_7019() {
   variable_del('dkan_dataset_api_package_revision_list');
   variable_del('dkan_dataset_api_group_list');
 }
+
+/**
+ * Update chosen_jquery_selector to avoid misuse.
+ */
+function dkan_update_7020() {
+  // REF #1936, #1890.
+  variable_set('chosen_jquery_selector',
+    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])');
+}

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -497,6 +497,24 @@ function dkan_dataset_dataset_node_form_validate($form, &$form_state) {
   if (isset($public_access_level) && $public_access_level != 'public' && empty($rights)) {
     form_set_error('field_rights', 'Rights field is required.');
   }
+
+  // Validate data dictionary with strict POD.
+  if (variable_get('dkan_dataset_form_pod_validation')) {
+    $field_data_dictionary_langcode = dkan_dataset_form_field_language($form, 'field_data_dictionary');
+    $data_dictionary = $form_state['values']['field_data_dictionary'][$field_data_dictionary_langcode][0]['value'];
+
+    // In order to pass strict POD validation the 'data dictionary' value must be NULL,
+    // a valid URL or redacted.
+    if (isset($data_dictionary) && $data_dictionary != '') {
+      $is_valid_URL = valid_url($data_dictionary, TRUE);
+      $is_redacted = preg_match('/^(\\[\\[REDACTED).*?(\\]\\])$/', $data_dictionary);
+
+      // If a value is present (not NULL) then chech if it is a valid URL or redacted.
+      if (!$is_valid_URL && !$is_redacted) {
+        form_set_error('field_data_dictionary', t('Data dictionary should be empty, a valid URL or redacted.'));
+      }
+    }
+  }
 }
 
 /**

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], ["id*="lines-terminated-by"])';
+  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"])';
+  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], ["id*="lines-terminated-by"])';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -289,9 +289,9 @@ function dkan_datastore_fast_import_form_alter(&$form, &$form_state, $form_id) {
       '#type' => 'select',
       '#title' => t('Lines terminated by:'),
       '#options' => array(
-        '\n' => '\n',
-        '\r' => '\r',
-        '\n\r' => '\n\r',
+        '\n' => '\n (Unix)',
+        '\r\n' => '\r\n (Windows)',
+        '\r' => '\r (Legacy Mac)',
       ),
       '#default_value' => variable_get('lines_terminated_by', '\n'),
       '#states' => array(


### PR DESCRIPTION
REF CIVIC-6466
## Description
Fast File imports has an option for which line endings are used for csv files. One of the options is /n/r for Windows line endings, but the actual characters for Window line endings are /r/n
https://en.wikipedia.org/wiki/Newline

###Steps to Reproduce
* enable fast imports
* navigate to a resource
* manage datastore
* check the options for 'Lines terminated by'
* try to import a file with windows endings using \n\r and it will fail

##Acceptance Criteria
* When fast imports is enabled I should see these options for 'Lines terminated by:'
```
\n (Unix)
\r\n (Windows)
\r (Legacy Mac)
```
* When I use a file with windows line endings, and select \r\n when choosing an option for 'Lines terminated by', then the file should be imported completely.