### PR TITLE
Update contrib modules

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -34,7 +34,7 @@ projects:
   bueditor_plus:
     version: '1.4'
   chosen:
-    version: '2.0'
+    version: '2.1'
     patch:
       2834096: https://www.drupal.org/files/issues/chosen-accesibility_problem_with_input-0.patch
   colorizer:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -75,7 +75,7 @@ projects:
     patch:
       2809655: https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff
   entityreference:
-    version: '1.2'
+    version: '1.4'
   entityreference_filter:
     version: '1.7'
   facetapi:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -332,7 +332,7 @@ projects:
   token:
     version: '1.7'
   uuid:
-    version: 1.0-beta2
+    version: '1.0'
   views:
     version: '3.15'
   views_autocomplete_filters:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -311,7 +311,7 @@ projects:
   search_api:
     version: '1.21'
   search_api_db:
-    version: '1.5'
+    version: '1.6'
   select_or_other:
     version: '2.22'
   services:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -330,7 +330,7 @@ projects:
       url: 'https://github.com/NuCivic/taxonomy_fixtures.git'
       branch: 7.x-1.x
   token:
-    version: '1.6'
+    version: '1.7'
   uuid:
     version: 1.0-beta2
   views:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -249,7 +249,7 @@ projects:
   panelizer:
     version: '3.4'
   panels:
-    version: '3.8'
+    version: '3.9'
   panels_style_collapsible:
     version: '1.3'
   panopoly_widgets:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -49,7 +49,7 @@ projects:
   conditional_styles:
     version: '2.2'
   context:
-    version: '3.6'
+    version: '3.7'
   ctools:
     version: '1.12'
   data:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -55,7 +55,7 @@ projects:
   data:
     version: 1.x
   date:
-    version: '2.9'
+    version: '2.10'
   defaultconfig:
     version: 1.0-alpha11
   diff:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -341,7 +341,7 @@ projects:
       2374709: http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch
       2317351: http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch
   views_bulk_operations:
-    version: '3.3'
+    version: '3.4'
   views_responsive_grid:
     version: '1.3'
   visualization_entity:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -295,7 +295,7 @@ projects:
   role_export:
     version: '1.0'
   rules:
-    version: '2.9'
+    version: '2.10'
     patch:
       2406863: https://www.drupal.org/files/issues/rules-remove-cache-rebuild-log-2406863-21.patch
       2851567: https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -213,7 +213,7 @@ projects:
   menu_admin_per_menu:
     version: '1.1'
   menu_badges:
-    version: '1.2'
+    version: '1.3'
   menu_block:
     version: '2.7'
   menu_token:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -309,7 +309,7 @@ projects:
     version: '1.2'
     revision: 08b02458694d186f8ab3bd0b24fbc738f9271108
   search_api:
-    version: '1.20'
+    version: '1.21'
   search_api_db:
     version: '1.5'
   select_or_other:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -59,7 +59,7 @@ projects:
   defaultconfig:
     version: 1.0-alpha11
   diff:
-    version: '3.2'
+    version: '3.3'
   double_field:
     version: '2.4'
   draggableviews:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -317,7 +317,7 @@ projects:
   services:
     version: '3.19'
   simple_gmap:
-    version: '1.3'
+    version: '1.4'
   strongarm:
     version: '2.0'
   tablefield:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -359,7 +359,7 @@ projects:
     patch:
       2360973: https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch
   drafty:
-    version: 1.0-beta3
+    version: 1.0-beta4
 libraries:
   chosen:
     download:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -225,7 +225,7 @@ projects:
   migrate_extras:
     version: '2.5'
   module_filter:
-    version: '2.0'
+    version: '2.1'
   multistep:
     download:
       type: git

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -259,7 +259,7 @@ projects:
       2: patches/panopoly_widgets_add_jquery_ui_tabs.patch
       3: patches/panopoly_widgets_overrides_OOB.patch
   panopoly_images:
-    version: '1.41'
+    version: '1.45'
   path_breadcrumbs:
     version: '3.3'
   pathauto:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -253,7 +253,7 @@ projects:
   panels_style_collapsible:
     version: '1.3'
   panopoly_widgets:
-    version: '1.41'
+    version: '1.45'
     patch:
       1: patches/panopoly_widgets_overrides.patch
       2: patches/panopoly_widgets_add_jquery_ui_tabs.patch

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -61,7 +61,7 @@ projects:
   diff:
     version: '3.3'
   double_field:
-    version: '2.4'
+    version: '2.5'
   draggableviews:
     version: '2.1'
   entity:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -353,7 +353,7 @@ projects:
   workbench:
     version: '1.2'
   workbench_email:
-    version: '3.11'
+    version: '3.12'
   workbench_moderation:
     version: '3.0'
     patch:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -302,7 +302,7 @@ projects:
   restws:
     version: '2.7'
   roleassign:
-    version: '1.1'
+    version: '1.2'
   safeword:
     version: '1.13'
   schema:


### PR DESCRIPTION
Issue: CIVIC-6483

## Description

Several contrib modules need to be upgraded for the release.

## QA Steps

1. Confirm that the following modules were upgraded:
- [ ] chosen was upgraded to 2.1
- [ ] context was upgraded to 3.7
- [ ] date was upgraded to 2.10
- [ ] diff was upgraded to 3.3
- [ ] double_field was upgraded to 2.5
- [ ] entityreference was upgraded to 1.4
- [ ] menu_badges was upgraded to 1.3
- [ ] module_filter was upgraded to 2.1
- [ ] panels was upgraded to 3.9
- [ ] panopoly_widgets was upgraded to 1.45
- [ ] panopoly_images was upgraded to 1.45
- [ ] rules was upgraded to 2.10
- [ ] roleassign was upgraded to 1.2
- [ ] search_api was upgraded to 1.21
- [ ] search_api_db was upgraded to 1.6
- [ ] simple_gmap was upgraded to 1.4
- [ ] token was upgraded to 1.7
- [ ] uuid was upgraded to 1.0
- [ ] views_bulk_operations was upgraded to 3.4
- [ ] workbench_email was upgraded to 3.12
- [ ] drafty was upgraded to 1.0-beta4

2. Automatic tests should pass.
3. Since a lot of modules were upgraded some manual QA is also suggested.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
