### PR TITLE
Update datastore-api.rst

### DIFF
--- a/docs/apis/datastore-api.rst
+++ b/docs/apis/datastore-api.rst
@@ -14,7 +14,7 @@ Parameters
    resource(s) to be searched against.
 -  **filters** (*mixed*) – array or string of matching conditions to
    select
--  **q** (*string*) – full text query
+-  **q** (*string*) – fulltext search
 -  **offset** (*int*) – offset this number of rows
 -  **limit** (*int*) – maximum number of rows to return (default: 100)
 -  **fields** (*array or comma separated string*) – fields to return


### PR DESCRIPTION
clarify fulltext search param

Issue: link_to_jira_github_issue

## Description
Updated the api docs to make (more) it clear that the `q` param refers to a search string, NOT an arbitrary sql query
