### PR TITLE
Fixes 1.13.4 upgraded issues encountered in devy upgrade.

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -297,13 +297,19 @@ function dkan_update_7015() {
  * Add data dictionary textarea id to bueditor excludes list.
  */
 function dkan_update_7016() {
+  $eid = db_select("bueditor_editors", "bue")
+    ->fields("bue", array("eid"))
+    ->condition("name", "Markdowneditor")
+    ->execute()
+    ->fetchField();
+
   db_update('bueditor_editors')
     ->fields(array(
       'excludes' => 'edit-log
 edit-menu-description
 *data-dictionary*',
     ))
-    ->condition('eid', '5')
+    ->condition('eid', $eid)
     ->execute();
 }
 

--- a/dkan.profile
+++ b/dkan.profile
@@ -130,6 +130,8 @@ function dkan_markdown_setup(array &$context) {
   drupal_write_record('bueditor_editors', $data, array('eid'));
   // Remove unsupported markdown options.
   dkan_delete_markdown_buttons($context);
+
+  return $context;
 }
 
 /**
@@ -324,8 +326,6 @@ function dkan_misc_variables_set(array &$context) {
     'og_extras_groups' => TRUE,
     'og_extras_members' => TRUE,
     'dataset' => TRUE,
-    'admin_views_file' => TRUE,
-    'admin_views_node' => TRUE,
   );
   variable_set('views_defaults', $views_disable);
 }
@@ -497,14 +497,14 @@ function dkan_bueditor_markdown_install() {
     }
   }
 
-  variable_set('bueditor_roles', $bueditor_roles);
-  variable_set('bueditor_user1', $eid);
-
   $eid = db_select("bueditor_editors", "bue")
     ->fields("bue", array("eid"))
     ->condition("name", "Markdowneditor")
     ->execute()
     ->fetchField();
+
+  variable_set('bueditor_roles', $bueditor_roles);
+  variable_set('bueditor_user1', $eid);
 
   $data = array(
     'html' => array('default' => $eid, 'alternative' => 0),

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
@@ -60,29 +60,28 @@ function dkan_default_content_import_default_pages() {
  * Removes all the generated content and disables all enabled migrations.
  */
 function dkan_default_content_disable() {
-  // Rollback Data Dashboards.
-  $migration = Migration::getInstance('dkan_default_content_data_dashboards');
-  $migration->processRollback();
-  // Rollback Data Stories.
-  $migration = Migration::getInstance('dkan_default_content_data_stories');
-  $migration->processRollback();
-  // Rollback Visualization Entities.
-  $migration = Migration::getInstance('dkan_default_content_visualization_entities');
-  $migration->processRollback();
-  // Rollback Datasets.
-  $migration = Migration::getInstance('dkan_default_content_datasets');
-  $migration->processRollback();
-  // Rollback Resources.
-  $migration = Migration::getInstance('dkan_default_content_resources');
-  $migration->processRollback();
-  // Rollback Groups.
-  $migration = Migration::getInstance('dkan_default_content_groups');
-  $migration->processRollback();
-  // Disable Mirations.
-  dkan_default_content_migrations_disable();
+  // Rollback Default Content Migrations.
+  $migrations = array(
+    'dkan_default_content_data_dashboards',
+    'dkan_default_content_data_stories',
+    'dkan_default_content_visualization_entities',
+    'dkan_default_content_datasets',
+    'dkan_default_content_resources',
+    'dkan_default_content_groups',
+  );
 
-  // Clear message queue.
-  drupal_get_messages('status', TRUE);
-  drupal_get_messages('warning', TRUE);
-  drupal_set_message('The default content was removed.');
+  foreach ($migrations as $migration) {
+    if ($migration) {
+      $migration = Migration::getInstance('dkan_default_content_data_dashboards');
+      $migration->processRollback();
+      Migration::deregisterMigration($migration);
+    }
+    else {
+      drupal_watchdog(
+        'dkan_default_content',
+        "You are attempting to disable a non existent migration: %migration", array(
+          '%migration' => $migration,
+        ));
+    }
+  }
 }

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
@@ -59,14 +59,3 @@ function dkan_default_content_dkan_fixtures_register() {
   return 'dkan_default_content';
 }
 
-/**
- * Deregisters migrations.
- */
-function dkan_default_content_migrations_disable() {
-  Migration::deregisterMigration('dkan_default_content_datasets');
-  Migration::deregisterMigration('dkan_default_content_resources');
-  Migration::deregisterMigration('dkan_default_content_groups');
-  Migration::deregisterMigration('dkan_default_content_visualization_entities');
-  Migration::deregisterMigration('dkan_default_content_data_stories');
-  Migration::deregisterMigration('dkan_default_content_data_dashboards');
-}

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -176,6 +176,12 @@ function dkan_topics_field_formatter_view($entity_type, $entity, $field, $instan
       // Custom formatter for topic field.
       foreach ($items as $delta => $item) {
         $term = taxonomy_term_load($item['tid']);
+        if (!$term) {
+          watchdog('dkan_topis', "Attempt to load missing taxonomy term id: %tid", array(
+            '%tid' => $item['tid'],
+          ), WATCHDOG_NOTICE);
+          continue;
+        }
         $url = $base_url . '/search/field_topic/' . pathauto_cleanstring($term->name) . '-' . $term->tid;
         // Gather icon values if font icon is used.
         $icons = field_get_items('taxonomy_term', $term, 'field_topic_icon');

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/HarvestSourceContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/HarvestSourceContext.php
@@ -7,6 +7,7 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Behat\Hook\Scope\AfterFeatureScope;
 
@@ -95,25 +96,61 @@ class HarvestSourceContext extends RawDKANEntityContext {
   }
 
   /**
-  * @AfterScenario @harvest_rollback
-  */
-  public function harvestRollback(AfterScenarioScope $event)
-  {
+   * @BeforeScenario @harvest
+   */
+  public function harvestSetup(BeforeScenarioScope $event) {
+    $user = user_load_by_name("sitemanager");
+    $sources = array(
+      "source_one" => "Source one",
+      "source_two" => "Source two",
+    );
+
+    foreach ($sources as $machine_name => $title) {
+      $user = user_load_by_name("sitemanager");
+      $entity = array('type' => 'harvest_source');
+      $entity = entity_create('node', $entity);
+      $wrapper = entity_metadata_wrapper('node', $entity);
+      $wrapper->title = $title;
+      $wrapper->status = 1;
+      $wrapper->field_dkan_harveset_type = 'datajson_v1_1_json';
+      $wrapper->field_dkan_harvest_source_uri = 'http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json';
+      $wrapper->field_dkan_harvest_machine_name = array(
+        'human' => $title,
+        'machine' => $machine_name,
+      );
+      if ($user) {
+        $wrapper->author = $user->uid;
+      }
+      if ($machine_name == 'source_two') {
+        $wrapper->status = 0;
+      }
+      $wrapper->save();
+    }
+  }
+
+  /**
+   * @AfterScenario @harvest
+   */
+  public function harvestTeardown(AfterScenarioScope $event) {
     $migrations = migrate_migrations();
-    $harvest_migrations = array();
+
     foreach ($migrations as $name => $migration) {
-      if(strpos($name , 'dkan_harvest') === 0) {
+      if (strpos($name, 'dkan_harvest') === 0) {
         $migration = \Migration::getInstance($name);
-        $migration->processRollback();
+        if ($migration) {
+          $migration->processRollback();
+        }
       }
     }
+
+    module_load_include('inc', 'devel_generate', 'devel_generate');
+    devel_generate_content_kill(array('node_types' => array('harvest_source')));
   }
 
   /**
    * @Then the content :content_title should be :status
    */
-  public function theContentShouldBe($content_title, $status)
-  {
+  public function theContentShouldBe($content_title, $status) {
     // Get content by title.
     $query = new \EntityFieldQuery();
     $result = $query->entityCondition('entity_type', 'node')
@@ -130,7 +167,8 @@ class HarvestSourceContext extends RawDKANEntityContext {
       $content_id = current($content_ids);
       $content = node_load($content_id, NULL, TRUE);
       $content_wrapper = entity_metadata_wrapper('node', $content);
-    } else {
+    }
+    else {
       if ($status != 'deleted') {
         throw new \Exception("Content with title '$content_title' was not found.");
       }
@@ -144,18 +182,22 @@ class HarvestSourceContext extends RawDKANEntityContext {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       case 'unpublished':
         if ($content_wrapper->status->value() != NODE_NOT_PUBLISHED) {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       case 'orphaned':
         if (!$content_wrapper->field_orphan->value()) {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       default:
         break;
     }
   }
+
 }

--- a/test/features/dkan_harvest.feature
+++ b/test/features/dkan_harvest.feature
@@ -1,6 +1,11 @@
 # time:3m30.05s
 @harvest_rollback @disablecaptcha
 Feature: Dkan Harvest
+  Background:
+    Given pages:
+      | name       | url                        |
+      | Source one | /harvest_source/source-one |
+      | Source two | /harvest_source/source-two |
 
   @api @javascript
   Scenario: As a site manager I should be able to add a harvest source.
@@ -45,15 +50,11 @@ Feature: Dkan Harvest
       | role                    |
       | authenticated user      |
 
-  @api
+  @api @harvest
   Scenario: As a site manager I should see only the published harvest sources listed on the harvest dashboard.
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site manager | Yes       |
-      | Source two | source_two   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site manager | No        |
     And pages:
       | name               | url                            |
       | Harvest Dashboard  | /admin/dkan/harvest/dashboard  |
@@ -62,15 +63,11 @@ Feature: Dkan Harvest
     Then I should see the text "Source one"
     And I should not see the text "Source two"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Delete all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site manager      | admin@fakeemail.com      | 1      | site manager      |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site manager"
     When I am on "admin/content"
@@ -83,17 +80,14 @@ Feature: Dkan Harvest
     And I press "Delete Sources"
     And I wait for the batch job to finish
     Then I should see "Harvest Source Source one has been deleted."
+    And I wait for "3" seconds
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "deleted"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Unpublish and mark as orphan all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site manager      | admin@fakeemail.com      | 1      | site manager     |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site manager"
     When I am on the "Source one" page
@@ -107,15 +101,11 @@ Feature: Dkan Harvest
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "unpublished"
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "orphaned"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Keep published but mark as orphan all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site Manager      | admin@fakeemail.com      | 1      | site manager      |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site Manager"
     When I am on the "Source one" page
@@ -129,14 +119,11 @@ Feature: Dkan Harvest
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "published"
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "orphaned"
 
-  @api
+  @api @harvest
   Scenario: As a user I should have access to see harvest information into dataset node.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author       | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -150,14 +137,11 @@ Feature: Dkan Harvest
     And I should see "2016-06-22" in the "Release Date" row
     And I should see "2016-08-02" in the "Modified Date" row
 
-  @api
+  @api @harvest
   Scenario: As a user I should have access to see harvest preview information.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -167,14 +151,11 @@ Feature: Dkan Harvest
     And I should see the text "Harvest now"
     And I should see the text "Florida Bike Lanes Harvest"
 
-  @api
+  @api @harvest
   Scenario: As a user I should be able to refresh the preview on the Harvest Source.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -187,14 +168,11 @@ Feature: Dkan Harvest
     And I should see the text "Preview"
 
 
-  @api
+  @api @harvest
   Scenario Outline: As a user I should have access to the Event log tab on the Harvest Source.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "<role>"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -209,14 +187,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api
+  @api @harvest
   Scenario Outline: As a user I should see a list of imported datasets on the Harvest Source page.
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And The "source_one" source is harvested
     And I am logged in as a "<role>"
     And I am on the "Source one" page
@@ -227,14 +202,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api
+  @api @harvest
   Scenario Outline: As user I should see a list of imported datasets in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -248,14 +220,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by orphan status in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -270,14 +239,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by post date in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -296,14 +262,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by updated date in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -325,14 +288,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to delete harvested datasets in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -449,13 +449,11 @@ Feature:
     And I click "View draft"
     Then I should see "Dataset draft title"
 
-  @workflow_20 @api @javascript @harvest_rollback
+  @workflow_20 @ok @javascript @harvest
   Scenario: Check harvested datasets are published by default even when dkan_workflow is enabled.
     Given users:
       | name               | mail                     | status | roles             |
       | Administrator      | admin@fakeemail.com      | 1      | administrator     |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Administrator | Yes       |
     And The "source_one" source is harvested
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "published"
+


### PR DESCRIPTION
Description:
====

These changes are to fix bugs discovered in the latest rounds of site upgrades.

1. Fix dkan_bueditor_markdown_install() uses variable before it is initialized.
2. Fix dkan_update_7016 assumes bueditor id is '5' (not always true).
3. Fix dkan_topics_field_formatter_view() does not check if term exists causing drupal to throw.
4. Fix dkan_default_content_disable() call to processRollback() on null.
5. Fix harvest tests do not clean up.