### PR TITLE
Make fast import queue run during cron. 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
-7.x-1.13.4
+7.x-1.13.x
 ----------
+ - #1910 Make fast import queue run during cron.
  - #1906 Refactor datastore import to restore drush command (dsu).
  - #1898 Add validation to field data dictionary when strict POD validation is enabled.
  - #1920 Update Bureau codes for Open Data Federal Extras.
@@ -42,9 +43,6 @@
  - #1852 Allow the use of multi-polygonal data for Dataset Spatial field.
  - #1857 Fixed publishing options not accessible when dkan_workflow is enabled. 
 
-7.x-1.13.3-RC1
---------------
- - #1810 Stop throwing exception on tables with only numeric columns, to prevent preview breaking.
 7.x-1.13.3 2017-04-18
 ---------------------
  - #1863 Update restws module to v2.7

--- a/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
@@ -461,7 +461,7 @@ class DkanDatastore extends Datastore implements DatastoreFormInterface {
    *   A boolean indicating whether to copy the file locally.
    *   If set to TRUE the file is copied locally.
    */
-  public function updateFromFileUri($uri, $copy_file = TRUE) {
+  public function updateFromFileUri($uri = '', $copy_file = TRUE) {
     $file = FALSE;
 
     // Sanity check: make sure the file exits.

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -140,7 +140,7 @@ function dkan_datastore_fast_import_cron_queue_info() {
   return array(
     dkan_datastore_fast_import_queue_name() => array(
       'worker callback' => 'dkan_datastore_fast_import_import_queue_worker',
-      'skip on cron' => TRUE,
+      'skip on cron' => FALSE,
       'time' => 600,
     ),
   );


### PR DESCRIPTION

Re-roll of #1910 

Issue: CIVIC-6363

## Description

When we try to import the datastore for a node using fast imports and the option for `queue_filesize_threshold`, the website displays a message that says, `File was succesfully enqueued to be imported and will be available in the datastore in a few minutes.` However, the import never runs. Even if we run the cron manually to force the import we get no success. Using drush queue-run also doesn't work. Here's the drush command and the response:

```
drush @cadepttech.test queue-run dkan_datastore_queue
Processed 0 items from the dkan_datastore_queue queue in 0 sec.
```

The issue is the callback function is not being run on crun, so here we're setting the option for skipping the queue on cron to false, that way the issue gets fixed.

## QA Steps

* Go to admin/dkan/datastore and select the option `Use fast import for files with a weight over:`, then add a size in the textbox "File size threshold".
* Go to a resource page in which the file is bigger than the size set in the step before and click on "Manage Datastore".
* Make sure the option "Use fast import" is checked and click on "Import".
* You should see a message that reads `File was succesfully enqueued to be imported and will be available in the datastore in a few minutes.`
* After the next cron run (or if you execute it manually), the resource should be fully imported into the datastore.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
