### PR TITLE
Fix php error for dots in URL. Add new `ahoy dkan server` command

### DIFF
--- a/.ahoy/.scripts/.ht.router.php
+++ b/.ahoy/.scripts/.ht.router.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ * Routing-script for the built-in PHP web server.
+ *
+ * The built-in webserver should only be used for development and testing as it
+ * has a number of limitations that makes running Drupal on it highly insecure
+ * and somewhat limited.
+ *
+ * In particular be aware that:
+ *   - The server is single-threaded, any requests made during the execution of
+ *     the main request will hang until the main request has been completed.
+ *   - The webserver does not enforce any of the settings in .htaccess in
+ *     particular a remote user will be able to download files that normally
+ *     would be protected from direct access such as .module files.
+ *
+ * Usage:
+ * php -S localhost:8888 .ht.router.php
+ *
+ * @see http://php.net/manual/en/features.commandline.webserver.php
+ */
+
+$url = parse_url($_SERVER['REQUEST_URI']);
+if (file_exists('.' . $url['path'])) {
+  // Serve the requested resource as-is.
+  return FALSE;
+}
+
+// The use of a router-script means that a number of $_SERVER variables has to
+// be updated to point to the index-file.
+$index_file_absolute = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
+$index_file_relative = DIRECTORY_SEPARATOR . 'index.php';
+
+// SCRIPT_FILENAME will point to the router-script itself, it should point to
+// the full path to index.php.
+$_SERVER['SCRIPT_FILENAME'] = $index_file_absolute;
+
+// SCRIPT_NAME and PHP_SELF will either point to /index.php or contain the full
+// virtual path being requested depending on the url being requested. They
+// should always point to index.php relative to document root.
+$_SERVER['SCRIPT_NAME'] = $index_file_relative;
+$_SERVER['PHP_SELF'] = $index_file_relative;
+
+// Require the main index-file and let core take over.
+require $index_file_absolute;

--- a/.ahoy/.scripts/server.sh
+++ b/.ahoy/.scripts/server.sh
@@ -1,0 +1,12 @@
+
+if [ "$HOSTNAME" = "cli" ]; then
+  HOST=cli
+else
+  HOST=localhost
+fi
+
+cp ./dkan/.ahoy/.scripts/.ht.router.php ./docroot/
+cd ./docroot
+
+echo $HOST
+php -S $HOST:8888 .ht.router.php

--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -195,3 +195,8 @@ commands:
       else
         echo $url
       fi
+
+  server:
+    usage: Provided as an easy way to setup the php server during testing.
+    cmd:
+      ahoy cmd-proxy bash dkan/.ahoy/.scripts/server.sh

--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -11,6 +11,7 @@ web:
   ports:
     - "80"
     - "443"
+    - "8888"
   volumes:
     # PHP configuration overrides
     - "./.docker/etc/php5/php.ini:/etc/php5/fpm/conf.d/z_php.ini"
@@ -49,21 +50,24 @@ cli:
   environment:
     - XDEBUG_CONFIG=idekey=cli
     - PHP_IDE_CONFIG=serverName=dkan.docker
+    - VIRTUAL_HOST=dkan.docker
   volumes:
     # PHP configuration overrides
     - "./.docker/etc/php5/php-cli.ini:/etc/php5/cli/conf.d/z_php.ini"
     # Project root folder mapping
     - *project_root
+  links:
     # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
     # - /.ssh:/.ssh   # boot2docker-vagrant
     - ~/.ssh:/.ssh  # Linux
-  links:
     - db
     - web
     # Uncomment this and the browser service definition below to start using selenium2.
     - browser
     - memcached
     - solr
+  ports:
+    - "8888"
 
 # Memcached node
 # Uncomment the service definition section below and the link in the web service above to start using memcached.

--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -56,10 +56,10 @@ cli:
     - "./.docker/etc/php5/php-cli.ini:/etc/php5/cli/conf.d/z_php.ini"
     # Project root folder mapping
     - *project_root
-  links:
     # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
     # - /.ssh:/.ssh   # boot2docker-vagrant
     - ~/.ssh:/.ssh  # Linux
+  links:
     - db
     - web
     # Uncomment this and the browser service definition below to start using selenium2.

--- a/circle.yml
+++ b/circle.yml
@@ -60,7 +60,7 @@ dependencies:
     - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush --yes en dkan_harvest dkan_harvest_datajson dkan_harvest_dashboard'
     - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush cc all'
     # Run a webserver using drush.
-    - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush --yes runserver :8888':
+    - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy dkan server':
         background: true
 
     # Setup display for selenium


### PR DESCRIPTION
Description
==
CIRCLE CI Uses the php server to server dkan and there are some issues that
cannot be reproduced locally unless we use this server.  This command enables
pages to be served via the PHP server in order to test locally some issues that
be be caused by the PHP server.

Updates circle.yml to use this new command.

Acceptance
==
- [ ] `ahoy dkan server` serves dkan.