### PR TITLE
Fix function definition on DKAN Datastore

### DIFF
--- a/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
@@ -461,7 +461,7 @@ class DkanDatastore extends Datastore implements DatastoreFormInterface {
    *   A boolean indicating whether to copy the file locally.
    *   If set to TRUE the file is copied locally.
    */
-  public function updateFromFileUri($uri, $copy_file = TRUE) {
+  public function updateFromFileUri($uri = '', $copy_file = TRUE) {
     $file = FALSE;
 
     // Sanity check: make sure the file exits.


### PR DESCRIPTION
Issue: None

## Description

A strict warning message is displayed when a user access to the datastore saying that the updateFromFileUri() function definition is wrong.

## How to reproduce

1. Go to any resource page.
2. Go to the "Manage datastore" section and confirm that you see a strict warning saying that the updateFromFileUri() function definition is wrong.

## QA Steps

- [x] Go to any resource page.
- [x] Go to the "Manage datastore" section.
- [x] Confirm that you don't see any warning.
