### PR TITLE
Zeros in data are not displayed on line graph Charts

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #1962 Recline.view.nvd3.js: Fixed display of data with zero as values.
  - #1888 Added validation on axis tick settings on visualization_entity.
  - #1725 Fix `ahoy dkan uli` output login link.
  - #1881 Fix yaml syntaxt to make it standard. 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/civic-6355-fix-zero/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -352,7 +352,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: civic-6355-fix-zero
+      branch: 7.x-1.x
     type: module
   workbench:
     version: '1.2'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/6041_chart_axis_range/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/civic-6355-fix-zero/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -352,7 +352,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: 7.x-1.x
+      branch: civic-6355-fix-zero
     type: module
   workbench:
     version: '1.2'


### PR DESCRIPTION
### Description
When creating a Chart using the lineChart type, any zeros in the data are not displayed. Any following data replaces where the 0s should be displayed. 

### Dependencies
- https://github.com/NuCivic/recline.view.nvd3.js/pull/43

## Cleanup 
- [x]  Delete branches with the same name in recline.view.nvd3.js, visualization_entity and dkan