### PR TITLE
Allow skipping of features test via config.

### DIFF
--- a/.ahoy/.scripts/behat-parse-params.rb
+++ b/.ahoy/.scripts/behat-parse-params.rb
@@ -3,7 +3,6 @@
 #
 require "base64"
 require "./dkan/.ahoy/.scripts/config.rb"
-require "pp"
 
 def behat_join_params args
   args.join(" ").split("--").map do |arg|

--- a/.ahoy/.scripts/behat-parse-params.rb
+++ b/.ahoy/.scripts/behat-parse-params.rb
@@ -2,6 +2,8 @@
 # Defines helper function for processing behat parameters.
 #
 require "base64"
+require "./dkan/.ahoy/.scripts/config.rb"
+require "pp"
 
 def behat_join_params args
   args.join(" ").split("--").map do |arg|
@@ -40,7 +42,14 @@ def behat_parse_params args
     puts "Seaching #{param} for feature files..."
     # Fetch all of the feature files for each parameter (directories)
     if Dir.exist? param
-      Dir.glob("#{param}/*.feature") {|f| files.push f}
+      Dir.glob("#{param}/*.feature") {
+        |f|
+        filename = File.basename(f)
+        if CONFIG["circle"]["skip_features"].include? filename
+          next
+        end
+        files.push f
+      }
 
       # Add loose features passed in as direct paths
     elsif File.exist? param

--- a/.ahoy/.scripts/circle-behat.rb
+++ b/.ahoy/.scripts/circle-behat.rb
@@ -25,19 +25,8 @@ parsed = behat_parse_params(ARGV)
 params = behat_join_params parsed[:params]
 files = balance(parsed[:files])
 
-begin
-  config = YAML.load_file("config/config.yml")
-rescue Exception
-  config = {"circle" => {"skip_features" => []}}
-end
-
 files[CIRCLE_NODE_INDEX].each_index do |i|
-  filename = File.basename(files[CIRCLE_NODE_INDEX][i])
-  if config["circle"]["skip_features"].include? filename
-    next
-  end
   file = Pathname(files[CIRCLE_NODE_INDEX][i]).realpath.to_s
-
   suite = behat_parse_suite(file)
   puts "RUNNING: ahoy dkan test #{file} --suite=#{suite} --format=pretty --out=std --format=junit --out='#{CIRCLE_ARTIFACTS}/junit' #{params} --colors"
   IO.popen(

--- a/.ahoy/.scripts/circle-behat.rb
+++ b/.ahoy/.scripts/circle-behat.rb
@@ -20,14 +20,24 @@ TOKENS = {
 puts "CIRCLE_NODE_TOTAL = #{CIRCLE_NODE_TOTAL}"
 puts "CIRCLE_NODE_INDEX = #{CIRCLE_NODE_INDEX}"
 
-
 error = 0
 parsed = behat_parse_params(ARGV)
 params = behat_join_params parsed[:params]
 files = balance(parsed[:files])
 
+begin
+  config = YAML.load_file("config/config.yml")
+rescue Exception
+  config = {"circle" => {"skip_features" => []}}
+end
+
 files[CIRCLE_NODE_INDEX].each_index do |i|
+  filename = File.basename(files[CIRCLE_NODE_INDEX][i])
+  if config["circle"]["skip_features"].include? filename
+    next
+  end
   file = Pathname(files[CIRCLE_NODE_INDEX][i]).realpath.to_s
+
   suite = behat_parse_suite(file)
   puts "RUNNING: ahoy dkan test #{file} --suite=#{suite} --format=pretty --out=std --format=junit --out='#{CIRCLE_ARTIFACTS}/junit' #{params} --colors"
   IO.popen(

--- a/.ahoy/.scripts/config.rb
+++ b/.ahoy/.scripts/config.rb
@@ -1,0 +1,11 @@
+require 'yaml'
+
+begin
+  CONFIG = YAML.load_file("config/config.yml")
+rescue Exception => msg
+  puts "Loading of Configuration errored out with: #{msg}."
+  puts "Using default CONFIG instead."
+  CONFIG = {"circle" => {"skip_features" => []}}
+end
+
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@
  - #1839 Add help text and improve UI on the chart form for better clarity.
  - #1827 Remove option to import TABed CSV files into datastore. 
  - #1807 Add admin_views module for enhanced content and file filtering. 
+ - #1938 DevOps: Allow behat tests to be skipped in circle.
 
 7.x-1.13.x
 ----------


### PR DESCRIPTION
REF CIVIC-6480

Description
===
We want to run dkan tests on client sites but some client sites will have extensive customizations (HHS) that cause tests to fail in ways we can't adjust for so we need to be able to skip the whole file. Using tags to skip the feature causes a new error because there are no scenarios to run.
Acceptance Criteria

A. Find an argument in behat that avoids the No specifications found at path(s) error when using tags
OR
B. There is a section in the config.yml file to list features to skip when running tests. Something like the following

```
circle:
  test_dirs:
    - config/tests/features
    - dkan/test/features
  skip_tags:
    - customizable 
    - fixme
  skip_features:
    - dataset.admin.feature
    - dataset.author.feature
    - dataset.editor.feature
```