### PR TITLE
Add reconnect step to ahoy dkan drupal-rebuild.

### DIFF
--- a/.ahoy/.scripts/mysql-reconnect.sh
+++ b/.ahoy/.scripts/mysql-reconnect.sh
@@ -1,0 +1,11 @@
+SETTINGS_PATH=docroot/sites/default/settings.php
+DIR=$(dirname $SETTINGS_PATH)
+chmod +w $SETTINGS_PATH 
+chmod +w $DIR
+echo ".. Reconnect mysql."
+MYSQL_IP=`echo $1 | sed 's/.*@\(.*\)\/.*/\1/g'`
+sed -i "s/\(^\s*\)'host' => \(.*\),/\1'host' => $MYSQL_IP,/g" $SETTINGS_PATH
+
+chmod -w $SETTINGS_PATH 
+chmod -w $DIR
+

--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -17,7 +17,11 @@ commands:
       if [ -d docroot ]
         then
           ahoy confirm "./docroot folder alredy exists. Delete it and reinstall drupal?" && chmod -R 777 docroot/sites/default && rm -rf docroot ||
-          { echo ".. skipping installation"; exit 1;}
+          {
+            echo ".. skipping installation";
+            ahoy cmd-proxy bash dkan/.ahoy/.scripts/mysql-reconnect.sh $ARGS
+            exit 1;
+          }
       fi
       ahoy cmd-proxy bash dkan/.ahoy/.scripts/drupal-rebuild.sh $ARGS
 


### PR DESCRIPTION
Every once in a while the mysql docker container IP changes and this brakes the
connection because settings.php is still pointing to the old IP.  This change
resets the mysql IP in order to avoid this issue.