### PR TITLE
Fix fast import docs.

### DIFF
--- a/docs/components/datastore.rst
+++ b/docs/components/datastore.rst
@@ -192,7 +192,7 @@ Installation
 
     Required PDO flags for dkan_datastore_fast_import were not found. This module requires PDO::MYSQL_ATTR_LOCAL_INFILE and PDO::MYSQL_ATTR_USE_BUFFERED_QUERY
 
-- Set up the following command to run periodically using a cronjob or similar: ``drush queue-run dkan_datastore_queue``
+- Set up the following command to run periodically using a cronjob or similar: ``drush queue-run dkan_datastore_fast_import_queue``
 
 
 Configuration


### PR DESCRIPTION
Issue: CIVIC-6363.

## Description

Fixed the command that needs to be run periodically on a cronjob when using fast import. The documentation says the command is `drush queue-run dkan_datastore_queue`, but that is not ok, we have another queue when we are using fast import, so the right command is `drush queue-run dkan_datastore_fast_import_queue`
