### PR TITLE
Added changes from PR#1936

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1940 Fix slow remote_file datastore imports.
  - #1925 Fix issues with remote_stream_wrapper and recline causing Harvest and Search API to fail on certain larger resources
  - #1906 Refactor datastore import to restore drush command (dsu).
  - #1898 Add validation to field data dictionary when strict POD validation is enabled.

--- a/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
@@ -461,7 +461,7 @@ class DkanDatastore extends Datastore implements DatastoreFormInterface {
    *   A boolean indicating whether to copy the file locally.
    *   If set to TRUE the file is copied locally.
    */
-  public function updateFromFileUri($uri, $copy_file = TRUE) {
+  public function updateFromFileUri($uri = '', $copy_file = TRUE) {
     $file = FALSE;
 
     // Sanity check: make sure the file exits.

--- a/modules/dkan/dkan_datastore/includes/DkanDatastoreFastImport.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastoreFastImport.inc
@@ -15,13 +15,6 @@ class DkanDatastoreFastImport extends DkanDatastore implements DatastoreFormInte
   const FAST_IMPORT_THRESHOLD_DEFAULT = '30MB';
 
   /**
-   * Sets default items for datastore object.
-   */
-  protected function __construct($uuid) {
-    parent::__construct($uuid);
-  }
-
-  /**
    * Takes values from form submit, saves updated config and starts import.
    */
   public function manageFormSubmit(&$form_state) {
@@ -46,9 +39,16 @@ class DkanDatastoreFastImport extends DkanDatastore implements DatastoreFormInte
     variable_set('fields_escaped_by', $form_state['values']['fields_escaped_by']);
     variable_set('dkan_datastore_fast_import_load_empty_cells_as_null', $form_state['values']['dkan_datastore_fast_import_load_empty_cells_as_null']);
 
-    // If a remote file is provided we fallback to feeds importer
-    // else we perform a fast import.
-    if (!empty($file_remote) || !$use_fast_import) {
+    // The stream_wrapper import is too slow.
+    // We need to force regular upload import for remote_files.
+    if ($file_remote) {
+      $use_fast_import = TRUE;
+      $node = $form_state['build_info']['args'][0];
+      $node->field_upload = $node->field_link_remote_file;
+      $node = entity_metadata_wrapper('node', $node);
+    }
+
+    if (!$use_fast_import) {
       $this->import();
     }
     else {

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -201,6 +201,9 @@ function dkan_datastore_fast_import_import($source, $node, $table, $config) {
       }
     }
     $node->field_datastore_status->set(DKAN_DATASTORE_EXISTS);
+    if ($node->field_link_remote_file->value()) {
+      $node->field_upload->set(NULL);
+    }
     $node->save();
     return array('total_imported_items' => $result->rowCount());
   }
@@ -304,7 +307,7 @@ function dkan_datastore_fast_import_form_alter(&$form, &$form_state, $form_id) {
       '#type' => 'textfield',
       '#title' => t('Fields escaped by:'),
       '#default_value' => variable_get('fields_escaped_by', ''),
-      '#description' => t('The character used to escape other characters on each fields. Leave empty if it isn\'t needed.'),
+      '#description' => t("The character used to escape other characters on each fields. Leave empty if it isn't needed."),
       '#states' => array(
         'invisible' => array(
           ':input[name="use_fast_import"]' => array('checked' => FALSE),


### PR DESCRIPTION
Issue: CIVIC-5317

Makes remote_file temporarily upload_file fields during a datastore import.
This has the value of bi-passing the remote-stream wrapper which is very slow
for datastore imports and can take up to 3 hours for 15 megabyte file.

Description
===
When trying to import a remote file resource into the datastore it takes a very long time. This is an unexpected behavior and is likely fixable by first downloading the remote file locally before attempting to import it.
This is partly the cause of CIVIC-5292 and CIVIC-5293

Steps to Reproduce
===
* Add the following remote file resource to a dataset https://gisdata.nd.gov/Metadata/CSV/NDHUB.Roads_County.csv
* Attempt to import the resource into the datastore
* Observe how slowly the import takes place