### PR TITLE
Upgrade Drupal to 7.55

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.4
 ----------
+ - #1956 Update Drupal to 7.55
  - #1925 Fix issues with remote_stream_wrapper and recline causing Harvest and Search API to fail on certain larger resources
  - #1916 Federal extras: Fix spelling of "Government" in group label.
  - #1939 Removed references to DKAN Demo files from PHPUnit tests.

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.54'
+    version: '7.55'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'http://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
Update Drupal core to 7.55. No changes in functionality expected, as this is merely a maintenance release. Tests passing should be enough to merge.