### PR TITLE
Fixes issues found on upgrade 1.13.4 for QA site.

### DIFF
--- a/.ahoy/.scripts/behat-parse-params.rb
+++ b/.ahoy/.scripts/behat-parse-params.rb
@@ -2,6 +2,7 @@
 # Defines helper function for processing behat parameters.
 #
 require "base64"
+require "./dkan/.ahoy/.scripts/config.rb"
 
 def behat_join_params args
   args.join(" ").split("--").map do |arg|
@@ -40,7 +41,14 @@ def behat_parse_params args
     puts "Seaching #{param} for feature files..."
     # Fetch all of the feature files for each parameter (directories)
     if Dir.exist? param
-      Dir.glob("#{param}/*.feature") {|f| files.push f}
+      Dir.glob("#{param}/*.feature") {
+        |f|
+        filename = File.basename(f)
+        if CONFIG["circle"]["skip_features"].include? filename
+          next
+        end
+        files.push f
+      }
 
       # Add loose features passed in as direct paths
     elsif File.exist? param

--- a/.ahoy/.scripts/circle-behat.rb
+++ b/.ahoy/.scripts/circle-behat.rb
@@ -20,7 +20,6 @@ TOKENS = {
 puts "CIRCLE_NODE_TOTAL = #{CIRCLE_NODE_TOTAL}"
 puts "CIRCLE_NODE_INDEX = #{CIRCLE_NODE_INDEX}"
 
-
 error = 0
 parsed = behat_parse_params(ARGV)
 params = behat_join_params parsed[:params]

--- a/.ahoy/.scripts/config.rb
+++ b/.ahoy/.scripts/config.rb
@@ -1,0 +1,11 @@
+require 'yaml'
+
+begin
+  CONFIG = YAML.load_file("config/config.yml")
+rescue Exception => msg
+  puts "Loading of Configuration errored out with: #{msg}."
+  puts "Using default CONFIG instead."
+  CONFIG = {"circle" => {"skip_features" => []}}
+end
+
+

--- a/.ahoy/.scripts/dkan-lint.sh
+++ b/.ahoy/.scripts/dkan-lint.sh
@@ -20,7 +20,7 @@ fi
 
 if [ ! -z "$files" ]; then
   echo "Linting: $files"
-  test/bin/phpcs --standard=Drupal,DrupalPractice -n $files
+  test/bin/phpcs --standard=Drupal,DrupalPractice -n $files --ignore=test/dkanextension/*
 else
   echo "No Drupal file changes available for linting."
 fi

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@
  - #1963 Allow dkanextension to handle custom fields
  - #1938 Allow skipping of features test via config
  - #2003 Do not deregister default content migrations on disable.
+ - #2003 Deregister default content migrations on uninstall.
  - #2003 Fix dkan_migrate_base warning wrong type supplied to foreach.
 
 7.x-1.13.4

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+7.x-1.13.5
+----------
+ - #2003 Fix dkan_bueditor_markdown_install() uses variable before it is initialized.
+ - #2003 Fix dkan_update_7016 assumes bueditor id is '5' (not always true).
+ - #2003 Fix dkan_topics_field_formatter_view() does not check if term exists causing drupal to throw.
+ - #2003 Fix dkan_default_content_disable() call to processRollback() on null.
+ - #2003 Fix harvest tests do not clean up.
+ - #1963 Allow dkanextension to handle custom fields
+ - #1938 Allow skipping of features test via config
+ - #2003 Do not deregister default content migrations on disable.
+ - #2003 Fix dkan_migrate_base warning wrong type supplied to foreach.
+
 7.x-1.13.4
 ----------
  - #1970 DevOps: Automatically populate required fields when running behat tests.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,11 +10,10 @@
  - #2003 Do not deregister default content migrations on disable.
  - #2003 Deregister default content migrations on uninstall.
  - #2003 Fix dkan_migrate_base warning wrong type supplied to foreach.
+ - #1970 DevOps: Automatically populate required fields when running behat tests.
 
 7.x-1.13.4
 ----------
- - #1970 DevOps: Automatically populate required fields when running behat tests.
- - #1938 DevOps: Allow behat tests to be skipped in circle.
  - #1983 Apply services security update 3.20 for DRUPAL-SA-CONTRIB-2017-054
  - #1877 Fix broken update that tries to migrate fields that may not exist (primarily due to Federal Extras upgrade)
  - #1960 Update field_group_table to 1.6

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,7 @@
 7.x-1.13.4
 ----------
+ - #1970 DevOps: Automatically populate required fields when running behat tests.
+ - #1938 DevOps: Allow behat tests to be skipped in circle.
  - #1983 Apply services security update 3.20 for DRUPAL-SA-CONTRIB-2017-054
  - #1877 Fix broken update that tries to migrate fields that may not exist (primarily due to Federal Extras upgrade)
  - #1960 Update field_group_table to 1.6

--- a/circle.yml
+++ b/circle.yml
@@ -78,7 +78,6 @@ dependencies:
 ## Customize test commands
 test:
   override:
-    - ahoy dkan lint
     - ruby dkan/.ahoy/.scripts/circle-behat.rb docroot/profiles/dkan/test/features:
         timeout: 1200
         parallel: true
@@ -87,6 +86,7 @@ test:
     - PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush dis --yes dkan_default_content
     - PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush pm-uninstall --yes dkan_default_content
     - ahoy dkan unittests
+    - ahoy dkan lint
   post:
     - echo $CIRCLE_ARTIFACTS; cp -av dkan/test/assets $CIRCLE_ARTIFACTS:
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -78,6 +78,7 @@ dependencies:
 ## Customize test commands
 test:
   override:
+    - ahoy dkan lint
     - ruby dkan/.ahoy/.scripts/circle-behat.rb docroot/profiles/dkan/test/features:
         timeout: 1200
         parallel: true
@@ -86,7 +87,6 @@ test:
     - PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush dis --yes dkan_default_content
     - PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy drush pm-uninstall --yes dkan_default_content
     - ahoy dkan unittests
-    - ahoy dkan lint
   post:
     - echo $CIRCLE_ARTIFACTS; cp -av dkan/test/assets $CIRCLE_ARTIFACTS:
         parallel: true

--- a/dkan.install
+++ b/dkan.install
@@ -359,7 +359,8 @@ function dkan_update_7020() {
 
 /**
  * Add data dictionary textarea id to bueditor excludes list.
- * Similar to 'dkan_update_7016' but loading the ID from the DB first.
+ *
+ * This is similar to 'dkan_update_7016' but loading the ID from the DB first.
  */
 function dkan_update_7021() {
   $eid = db_select("bueditor_editors", "bue")

--- a/dkan.install
+++ b/dkan.install
@@ -297,19 +297,13 @@ function dkan_update_7015() {
  * Add data dictionary textarea id to bueditor excludes list.
  */
 function dkan_update_7016() {
-  $eid = db_select("bueditor_editors", "bue")
-    ->fields("bue", array("eid"))
-    ->condition("name", "Markdowneditor")
-    ->execute()
-    ->fetchField();
-
   db_update('bueditor_editors')
     ->fields(array(
       'excludes' => 'edit-log
 edit-menu-description
 *data-dictionary*',
     ))
-    ->condition('eid', $eid)
+    ->condition('eid', '5')
     ->execute();
 }
 
@@ -361,4 +355,25 @@ function dkan_update_7020() {
   // REF #1936, #1890.
   variable_set('chosen_jquery_selector',
     '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])');
+}
+
+/**
+ * Add data dictionary textarea id to bueditor excludes list.
+ * Similar to 'dkan_update_7016' but loading the ID from the DB first.
+ */
+function dkan_update_7021() {
+  $eid = db_select("bueditor_editors", "bue")
+    ->fields("bue", array("eid"))
+    ->condition("name", "Markdowneditor")
+    ->execute()
+    ->fetchField();
+
+  db_update('bueditor_editors')
+    ->fields(array(
+      'excludes' => 'edit-log
+        edit-menu-description
+        *data-dictionary*',
+    ))
+    ->condition('eid', $eid)
+    ->execute();
 }

--- a/dkan.install
+++ b/dkan.install
@@ -2,569 +2,363 @@
 
 /**
  * @file
- * Additional setup tasks for DKAN.
+ * Install functions and update hooks for DKAN profile.
  */
 
 /**
- * Implements hook_install_tasks().
+ * Reverts dkan_sitewide to add Markdown filter. Sets up roleassign feature.
  */
-function dkan_install_tasks() {
-  return array(
-    'dkan_additional_setup' => array(
-      'display_name' => t('DKAN final setup tasks'),
-      'display' => TRUE,
-      'type' => 'batch',
-      'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
-    ),
-  );
+function dkan_update_7001() {
+  module_load_include("profile", "dkan");
+  dkan_bueditor_markdown_install();
 }
 
 /**
- * DKAN setup task. Runs a series of helper functions defined below.
- */
-function dkan_additional_setup() {
-  return array(
-    'operations' => array(
-      array('dkan_theme_config', array()),
-      array('dkan_change_block_titles', array()),
-      array('dkan_markdown_setup', array()),
-      array('dkan_enable_optional_module', array('dkan_permissions')),
-      array('dkan_enable_optional_module', array('dkan_default_topics')),
-      array('dkan_revert_feature',
-        array(
-          'dkan_sitewide_menu',
-          array('content_menu_links', 'menu_links'),
-        ),
-      ),
-      array('dkan_revert_feature',
-        array(
-          'dkan_dataset_content_types',
-          array('field_base', 'field_instance'),
-        ),
-      ),
-      array('dkan_revert_feature',
-        array(
-          'dkan_dataset_groups',
-          array('field_base'),
-        ),
-      ),
-      array('dkan_revert_feature',
-        array(
-          'dkan_dataset_groups_perms',
-          array('og_features_permission'),
-        ),
-      ),
-      array('dkan_revert_feature',
-        array(
-          'dkan_permissions',
-          array('roles_permissions'),
-        ),
-      ),
-      array('dkan_revert_feature', array('dkan_sitewide', array('variable'))),
-      array('dkan_revert_feature',
-        array(
-          'dkan_sitewide_menu',
-          array('custom_menu', 'menu_links'),
-        ),
-      ),
-      // The module needs to be enabled after the revert on dkan_dataset_groups
-      // is done. If not, a warning will appear during install about
-      // og_group_ref not being present.
-      array('dkan_enable_optional_module', array('dkan_default_content')),
-      array('dkan_add_default_menu_links', array()),
-      array('dkan_build_menu_links', array()),
-      array('dkan_flush_image_styles', array()),
-      array('dkan_colorizer_reset', array()),
-      array('dkan_misc_variables_set', array()),
-      array('dkan_group_link_delete', array()),
-      array('dkan_set_adminrole', array()),
-      array('dkan_set_roleassign_roles', array()),
-      array('dkan_set_bueditor_excludes', array()),
-      array('dkan_post_install', array()),
-    ),
-  );
-}
-
-/**
- * Set up theme options for nuboot_radix on install.
+ * Rename a field.
  *
- * @param array &$context
- *   Batch context.
- */
-function dkan_theme_config(array &$context) {
-  $context['message'] = t('Setting theme options.');
-  theme_enable(array('nuboot_radix'));
-  theme_enable(array('seven'));
-  variable_set('theme_default', 'nuboot_radix');
-  variable_set('admin_theme', '0');
-
-  // Disable the default Bartik theme.
-  theme_disable(array('bartik'));
-  theme_disable(array('seven'));
-}
-
-/**
- * Change block titles for selected blocks.
- */
-function dkan_change_block_titles(&$context) {
-  $context['message'] = t('Changing block titles for selected blocks');
-  db_query("UPDATE {block} SET title ='<none>' WHERE delta = 'main-menu' OR delta = 'login'");
-  variable_set('node_access_needs_rebuild', FALSE);
-  variable_set('gravatar_size', 190);
-}
-
-/**
- * Make sure markdown editor installs correctly.
+ * Addapted from field_rename_rename_fields() in 'Field Rename' module.
  *
- * @param array $context
- *   Batch context.
+ * @param string $old_field_name
+ *   The old name of the field.
+ * @param string $new_field_name
+ *   The new name of the field.
  */
-function dkan_markdown_setup(array &$context) {
-  $context['message'] = t('Installing Markdown');
-  module_load_include('install', 'markdowneditor', 'markdowneditor');
-  _markdowneditor_insert_latest();
-  $data = array(
-    'pages' => "node/*\ncomment/*\nsystem/ajax",
-    'eid' => 5,
-  );
-  drupal_write_record('bueditor_editors', $data, array('eid'));
-  // Remove unsupported markdown options.
-  dkan_delete_markdown_buttons($context);
+function dkan_rename_field($old_field_name, $new_field_name) {
 
-  return $context;
-}
+  $messages = array();
 
-/**
- * Enable a module on install we don't want as a dependency for existing sites.
- *
- * @param string $module
- *   The module name.
- * @param array $context
- *   Batch context.
- */
-function dkan_enable_optional_module($module, array &$context) {
-  module_enable(array($module));
-  $module_info = system_get_info('module', $module);
-  $context['message'] = t('Enabled %module', array('%module' => $module_info['name']));
-}
-
-/**
- * Revert particular feature components that have been overridden during setup.
- *
- * @param string $feature
- *   The feature module name.
- * @param array $components
- *   Array of components to revert.
- * @param array $context
- *   Batch context.
- */
-function dkan_revert_feature($feature, array $components, array &$context) {
-  $context['message'] = t('Reverting feature %feature_name', array('%feature_name' => $feature));
-  features_revert(array($feature => $components));
-}
-
-/**
- * Import default menu links.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_add_default_menu_links(array &$context) {
-  $menu_links = array();
-  // Exported menu link: main-menu_dataset:search/type/dataset.
-  $menu_links['main-menu_dataset:search/type/dataset'] = array(
-    'menu_name' => 'main-menu',
-    'link_path' => 'search/type/dataset',
-    'router_path' => 'search/type/dataset',
-    'link_title' => 'Datasets',
-    'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
-      'identifier' => 'main-menu_dataset:search/type/dataset',
-    ),
-    'module' => 'menu',
-    'hidden' => 0,
-    'external' => 0,
-    'has_children' => 0,
-    'expanded' => 0,
-    'weight' => -1,
-    'customized' => 1,
-  );
-  // Exported menu link: main-menu_dataset:search/type/data_dashboard.
-  $menu_links['main-menu_dashboard:search/type/data_dashboard'] = array(
-    'menu_name' => 'main-menu',
-    'link_path' => 'search/type/data_dashboard',
-    'router_path' => 'search/type/data_dashboard',
-    'link_title' => 'Dashboards',
-    'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
-      'identifier' => 'main-menu_dashboard:search/type/data_dashboard',
-    ),
-    'module' => 'menu',
-    'hidden' => 0,
-    'external' => 0,
-    'has_children' => 0,
-    'expanded' => 0,
-    'weight' => 4,
-    'customized' => 1,
-  );
-  // Exported menu link: main-menu_stories:stories.
-  $menu_links['main-menu_stories:stories'] = array(
-    'menu_name' => 'main-menu',
-    'link_path' => 'stories',
-    'router_path' => 'stories',
-    'link_title' => 'Stories',
-    'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
-      'identifier' => 'main-menu_stories:stories',
-    ),
-    'module' => 'menu',
-    'hidden' => 0,
-    'external' => 0,
-    'has_children' => 0,
-    'expanded' => 0,
-    'weight' => 3,
-    'customized' => 1,
-  );
-  // Exported menu link: main-menu_groups:groups.
-  $menu_links['main-menu_groups:groups'] = array(
-    'menu_name' => 'main-menu',
-    'link_path' => 'groups',
-    'router_path' => 'groups',
-    'link_title' => 'Groups',
-    'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
-      'identifier' => 'main-menu_groups:groups',
-    ),
-    'module' => 'menu',
-    'hidden' => 0,
-    'external' => 0,
-    'has_children' => 0,
-    'expanded' => 0,
-    'weight' => 2,
-    'customized' => 1,
-  );
-  t('Datasets');
-  t('Dashboards');
-  t('Stories');
-  t('Groups');
-
-  foreach ($menu_links as $menu_link) {
-    menu_link_save($menu_link);
+  // Read field data.
+  $old_field = field_read_field($old_field_name);
+  if (empty($old_field)) {
+    $messages[] = t('The field %old_field_name does not exist so it cannot be renamed.', array('%old_field_name' => $old_field_name));
+    return $messages;
   }
-}
 
-/**
- * Build menu links.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_build_menu_links(array &$context) {
-  module_load_include('inc', 'features', 'features.export');
-  $context['message'] = t('Building menu links and assigning custom admin menus to roles');
-  $menu_links = features_get_default('menu_links', 'dkan_sitewide_menu');
-  menu_links_features_rebuild_ordered($menu_links, TRUE);
-  unset($_SESSION['messages']['warning']);
-}
+  try {
+    // Update {field_config}.
+    db_update('field_config')
+      ->fields(array('field_name' => $new_field_name))
+      ->condition('id', $old_field['id'])
+      ->execute();
 
-/**
- * Flush the image styles.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_flush_image_styles(array &$context) {
-  $context['message'] = t('Flushing image styles');
-  $image_styles = image_styles();
-  foreach ($image_styles as $image_style) {
-    image_style_flush($image_style);
-  }
-}
+    // Update {field_config_instance}.
+    db_update('field_config_instance')
+      ->fields(array('field_name' => $new_field_name))
+      ->condition('field_id', $old_field['id'])
+      ->execute();
 
-/**
- * Reset colorizer cache so colors are not blank at first page view.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_colorizer_reset(array &$context) {
-  $context['message'] = t('Resetting colorizer cache');
-  global $theme_key;
-  $instance = $theme_key;
-  drupal_alter('colorizer_instance', $instance);
-  $palette = colorizer_get_palette($theme_key, $instance);
-  $file = colorizer_update_stylesheet($theme_key, $theme_key, $palette);
-  clearstatcache();
-}
+    // The tables that need updating in the form 'old_name' => 'new_name'.
+    $tables = array(
+      'field_data_' . $old_field_name => 'field_data_' . $new_field_name,
+      'field_revision_' . $old_field_name => 'field_revision_' . $new_field_name,
+    );
 
-/**
- * Set a number of miscellaneous variables.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_misc_variables_set(array &$context) {
-  $context['message'] = t('Setting misc DKAN variables');
-  variable_set('honeypot_form_user_register_form', 1);
-  variable_set('page_manager_node_view_disabled', FALSE);
-  variable_set('page_manager_node_edit_disabled', FALSE);
-  variable_set('page_manager_user_view_disabled', FALSE);
-  variable_set('jquery_update_jquery_version', '1.10');
-  // Disable selected views enabled by contributed modules.
-  $views_disable = array(
-    'og_extras_nodes' => TRUE,
-    'feeds_log' => TRUE,
-    'groups_page' => TRUE,
-    'og_extras_groups' => TRUE,
-    'og_extras_members' => TRUE,
-    'dataset' => TRUE,
-  );
-  variable_set('views_defaults', $views_disable);
-}
+    // Iterate through tables to be redefined and renamed.
+    foreach ($tables as $old_table => $new_table) {
+      // Iterate through the field's columns. For example, a 'text' field will
+      // have columns 'value' and 'format'.
+      foreach ($old_field['columns'] as $column_name => $column_definition) {
+        // Column names are in the format {field_name}_{column_name}.
+        $old_column_name = $old_field_name . '_' . $column_name;
+        $new_column_name = $new_field_name . '_' . $column_name;
 
-/**
- * Set the user admin role.
- *
- * @param array $context
- *   Batch context.
- */
-function dkan_set_adminrole(array &$context) {
-  $context['message'] = t('Setting user admin role');
-  if (!variable_get('user_admin_role')) {
-    if ($role = user_role_load_by_name('administrator')) {
-      variable_set('user_admin_role', $role->rid);
-      return t('User admin role reset to "administrator."');
-    }
-    else {
-      return t('Administrator role not found. Skipping update.');
+        // If there is an index for the field, drop and then re-add it.
+        $has_index = isset($old_field['indexes'][$column_name]) && ($old_field['indexes'][$column_name] == array($column_name));
+        if ($has_index) {
+          db_drop_index($old_table, $old_column_name);
+        }
+
+        // Rename the column.
+        db_change_field($old_table, $old_column_name, $new_column_name, $column_definition);
+
+        if ($has_index) {
+          db_drop_index($old_table, $new_column_name);
+          db_add_index($old_table, $new_column_name, array($new_column_name));
+        }
+      }
+
+      // The new table may exist e.g. due to having been included in a feature
+      // that was reverted prior to this update being run. If so, we need to
+      // drop the new table so that the old one can be renamed.
+      if (db_table_exists($new_table)) {
+        db_drop_table($new_table);
+      }
+
+      // Rename the table.
+      db_rename_table($old_table, $new_table);
     }
   }
-  else {
-    return t('User admin role already set. Skipping update.');
+  catch (Exception $e) {
+    $messages[] = t('The field %old_field_name could not be renamed because there was an error: %error.',
+      array('%old_field_name' => $old_field_name, '%error' => $e->getMessage()));
+  }
+
+  cache_clear_all('*', 'cache_field', TRUE);
+
+  return $messages;
+}
+
+/**
+ * Update the default jquery library to 1.10.
+ */
+function dkan_update_7002() {
+  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
+    variable_set('jquery_update_jquery_version', '1.10');
   }
 }
 
 /**
- * Remove unsupported markdown options.
- *
- * @param array $context
- *   Batch context.
+ * Disable the dkan_default_content module.
  */
-function dkan_delete_markdown_buttons(array &$context) {
-  $context['message'] = t('Removing unsupported Markdown buttons');
-  $eid = db_query('SELECT eid FROM {bueditor_editors} WHERE name = :name', array(':name' => 'Markdowneditor'))->fetchField();
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Insert a table')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Insert an abbreviation (word or acronym with definition)')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Insert a footnote')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Insert a horizontal ruler (horizontal line)')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Teaser break')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Insert a definition list')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Format selected text as code')
-    ->condition('eid', $eid)
-    ->execute();
-
-  db_delete('bueditor_buttons')
-    ->condition('title', 'Format selected text as a code block')
-    ->condition('eid', $eid)
-    ->execute();
-
-  // Update markdown linebreak button with html.
-  db_update('bueditor_buttons')
-    ->fields(array('content' => '<br>'))
-    ->condition('title', 'Insert a line break', '=')
-    ->condition('eid', $eid)
+function dkan_update_7005() {
+  db_update('system')
+    ->fields(array('status' => '0'))
+    ->condition('name', 'dkan_default_content')
     ->execute();
 }
 
 /**
- * Fix extra group links.
+ * We need to revert field instances.
  *
- * The groups view in og_extras creates a menu item even when the view is
- * disabled. This will delete the extra menu item until the og_extras is removed
- * from the code base.
- *
- * @param array $context
- *   Batch context.
+ * This is required for the next update in another case
+ * we have problem with new fields added on version 12.
  */
-function dkan_group_link_delete(array &$context) {
-  $context['message'] = t('Removing og_extra groups link');
-  db_query('DELETE FROM {menu_links} WHERE link_path = :link_path LIMIT 1', array(':link_path' => 'groups'));
+function dkan_update_7006() {
+  module_enable(array('field_hidden'));
+  features_revert(array('dkan_datastore' => array('field_base', 'field_instance')));
 }
 
 /**
- * Set up the roles that sitemanagers are allowed to assign via roleassign.
+ * Resource group field.
+ *
+ * Groups cannot be edited manually on resources anymore. Group affiliation
+ * will be inherited from parent datasets. This update hook was added to be sure
+ * that all resources that do not have groups assigned are synchronized and
+ * updated with the groups from the parent datasets.
  */
-function dkan_set_roleassign_roles(&$context) {
-  $context['message'] = t('Configuring Role Assign module');
-  $roles_rids = array_flip(user_roles());
-  $roleassign_roles = array($roles_rids['administrator'] => 0);
+function dkan_update_7007(&$sandbox) {
 
-  // Should be everything except admin:
-  $allowed_roles = array('editor', 'site manager', 'content creator');
-
-  foreach ($allowed_roles as $role) {
-    $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['max'] = db_query("SELECT COUNT(DISTINCT fdr.field_dataset_ref_target_id) FROM {node} n LEFT JOIN {field_data_field_dataset_ref} fdr ON fdr.entity_id=n.nid LEFT JOIN {og_membership} og ON n.nid=og.etid WHERE n.type='resource' AND og.etid IS NULL AND fdr.field_dataset_ref_target_id IN (SELECT etid FROM {og_membership} WHERE etid IN (SELECT field_dataset_ref_target_id FROM {field_data_field_dataset_ref}))")->fetchField();
   }
-  variable_set('roleassign_roles', $roleassign_roles);
+
+  // Get all resources without group but the parent dataset has groups.
+  $result = db_query("SELECT DISTINCT fdr.field_dataset_ref_target_id FROM {node} n LEFT JOIN {field_data_field_dataset_ref} fdr ON fdr.entity_id=n.nid LEFT JOIN {og_membership} og ON n.nid=og.etid WHERE n.type='resource' AND og.etid IS NULL AND fdr.field_dataset_ref_target_id IN (SELECT etid FROM {og_membership} WHERE etid IN (SELECT field_dataset_ref_target_id FROM {field_data_field_dataset_ref})) LIMIT 0,10");
+
+  foreach ($result as $item) {
+    // Simulate a empty original.
+    // The 'dkan_dataset_sync_groups' function synchronizes
+    // the groups only when a change on the dataset is detected.
+    $original = new stdClass();
+    $original->type = 'dataset';
+    $original->og_group_ref = array();
+    $dataset = node_load($item->field_dataset_ref_target_id);
+    $dataset->original = $original;
+    dkan_dataset_sync_groups($dataset);
+    $sandbox['progress']++;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+
+  return t('All resources without group were updated.');
+
 }
 
 /**
- * Configures BUEditor and markdown test format.
+ * Point source menu to the command menu center in dkan workflow roles.
  */
-function dkan_bueditor_markdown_install() {
-  module_enable(array('bueditor_plus'));
+function dkan_update_7008() {
+  if (module_exists('dkan_workflow')) {
+    dkan_workflow_admin_menu_source();
+  }
+}
 
-  $context = array();
-  dkan_set_roleassign_roles($context);
+/**
+ * Flush client site colorizer file to grab new updates.
+ */
+function dkan_update_7009() {
+  $theme = $GLOBALS['theme'];
+  $instance = $theme;
+  variable_del('colorizer_' . $instance . '_files');
+  colorizer_clearcache();
+  cache_clear_all();
+}
 
-  // Delete the old bueditor settings and profile.
-  db_delete('bueditor_editors')
-    ->condition('name', 'Markdowneditor')
-    ->execute();
+/**
+ * Disable/uninstall deprecated dkan_dataset_api, enable open_data_schema_map.
+ */
+function dkan_update_7010() {
+  if (module_exists('dkan_dataset_api')) {
+    module_disable(array('dkan_dataset_api'));
+    drupal_uninstall_modules(array('dkan_dataset_api'));
+    module_enable(array('open_data_schema_map'));
+  }
+}
 
-  db_delete('bueditor_plus_profiles')
-    ->condition('name', 'Global')
-    ->execute();
+/**
+ * Update copyright information.
+ */
+function dkan_update_7011() {
+  $settings = variable_get('theme_nuboot_radix_settings', array());
+  if ($settings['copyright']['value'] == 'Powered by <a href="http://nucivic.com/dkan">DKAN</a>, a project of <a href="http://nucivic.com">NuCivic</a>') {
+    $settings['copyright']['value'] = t('Powered by <a href="http://getdkan.com/">DKAN</a>, a project of <a href="http://granicus.com">Granicus</a>');
+    variable_set('theme_nuboot_radix_settings', $settings);
+  }
+}
 
-  // Create the new bueditor settings and profile.
-  dkan_markdown_setup($context);
-  features_revert(array('dkan_sitewide' => array('filter')));
+/**
+ * Clean up db on upgrade to 7.x-1.13.
+ *
+ * Deprecated modules: Conditional Fields, Entity RDF, RDF UI, RDF Extensions.
+ */
+function dkan_update_7012() {
+  if (!module_exists('conditional_fields')) {
+    db_delete('system')
+      ->condition('name', 'conditional_fields')
+      ->condition('type', 'module')
+      ->execute();
+    db_drop_table('conditional_fields');
+  }
+  if (!module_exists('entity_rdf')) {
+    db_delete('system')
+      ->condition('name', 'entity_rdf')
+      ->condition('type', 'module')
+      ->execute();
+  }
+  if (!module_exists('rdfui')) {
+    db_delete('system')
+      ->condition('name', 'rdfui')
+      ->condition('type', 'module')
+      ->execute();
+  }
+  if (!module_exists('rdfx')) {
+    db_delete('system')
+      ->condition('name', 'rdfx')
+      ->condition('type', 'module')
+      ->execute();
 
-  $roles = user_roles();
-  $bueditor_roles = array();
+    db_drop_table('rdfx_namespaces');
+    db_drop_table('rdfx_term_details');
+    db_drop_table('rdfx_term_domains');
+    db_drop_table('rdfx_term_inverses');
+    db_drop_table('rdfx_term_ranges');
+    db_drop_table('rdfx_term_superclasses');
+    db_drop_table('rdfx_term_superproperties');
+    db_drop_table('rdfx_term_types');
+    db_drop_table('rdfx_terms');
+    db_drop_table('rdfx_vocabulary_details');
+    db_drop_table('rdfx_vocabulary_graphs');
+  }
+}
 
-  foreach ($roles as $rid => $role) {
-    switch ($role) {
-      case 'anonymous user':
-        $bueditor_roles[$rid] = array(
-          'weight' => 12,
-          'editor' => _dkan_bueditor_by_name('Commenter'),
-          'alt' => 0,
-        );
-        break;
-
-      case 'administrator':
-      case 'content creator':
-      case 'editor':
-      case 'site manager':
-        $bueditor_roles[$rid] = array(
-          'weight' => 0,
-          'editor' => _dkan_bueditor_by_name('Markdowneditor'),
-          'alt' => 0,
-        );
-        break;
-
-      default:
-        $bueditor_roles[$rid] = array(
-          'weight' => 11,
-          'editor' => 0,
-          'alt' => 0,
-        );
-        break;
+/**
+ * Remove deprecated test and theme directories.
+ */
+function dkan_update_7013() {
+  $deprecated = array(
+    'profiles/dkan/modules/dkan/dkan_dataset/fonts',
+    'profiles/dkan/modules/dkan/dkan_dataset/tests',
+    'profiles/dkan/modules/dkan/dkan_datastore/tests',
+    'profiles/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/tests',
+    'profiles/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/test',
+    'profiles/dkan/modules/dkan/dkan_workflow/test',
+    'profiles/dkan/themes/contrib/nuboot_radix',
+    'profiles/dkan/themes/contrib/omega',
+  );
+  foreach ($deprecated as $dir) {
+    if (is_dir($dir)) {
+      drupal_rmdir($dir);
     }
   }
+}
 
+/**
+ * Drop the 'field_modified_source_date' field.
+ */
+function dkan_update_7014() {
+  // Mark the field for deletion.
+  field_delete_field('field_modified_source_date');
+  // Run the batch process to actually delete the field.
+  $batch_size = 1;
+  field_purge_batch($batch_size);
+}
+
+/**
+ * Update the default jquery library to 1.10 (again).
+ */
+function dkan_update_7015() {
+  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
+    variable_set('jquery_update_jquery_version', '1.10');
+  }
+}
+
+/**
+ * Add data dictionary textarea id to bueditor excludes list.
+ */
+function dkan_update_7016() {
   $eid = db_select("bueditor_editors", "bue")
     ->fields("bue", array("eid"))
     ->condition("name", "Markdowneditor")
     ->execute()
     ->fetchField();
 
-  variable_set('bueditor_roles', $bueditor_roles);
-  variable_set('bueditor_user1', $eid);
-
-  $data = array(
-    'html' => array('default' => $eid, 'alternative' => 0),
-    'plain_text' => array('plain_text' => 0, 'alternative' => 0),
-  );
-
-  db_insert('bueditor_plus_profiles')
-    ->fields(array(
-      'name' => 'Global',
-      'data' => serialize($data),
-      'global' => 1,
-    ))
-    ->execute();
-}
-
-/**
- * Extracts the editor id for an editor name.
- *
- * @param string $name
- *   The user role name of the editor.
- *
- * @return int
- *   The eid of the editor.
- */
-function _dkan_bueditor_by_name($name = '') {
-  module_load_include("inc", "bueditor");
-
-  if ($name == '') {
-    return 0;
-  }
-
-  $editors = bueditor_editors('all');
-
-  foreach ($editors as $eid => $editor) {
-    if ($editor->name == $name) {
-      return $eid;
-    }
-  }
-
-  return 0;
-}
-
-/**
- * Add data dictionary textarea id to bueditor excludes list.
- */
-function dkan_set_bueditor_excludes() {
   db_update('bueditor_editors')
     ->fields(array(
       'excludes' => 'edit-log
 edit-menu-description
 *data-dictionary*',
     ))
-    ->condition('eid', '5')
+    ->condition('eid', $eid)
     ->execute();
 }
 
 /**
- * Final post-install tasks.
+ * Update chosen_jquery_selector to avoid misuse.
  */
-function dkan_post_install() {
-  variable_set('preprocess_css', 1);
-  variable_set('preprocess_js', 1);
+function dkan_update_7017() {
+  variable_set('chosen_jquery_selector',
+    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"])');
+}
+
+/**
+ * Update language field values to use dashes rather than underscores.
+ */
+function dkan_update_7018() {
+  db_update('field_data_field_language')
+    ->expression('field_language_value', 'replace(field_language_value, :underscore, :dash)', array(':underscore' => '_', ':dash' => '-'))
+    ->execute();
+
+  db_update('field_revision_field_language')
+    ->expression('field_language_value', 'replace(field_language_value, :underscore, :dash)', array(':underscore' => '_', ':dash' => '-'))
+    ->execute();
+
+}
+
+/**
+ * Remove old variables from dkan_dataset_api.
+ */
+function dkan_update_7019() {
+  variable_del('dkan_catalog_desc');
+  variable_del('dkan_catalog_contact');
+  variable_del('dkan_catalog_mbox');
+  variable_del('dkan_dataset_api_site_read');
+  variable_del('dkan_dataset_api_data_json');
+  variable_del('dkan_dataset_api_revision_list');
+  variable_del('dkan_dataset_api_package_list');
+  variable_del('dkan_dataset_api_current_package_list_with_resources');
+  variable_del('dkan_dataset_api_package_show');
+  variable_del('dkan_dataset_api_resource_show');
+  variable_del('dkan_dataset_api_group_package_show');
+  variable_del('dkan_dataset_api_package_revision_list');
+  variable_del('dkan_dataset_api_group_list');
+}
+
+/**
+ * Update chosen_jquery_selector to avoid misuse.
+ */
+function dkan_update_7020() {
+  // REF #1936, #1890.
+  variable_set('chosen_jquery_selector',
+    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])');
 }

--- a/dkan.install
+++ b/dkan.install
@@ -2,301 +2,555 @@
 
 /**
  * @file
- * Install functions and update hooks for DKAN profile.
+ * Additional setup tasks for DKAN.
  */
 
 /**
- * Reverts dkan_sitewide to add Markdown filter. Sets up roleassign feature.
+ * Implements hook_install_tasks().
  */
-function dkan_update_7001() {
-  module_load_include("profile", "dkan");
-  dkan_bueditor_markdown_install();
+function dkan_install_tasks() {
+  return array(
+    'dkan_additional_setup' => array(
+      'display_name' => t('DKAN final setup tasks'),
+      'display' => TRUE,
+      'type' => 'batch',
+      'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
+    ),
+  );
 }
 
 /**
- * Rename a field.
- *
- * Addapted from field_rename_rename_fields() in 'Field Rename' module.
- *
- * @param string $old_field_name
- *   The old name of the field.
- * @param string $new_field_name
- *   The new name of the field.
+ * DKAN setup task. Runs a series of helper functions defined below.
  */
-function dkan_rename_field($old_field_name, $new_field_name) {
+function dkan_additional_setup() {
+  return array(
+    'operations' => array(
+      array('dkan_theme_config', array()),
+      array('dkan_change_block_titles', array()),
+      array('dkan_markdown_setup', array()),
+      array('dkan_enable_optional_module', array('dkan_permissions')),
+      array('dkan_enable_optional_module', array('dkan_default_topics')),
+      array('dkan_revert_feature',
+        array(
+          'dkan_sitewide_menu',
+          array('content_menu_links', 'menu_links'),
+        ),
+      ),
+      array('dkan_revert_feature',
+        array(
+          'dkan_dataset_content_types',
+          array('field_base', 'field_instance'),
+        ),
+      ),
+      array('dkan_revert_feature',
+        array(
+          'dkan_dataset_groups',
+          array('field_base'),
+        ),
+      ),
+      array('dkan_revert_feature',
+        array(
+          'dkan_dataset_groups_perms',
+          array('og_features_permission'),
+        ),
+      ),
+      array('dkan_revert_feature',
+        array(
+          'dkan_permissions',
+          array('roles_permissions'),
+        ),
+      ),
+      array('dkan_revert_feature', array('dkan_sitewide', array('variable'))),
+      array('dkan_revert_feature',
+        array(
+          'dkan_sitewide_menu',
+          array('custom_menu', 'menu_links'),
+        ),
+      ),
+      // The module needs to be enabled after the revert on dkan_dataset_groups
+      // is done. If not, a warning will appear during install about
+      // og_group_ref not being present.
+      array('dkan_enable_optional_module', array('dkan_default_content')),
+      array('dkan_add_default_menu_links', array()),
+      array('dkan_build_menu_links', array()),
+      array('dkan_flush_image_styles', array()),
+      array('dkan_colorizer_reset', array()),
+      array('dkan_misc_variables_set', array()),
+      array('dkan_group_link_delete', array()),
+      array('dkan_set_adminrole', array()),
+      array('dkan_set_roleassign_roles', array()),
+      array('dkan_set_bueditor_excludes', array()),
+      array('dkan_post_install', array()),
+    ),
+  );
+}
 
-  $messages = array();
+/**
+ * Set up theme options for nuboot_radix on install.
+ *
+ * @param array &$context
+ *   Batch context.
+ */
+function dkan_theme_config(array &$context) {
+  $context['message'] = t('Setting theme options.');
+  theme_enable(array('nuboot_radix'));
+  theme_enable(array('seven'));
+  variable_set('theme_default', 'nuboot_radix');
+  variable_set('admin_theme', '0');
 
-  // Read field data.
-  $old_field = field_read_field($old_field_name);
-  if (empty($old_field)) {
-    $messages[] = t('The field %old_field_name does not exist so it cannot be renamed.', array('%old_field_name' => $old_field_name));
-    return $messages;
+  // Disable the default Bartik theme.
+  theme_disable(array('bartik'));
+  theme_disable(array('seven'));
+}
+
+/**
+ * Change block titles for selected blocks.
+ */
+function dkan_change_block_titles(&$context) {
+  $context['message'] = t('Changing block titles for selected blocks');
+  db_query("UPDATE {block} SET title ='<none>' WHERE delta = 'main-menu' OR delta = 'login'");
+  variable_set('node_access_needs_rebuild', FALSE);
+  variable_set('gravatar_size', 190);
+}
+
+/**
+ * Make sure markdown editor installs correctly.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_markdown_setup(array &$context) {
+  $context['message'] = t('Installing Markdown');
+  module_load_include('install', 'markdowneditor', 'markdowneditor');
+  _markdowneditor_insert_latest();
+  $data = array(
+    'pages' => "node/*\ncomment/*\nsystem/ajax",
+    'eid' => 5,
+  );
+  drupal_write_record('bueditor_editors', $data, array('eid'));
+  // Remove unsupported markdown options.
+  dkan_delete_markdown_buttons($context);
+
+  return $context;
+}
+
+/**
+ * Enable a module on install we don't want as a dependency for existing sites.
+ *
+ * @param string $module
+ *   The module name.
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_enable_optional_module($module, array &$context) {
+  module_enable(array($module));
+  $module_info = system_get_info('module', $module);
+  $context['message'] = t('Enabled %module', array('%module' => $module_info['name']));
+}
+
+/**
+ * Revert particular feature components that have been overridden during setup.
+ *
+ * @param string $feature
+ *   The feature module name.
+ * @param array $components
+ *   Array of components to revert.
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_revert_feature($feature, array $components, array &$context) {
+  $context['message'] = t('Reverting feature %feature_name', array('%feature_name' => $feature));
+  features_revert(array($feature => $components));
+}
+
+/**
+ * Import default menu links.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_add_default_menu_links(array &$context) {
+  $menu_links = array();
+  // Exported menu link: main-menu_dataset:search/type/dataset.
+  $menu_links['main-menu_dataset:search/type/dataset'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'search/type/dataset',
+    'router_path' => 'search/type/dataset',
+    'link_title' => 'Datasets',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+      'identifier' => 'main-menu_dataset:search/type/dataset',
+    ),
+    'module' => 'menu',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => -1,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_dataset:search/type/data_dashboard.
+  $menu_links['main-menu_dashboard:search/type/data_dashboard'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'search/type/data_dashboard',
+    'router_path' => 'search/type/data_dashboard',
+    'link_title' => 'Dashboards',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+      'identifier' => 'main-menu_dashboard:search/type/data_dashboard',
+    ),
+    'module' => 'menu',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 4,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_stories:stories.
+  $menu_links['main-menu_stories:stories'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'stories',
+    'router_path' => 'stories',
+    'link_title' => 'Stories',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+      'identifier' => 'main-menu_stories:stories',
+    ),
+    'module' => 'menu',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 3,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_groups:groups.
+  $menu_links['main-menu_groups:groups'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'groups',
+    'router_path' => 'groups',
+    'link_title' => 'Groups',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+      'identifier' => 'main-menu_groups:groups',
+    ),
+    'module' => 'menu',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 2,
+    'customized' => 1,
+  );
+  t('Datasets');
+  t('Dashboards');
+  t('Stories');
+  t('Groups');
+
+  foreach ($menu_links as $menu_link) {
+    menu_link_save($menu_link);
   }
+}
 
-  try {
-    // Update {field_config}.
-    db_update('field_config')
-      ->fields(array('field_name' => $new_field_name))
-      ->condition('id', $old_field['id'])
-      ->execute();
+/**
+ * Build menu links.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_build_menu_links(array &$context) {
+  module_load_include('inc', 'features', 'features.export');
+  $context['message'] = t('Building menu links and assigning custom admin menus to roles');
+  $menu_links = features_get_default('menu_links', 'dkan_sitewide_menu');
+  menu_links_features_rebuild_ordered($menu_links, TRUE);
+  unset($_SESSION['messages']['warning']);
+}
 
-    // Update {field_config_instance}.
-    db_update('field_config_instance')
-      ->fields(array('field_name' => $new_field_name))
-      ->condition('field_id', $old_field['id'])
-      ->execute();
+/**
+ * Flush the image styles.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_flush_image_styles(array &$context) {
+  $context['message'] = t('Flushing image styles');
+  $image_styles = image_styles();
+  foreach ($image_styles as $image_style) {
+    image_style_flush($image_style);
+  }
+}
 
-    // The tables that need updating in the form 'old_name' => 'new_name'.
-    $tables = array(
-      'field_data_' . $old_field_name => 'field_data_' . $new_field_name,
-      'field_revision_' . $old_field_name => 'field_revision_' . $new_field_name,
-    );
+/**
+ * Reset colorizer cache so colors are not blank at first page view.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_colorizer_reset(array &$context) {
+  $context['message'] = t('Resetting colorizer cache');
+  global $theme_key;
+  $instance = $theme_key;
+  drupal_alter('colorizer_instance', $instance);
+  $palette = colorizer_get_palette($theme_key, $instance);
+  $file = colorizer_update_stylesheet($theme_key, $theme_key, $palette);
+  clearstatcache();
+}
 
-    // Iterate through tables to be redefined and renamed.
-    foreach ($tables as $old_table => $new_table) {
-      // Iterate through the field's columns. For example, a 'text' field will
-      // have columns 'value' and 'format'.
-      foreach ($old_field['columns'] as $column_name => $column_definition) {
-        // Column names are in the format {field_name}_{column_name}.
-        $old_column_name = $old_field_name . '_' . $column_name;
-        $new_column_name = $new_field_name . '_' . $column_name;
+/**
+ * Set a number of miscellaneous variables.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_misc_variables_set(array &$context) {
+  $context['message'] = t('Setting misc DKAN variables');
+  variable_set('honeypot_form_user_register_form', 1);
+  variable_set('page_manager_node_view_disabled', FALSE);
+  variable_set('page_manager_node_edit_disabled', FALSE);
+  variable_set('page_manager_user_view_disabled', FALSE);
+  variable_set('jquery_update_jquery_version', '1.10');
+  // Disable selected views enabled by contributed modules.
+  $views_disable = array(
+    'og_extras_nodes' => TRUE,
+    'feeds_log' => TRUE,
+    'groups_page' => TRUE,
+    'og_extras_groups' => TRUE,
+    'og_extras_members' => TRUE,
+    'dataset' => TRUE,
+  );
+  variable_set('views_defaults', $views_disable);
+}
 
-        // If there is an index for the field, drop and then re-add it.
-        $has_index = isset($old_field['indexes'][$column_name]) && ($old_field['indexes'][$column_name] == array($column_name));
-        if ($has_index) {
-          db_drop_index($old_table, $old_column_name);
-        }
-
-        // Rename the column.
-        db_change_field($old_table, $old_column_name, $new_column_name, $column_definition);
-
-        if ($has_index) {
-          db_drop_index($old_table, $new_column_name);
-          db_add_index($old_table, $new_column_name, array($new_column_name));
-        }
-      }
-
-      // The new table may exist e.g. due to having been included in a feature
-      // that was reverted prior to this update being run. If so, we need to
-      // drop the new table so that the old one can be renamed.
-      if (db_table_exists($new_table)) {
-        db_drop_table($new_table);
-      }
-
-      // Rename the table.
-      db_rename_table($old_table, $new_table);
+/**
+ * Set the user admin role.
+ *
+ * @param array $context
+ *   Batch context.
+ */
+function dkan_set_adminrole(array &$context) {
+  $context['message'] = t('Setting user admin role');
+  if (!variable_get('user_admin_role')) {
+    if ($role = user_role_load_by_name('administrator')) {
+      variable_set('user_admin_role', $role->rid);
+      return t('User admin role reset to "administrator."');
+    }
+    else {
+      return t('Administrator role not found. Skipping update.');
     }
   }
-  catch (Exception $e) {
-    $messages[] = t('The field %old_field_name could not be renamed because there was an error: %error.',
-      array('%old_field_name' => $old_field_name, '%error' => $e->getMessage()));
-  }
-
-  cache_clear_all('*', 'cache_field', TRUE);
-
-  return $messages;
-}
-
-/**
- * Update the default jquery library to 1.10.
- */
-function dkan_update_7002() {
-  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
-    variable_set('jquery_update_jquery_version', '1.10');
+  else {
+    return t('User admin role already set. Skipping update.');
   }
 }
 
 /**
- * Disable the dkan_default_content module.
+ * Remove unsupported markdown options.
+ *
+ * @param array $context
+ *   Batch context.
  */
-function dkan_update_7005() {
-  db_update('system')
-    ->fields(array('status' => '0'))
-    ->condition('name', 'dkan_default_content')
+function dkan_delete_markdown_buttons(array &$context) {
+  $context['message'] = t('Removing unsupported Markdown buttons');
+  $eid = db_query('SELECT eid FROM {bueditor_editors} WHERE name = :name', array(':name' => 'Markdowneditor'))->fetchField();
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert a table')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert an abbreviation (word or acronym with definition)')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert a footnote')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert a horizontal ruler (horizontal line)')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Teaser break')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Insert a definition list')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Format selected text as code')
+    ->condition('eid', $eid)
+    ->execute();
+
+  db_delete('bueditor_buttons')
+    ->condition('title', 'Format selected text as a code block')
+    ->condition('eid', $eid)
+    ->execute();
+
+  // Update markdown linebreak button with html.
+  db_update('bueditor_buttons')
+    ->fields(array('content' => '<br>'))
+    ->condition('title', 'Insert a line break', '=')
+    ->condition('eid', $eid)
     ->execute();
 }
 
 /**
- * We need to revert field instances.
+ * Fix extra group links.
  *
- * This is required for the next update in another case
- * we have problem with new fields added on version 12.
- */
-function dkan_update_7006() {
-  module_enable(array('field_hidden'));
-  features_revert(array('dkan_datastore' => array('field_base', 'field_instance')));
-}
-
-/**
- * Resource group field.
+ * The groups view in og_extras creates a menu item even when the view is
+ * disabled. This will delete the extra menu item until the og_extras is removed
+ * from the code base.
  *
- * Groups cannot be edited manually on resources anymore. Group affiliation
- * will be inherited from parent datasets. This update hook was added to be sure
- * that all resources that do not have groups assigned are synchronized and
- * updated with the groups from the parent datasets.
+ * @param array $context
+ *   Batch context.
  */
-function dkan_update_7007(&$sandbox) {
-
-  if (!isset($sandbox['progress'])) {
-    $sandbox['progress'] = 0;
-    $sandbox['max'] = db_query("SELECT COUNT(DISTINCT fdr.field_dataset_ref_target_id) FROM {node} n LEFT JOIN {field_data_field_dataset_ref} fdr ON fdr.entity_id=n.nid LEFT JOIN {og_membership} og ON n.nid=og.etid WHERE n.type='resource' AND og.etid IS NULL AND fdr.field_dataset_ref_target_id IN (SELECT etid FROM {og_membership} WHERE etid IN (SELECT field_dataset_ref_target_id FROM {field_data_field_dataset_ref}))")->fetchField();
-  }
-
-  // Get all resources without group but the parent dataset has groups.
-  $result = db_query("SELECT DISTINCT fdr.field_dataset_ref_target_id FROM {node} n LEFT JOIN {field_data_field_dataset_ref} fdr ON fdr.entity_id=n.nid LEFT JOIN {og_membership} og ON n.nid=og.etid WHERE n.type='resource' AND og.etid IS NULL AND fdr.field_dataset_ref_target_id IN (SELECT etid FROM {og_membership} WHERE etid IN (SELECT field_dataset_ref_target_id FROM {field_data_field_dataset_ref})) LIMIT 0,10");
-
-  foreach ($result as $item) {
-    // Simulate a empty original.
-    // The 'dkan_dataset_sync_groups' function synchronizes
-    // the groups only when a change on the dataset is detected.
-    $original = new stdClass();
-    $original->type = 'dataset';
-    $original->og_group_ref = array();
-    $dataset = node_load($item->field_dataset_ref_target_id);
-    $dataset->original = $original;
-    dkan_dataset_sync_groups($dataset);
-    $sandbox['progress']++;
-  }
-
-  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
-
-  return t('All resources without group were updated.');
-
+function dkan_group_link_delete(array &$context) {
+  $context['message'] = t('Removing og_extra groups link');
+  db_query('DELETE FROM {menu_links} WHERE link_path = :link_path LIMIT 1', array(':link_path' => 'groups'));
 }
 
 /**
- * Point source menu to the command menu center in dkan workflow roles.
+ * Set up the roles that sitemanagers are allowed to assign via roleassign.
  */
-function dkan_update_7008() {
-  if (module_exists('dkan_workflow')) {
-    dkan_workflow_admin_menu_source();
+function dkan_set_roleassign_roles(&$context) {
+  $context['message'] = t('Configuring Role Assign module');
+  $roles_rids = array_flip(user_roles());
+  $roleassign_roles = array($roles_rids['administrator'] => 0);
+
+  // Should be everything except admin:
+  $allowed_roles = array('editor', 'site manager', 'content creator');
+
+  foreach ($allowed_roles as $role) {
+    $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
   }
+  variable_set('roleassign_roles', $roleassign_roles);
 }
 
 /**
- * Flush client site colorizer file to grab new updates.
+ * Configures BUEditor and markdown test format.
  */
-function dkan_update_7009() {
-  $theme = $GLOBALS['theme'];
-  $instance = $theme;
-  variable_del('colorizer_' . $instance . '_files');
-  colorizer_clearcache();
-  cache_clear_all();
-}
+function dkan_bueditor_markdown_install() {
+  module_enable(array('bueditor_plus'));
 
-/**
- * Disable/uninstall deprecated dkan_dataset_api, enable open_data_schema_map.
- */
-function dkan_update_7010() {
-  if (module_exists('dkan_dataset_api')) {
-    module_disable(array('dkan_dataset_api'));
-    drupal_uninstall_modules(array('dkan_dataset_api'));
-    module_enable(array('open_data_schema_map'));
-  }
-}
+  $context = array();
+  dkan_set_roleassign_roles($context);
 
-/**
- * Update copyright information.
- */
-function dkan_update_7011() {
-  $settings = variable_get('theme_nuboot_radix_settings', array());
-  if ($settings['copyright']['value'] == 'Powered by <a href="http://nucivic.com/dkan">DKAN</a>, a project of <a href="http://nucivic.com">NuCivic</a>') {
-    $settings['copyright']['value'] = t('Powered by <a href="http://getdkan.com/">DKAN</a>, a project of <a href="http://granicus.com">Granicus</a>');
-    variable_set('theme_nuboot_radix_settings', $settings);
-  }
-}
+  // Delete the old bueditor settings and profile.
+  db_delete('bueditor_editors')
+    ->condition('name', 'Markdowneditor')
+    ->execute();
 
-/**
- * Clean up db on upgrade to 7.x-1.13.
- *
- * Deprecated modules: Conditional Fields, Entity RDF, RDF UI, RDF Extensions.
- */
-function dkan_update_7012() {
-  if (!module_exists('conditional_fields')) {
-    db_delete('system')
-      ->condition('name', 'conditional_fields')
-      ->condition('type', 'module')
-      ->execute();
-    db_drop_table('conditional_fields');
-  }
-  if (!module_exists('entity_rdf')) {
-    db_delete('system')
-      ->condition('name', 'entity_rdf')
-      ->condition('type', 'module')
-      ->execute();
-  }
-  if (!module_exists('rdfui')) {
-    db_delete('system')
-      ->condition('name', 'rdfui')
-      ->condition('type', 'module')
-      ->execute();
-  }
-  if (!module_exists('rdfx')) {
-    db_delete('system')
-      ->condition('name', 'rdfx')
-      ->condition('type', 'module')
-      ->execute();
+  db_delete('bueditor_plus_profiles')
+    ->condition('name', 'Global')
+    ->execute();
 
-    db_drop_table('rdfx_namespaces');
-    db_drop_table('rdfx_term_details');
-    db_drop_table('rdfx_term_domains');
-    db_drop_table('rdfx_term_inverses');
-    db_drop_table('rdfx_term_ranges');
-    db_drop_table('rdfx_term_superclasses');
-    db_drop_table('rdfx_term_superproperties');
-    db_drop_table('rdfx_term_types');
-    db_drop_table('rdfx_terms');
-    db_drop_table('rdfx_vocabulary_details');
-    db_drop_table('rdfx_vocabulary_graphs');
-  }
-}
+  // Create the new bueditor settings and profile.
+  dkan_markdown_setup($context);
+  features_revert(array('dkan_sitewide' => array('filter')));
 
-/**
- * Remove deprecated test and theme directories.
- */
-function dkan_update_7013() {
-  $deprecated = array(
-    'profiles/dkan/modules/dkan/dkan_dataset/fonts',
-    'profiles/dkan/modules/dkan/dkan_dataset/tests',
-    'profiles/dkan/modules/dkan/dkan_datastore/tests',
-    'profiles/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/tests',
-    'profiles/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/test',
-    'profiles/dkan/modules/dkan/dkan_workflow/test',
-    'profiles/dkan/themes/contrib/nuboot_radix',
-    'profiles/dkan/themes/contrib/omega',
-  );
-  foreach ($deprecated as $dir) {
-    if (is_dir($dir)) {
-      drupal_rmdir($dir);
+  $roles = user_roles();
+  $bueditor_roles = array();
+
+  foreach ($roles as $rid => $role) {
+    switch ($role) {
+      case 'anonymous user':
+        $bueditor_roles[$rid] = array(
+          'weight' => 12,
+          'editor' => _dkan_bueditor_by_name('Commenter'),
+          'alt' => 0,
+        );
+        break;
+
+      case 'administrator':
+      case 'content creator':
+      case 'editor':
+      case 'site manager':
+        $bueditor_roles[$rid] = array(
+          'weight' => 0,
+          'editor' => _dkan_bueditor_by_name('Markdowneditor'),
+          'alt' => 0,
+        );
+        break;
+
+      default:
+        $bueditor_roles[$rid] = array(
+          'weight' => 11,
+          'editor' => 0,
+          'alt' => 0,
+        );
+        break;
     }
   }
+
+  $eid = db_select("bueditor_editors", "bue")
+    ->fields("bue", array("eid"))
+    ->condition("name", "Markdowneditor")
+    ->execute()
+    ->fetchField();
+
+  variable_set('bueditor_roles', $bueditor_roles);
+  variable_set('bueditor_user1', $eid);
+
+  $data = array(
+    'html' => array('default' => $eid, 'alternative' => 0),
+    'plain_text' => array('plain_text' => 0, 'alternative' => 0),
+  );
+
+  db_insert('bueditor_plus_profiles')
+    ->fields(array(
+      'name' => 'Global',
+      'data' => serialize($data),
+      'global' => 1,
+    ))
+    ->execute();
 }
 
 /**
- * Drop the 'field_modified_source_date' field.
+ * Extracts the editor id for an editor name.
+ *
+ * @param string $name
+ *   The user role name of the editor.
+ *
+ * @return int
+ *   The eid of the editor.
  */
-function dkan_update_7014() {
-  // Mark the field for deletion.
-  field_delete_field('field_modified_source_date');
-  // Run the batch process to actually delete the field.
-  $batch_size = 1;
-  field_purge_batch($batch_size);
-}
+function _dkan_bueditor_by_name($name = '') {
+  module_load_include("inc", "bueditor");
 
-/**
- * Update the default jquery library to 1.10 (again).
- */
-function dkan_update_7015() {
-  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
-    variable_set('jquery_update_jquery_version', '1.10');
+  if ($name == '') {
+    return 0;
   }
+
+  $editors = bueditor_editors('all');
+
+  foreach ($editors as $eid => $editor) {
+    if ($editor->name == $name) {
+      return $eid;
+    }
+  }
+
+  return 0;
 }
 
 /**
  * Add data dictionary textarea id to bueditor excludes list.
  */
-function dkan_update_7016() {
+function dkan_set_bueditor_excludes() {
   db_update('bueditor_editors')
     ->fields(array(
       'excludes' => 'edit-log
@@ -308,51 +562,9 @@ edit-menu-description
 }
 
 /**
- * Update chosen_jquery_selector to avoid misuse.
+ * Final post-install tasks.
  */
-function dkan_update_7017() {
-  variable_set('chosen_jquery_selector',
-    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"])');
-}
-
-/**
- * Update language field values to use dashes rather than underscores.
- */
-function dkan_update_7018() {
-  db_update('field_data_field_language')
-    ->expression('field_language_value', 'replace(field_language_value, :underscore, :dash)', array(':underscore' => '_', ':dash' => '-'))
-    ->execute();
-
-  db_update('field_revision_field_language')
-    ->expression('field_language_value', 'replace(field_language_value, :underscore, :dash)', array(':underscore' => '_', ':dash' => '-'))
-    ->execute();
-
-}
-
-/**
- * Remove old variables from dkan_dataset_api.
- */
-function dkan_update_7019() {
-  variable_del('dkan_catalog_desc');
-  variable_del('dkan_catalog_contact');
-  variable_del('dkan_catalog_mbox');
-  variable_del('dkan_dataset_api_site_read');
-  variable_del('dkan_dataset_api_data_json');
-  variable_del('dkan_dataset_api_revision_list');
-  variable_del('dkan_dataset_api_package_list');
-  variable_del('dkan_dataset_api_current_package_list_with_resources');
-  variable_del('dkan_dataset_api_package_show');
-  variable_del('dkan_dataset_api_resource_show');
-  variable_del('dkan_dataset_api_group_package_show');
-  variable_del('dkan_dataset_api_package_revision_list');
-  variable_del('dkan_dataset_api_group_list');
-}
-
-/**
- * Update chosen_jquery_selector to avoid misuse.
- */
-function dkan_update_7020() {
-  // REF #1936, #1890.
-  variable_set('chosen_jquery_selector',
-    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])');
+function dkan_post_install() {
+  variable_set('preprocess_css', 1);
+  variable_set('preprocess_js', 1);
 }

--- a/dkan.profile
+++ b/dkan.profile
@@ -130,6 +130,8 @@ function dkan_markdown_setup(array &$context) {
   drupal_write_record('bueditor_editors', $data, array('eid'));
   // Remove unsupported markdown options.
   dkan_delete_markdown_buttons($context);
+
+  return $context;
 }
 
 /**
@@ -495,14 +497,14 @@ function dkan_bueditor_markdown_install() {
     }
   }
 
-  variable_set('bueditor_roles', $bueditor_roles);
-  variable_set('bueditor_user1', $eid);
-
   $eid = db_select("bueditor_editors", "bue")
     ->fields("bue", array("eid"))
     ->condition("name", "Markdowneditor")
     ->execute()
     ->fetchField();
+
+  variable_set('bueditor_roles', $bueditor_roles);
+  variable_set('bueditor_user1', $eid);
 
   $data = array(
     'html' => array('default' => $eid, 'alternative' => 0),

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -58,6 +58,8 @@ projects:
     version: '2.10'
   defaultconfig:
     version: 1.0-alpha11
+  devel:
+    version: '1.5'
   diff:
     version: '3.3'
   double_field:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -58,8 +58,6 @@ projects:
     version: '2.10'
   defaultconfig:
     version: 1.0-alpha11
-  devel:
-    version: '1.5'
   diff:
     version: '3.3'
   double_field:

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
@@ -79,3 +79,28 @@ function dkan_default_content_disable() {
     }
   }
 }
+
+/**
+ * Implements hook_uninstall().
+ *
+ * De-register the dkan_default_content migrations on uninstall.
+ */
+function dkan_default_content_uninstall() {
+  $migrations = migrate_migrations();
+
+  foreach ($migrations as $name => $migration) {
+    if (strpos($name, 'dkan_default_content_') !== 0) {
+      continue;
+    }
+    if ($migration) {
+      Migration::deregisterMigration($name);
+    }
+    else {
+      drupal_watchdog(
+        'dkan_default_content',
+        "You are attempting to deregister a non existent migration: %migration", array(
+          '%migration' => $migration,
+        ));
+    }
+  }
+}

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
@@ -60,29 +60,28 @@ function dkan_default_content_import_default_pages() {
  * Removes all the generated content and disables all enabled migrations.
  */
 function dkan_default_content_disable() {
-  // Rollback Data Dashboards.
-  $migration = Migration::getInstance('dkan_default_content_data_dashboards');
-  $migration->processRollback();
-  // Rollback Data Stories.
-  $migration = Migration::getInstance('dkan_default_content_data_stories');
-  $migration->processRollback();
-  // Rollback Visualization Entities.
-  $migration = Migration::getInstance('dkan_default_content_visualization_entities');
-  $migration->processRollback();
-  // Rollback Datasets.
-  $migration = Migration::getInstance('dkan_default_content_datasets');
-  $migration->processRollback();
-  // Rollback Resources.
-  $migration = Migration::getInstance('dkan_default_content_resources');
-  $migration->processRollback();
-  // Rollback Groups.
-  $migration = Migration::getInstance('dkan_default_content_groups');
-  $migration->processRollback();
-  // Disable Mirations.
-  dkan_default_content_migrations_disable();
+  // Rollback Default Content Migrations.
+  $migrations = array(
+    'dkan_default_content_data_dashboards',
+    'dkan_default_content_data_stories',
+    'dkan_default_content_visualization_entities',
+    'dkan_default_content_datasets',
+    'dkan_default_content_resources',
+    'dkan_default_content_groups',
+  );
 
-  // Clear message queue.
-  drupal_get_messages('status', TRUE);
-  drupal_get_messages('warning', TRUE);
-  drupal_set_message('The default content was removed.');
+  foreach ($migrations as $migration) {
+    if ($migration) {
+      $migration = Migration::getInstance('dkan_default_content_data_dashboards');
+      $migration->processRollback();
+      Migration::deregisterMigration($migration);
+    }
+    else {
+      drupal_watchdog(
+        'dkan_default_content',
+        "You are attempting to disable a non existent migration: %migration", array(
+          '%migration' => $migration,
+        ));
+    }
+  }
 }

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.install
@@ -61,20 +61,14 @@ function dkan_default_content_import_default_pages() {
  */
 function dkan_default_content_disable() {
   // Rollback Default Content Migrations.
-  $migrations = array(
-    'dkan_default_content_data_dashboards',
-    'dkan_default_content_data_stories',
-    'dkan_default_content_visualization_entities',
-    'dkan_default_content_datasets',
-    'dkan_default_content_resources',
-    'dkan_default_content_groups',
-  );
+  $migrations = migrate_migrations();
 
-  foreach ($migrations as $migration) {
+  foreach ($migrations as $name => $migration) {
+    if (strpos($name, 'dkan_default_content_') !== 0) {
+      continue;
+    }
     if ($migration) {
-      $migration = Migration::getInstance('dkan_default_content_data_dashboards');
       $migration->processRollback();
-      Migration::deregisterMigration($migration);
     }
     else {
       drupal_watchdog(

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
@@ -59,14 +59,3 @@ function dkan_default_content_dkan_fixtures_register() {
   return 'dkan_default_content';
 }
 
-/**
- * Deregisters migrations.
- */
-function dkan_default_content_migrations_disable() {
-  Migration::deregisterMigration('dkan_default_content_datasets');
-  Migration::deregisterMigration('dkan_default_content_resources');
-  Migration::deregisterMigration('dkan_default_content_groups');
-  Migration::deregisterMigration('dkan_default_content_visualization_entities');
-  Migration::deregisterMigration('dkan_default_content_data_stories');
-  Migration::deregisterMigration('dkan_default_content_data_dashboards');
-}

--- a/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
+++ b/modules/dkan/dkan_fixtures/modules/dkan_default_content/dkan_default_content.module
@@ -58,4 +58,3 @@ function dkan_default_content_migrate_api() {
 function dkan_default_content_dkan_fixtures_register() {
   return 'dkan_default_content';
 }
-

--- a/modules/dkan/dkan_migrate_base/dkan_migrate_base.module
+++ b/modules/dkan/dkan_migrate_base/dkan_migrate_base.module
@@ -89,7 +89,7 @@ function dkan_migrate_base_create_resource_list_items($endpoint, $file_name) {
       $dataset_json = $dataset_response->data;
     }
     $dataset_data = drupal_json_decode($dataset_json);
-    $resources = $dataset_data['result']['resources'];
+    $resources = (array) $dataset_data['result']['resources'];
     foreach ($resources as $key => $resource) {
       $resource_ids['result'][] = $resource['id'];
     }

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -65,7 +65,7 @@ function dkan_topics_preprocess_menu_link(&$variables) {
     $css = '';
     foreach ($submenu as $child) {
       if (isset($child['#href'])) {
-        $url  = explode("/", $child['#href']);
+        $url = explode("/", $child['#href']);
         // Prepare term to match menu class.
         $term = strtolower($child['#title']);
         $term = str_replace(array('\\', '/', '[', ' '), '-', $term);

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -176,6 +176,12 @@ function dkan_topics_field_formatter_view($entity_type, $entity, $field, $instan
       // Custom formatter for topic field.
       foreach ($items as $delta => $item) {
         $term = taxonomy_term_load($item['tid']);
+        if (!$term) {
+          watchdog('dkan_topis', "Attempt to load missing taxonomy term id: %tid", array(
+            '%tid' => $item['tid'],
+          ), WATCHDOG_NOTICE);
+          continue;
+        }
         $url = $base_url . '/search/field_topic/' . pathauto_cleanstring($term->name) . '-' . $term->tid;
         // Gather icon values if font icon is used.
         $icons = field_get_items('taxonomy_term', $term, 'field_topic_icon');

--- a/modules/dkan/dkan_topics/dkan_topics.module
+++ b/modules/dkan/dkan_topics/dkan_topics.module
@@ -177,7 +177,7 @@ function dkan_topics_field_formatter_view($entity_type, $entity, $field, $instan
       foreach ($items as $delta => $item) {
         $term = taxonomy_term_load($item['tid']);
         if (!$term) {
-          watchdog('dkan_topis', "Attempt to load missing taxonomy term id: %tid", array(
+          watchdog('dkan_topics', "Attempt to load missing taxonomy term id: %tid", array(
             '%tid' => $item['tid'],
           ), WATCHDOG_NOTICE);
           continue;

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\DKANExtension\Context;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
@@ -12,19 +13,41 @@ class DatasetContext extends RawDKANEntityContext {
 
   use ModeratorTrait;
 
+  /**
+   *
+   */
   public function __construct() {
     parent::__construct(
       'node',
       'dataset',
-      NULL,
-      array('moderation', 'moderation_date')
+      // ToDo: load this from custom context.https://github.com/NuCivic/dkan_starter/issues/332.
+      array(
+        'title' => 'title',
+        'description' => 'body',
+        'published' => 'status',
+        'resource' => 'field_resources',
+        'access level' => 'field_public_access_level',
+        'contact name' => 'field_contact_name',
+        'contact email' => 'field_contact_email',
+        'attest name' => 'field_hhs_attestation_name',
+        'attest date' => 'field_hhs_attestation_date',
+        'verification status' => 'field_hhs_attestation_negative',
+        'attest privacy' => 'field_hhs_attestation_privacy',
+        'attest quality' => 'field_hhs_attestation_quality',
+        'bureau code' => 'field_odfe_bureau_code',
+        'license' => 'field_license',
+      ),
+      array(
+        'moderation',
+        'moderation_date',
+      )
     );
   }
 
   /**
    * @BeforeScenario
    */
-  public function gatherContexts(BeforeScenarioScope $scope){
+  public function gatherContexts(BeforeScenarioScope $scope) {
     parent::gatherContexts($scope);
     $environment = $scope->getEnvironment();
     $this->groupContext = $environment->getContext('Drupal\DKANExtension\Context\GroupContext');
@@ -53,11 +76,11 @@ class DatasetContext extends RawDKANEntityContext {
     $page = $session->getPage();
     $search_region = $page->find('css', '.view-dkan-datasets');
     $search_results = $search_region->findAll('css', '.views-row');
-    $found = false;
-    foreach( $search_results as $search_result ) {
+    $found = FALSE;
+    foreach ($search_results as $search_result) {
       $title = $search_result->find('css', 'h2');
       if ($title->getText() === $text) {
-        $found = true;
+        $found = TRUE;
       }
     }
     if (!$found) {
@@ -70,17 +93,23 @@ class DatasetContext extends RawDKANEntityContext {
    */
   public function theDatasetIsInModerationState($title, $state) {
     $node = reset($this->getNodeByTitle($title));
-    if(!$node) {
+    if (!$node) {
       throw new \Exception(sprintf($title . " node not found."));
     }
     $this->isNodeInModerationState($node, $state);
   }
 
+  /**
+   *
+   */
   public function pre_save($wrapper, $fields) {
     $this->preSaveModerate($wrapper, $fields);
     parent::pre_save($wrapper, $fields);
   }
 
+  /**
+   *
+   */
   public function post_save($wrapper, $fields) {
     parent::post_save($wrapper, $fields);
     $this->moderate($wrapper, $fields);
@@ -89,20 +118,19 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Then I should see the local preview link
    */
-  public function iShouldSeeTheLocalPreviewLink()
-  {
+  public function iShouldSeeTheLocalPreviewLink() {
     $this->assertSession()->pageTextContains(variable_get('dkan_dataset_teaser_preview_label', '') . ' ' . t('Preview'));
   }
 
   /**
    * @Given I should see the first :number dataset items in :orderby :sortdirection order.
    */
-  public function iShouldSeeTheFirstDatasetListInOrder($number, $orderby, $sortdirection){
+  public function iShouldSeeTheFirstDatasetListInOrder($number, $orderby, $sortdirection) {
     $number = (int) $number;
     // Search the list of datasets actually on the page (up to $number items)
     $dataset_list = array();
     $count = 0;
-    while(($count < $number ) && ($row = $this->getSession()->getPage()->find('css', '.views-row-'.($count+1))) !== null ){
+    while (($count < $number) && ($row = $this->getSession()->getPage()->find('css', '.views-row-' . ($count + 1))) !== NULL) {
       $row = $row->find('css', 'h2');
       $dataset_list[] = $row->getText();
       $count++;
@@ -112,13 +140,15 @@ class DatasetContext extends RawDKANEntityContext {
       throw new \Exception("Couldn't find $number datasets on the page. Found $count.");
     }
 
-    switch($orderby){
+    switch ($orderby) {
       case 'Date changed':
         $orderby = 'changed';
         break;
+
       case 'Title':
         $orderby = 'title';
         break;
+
       default:
         throw new \Exception("Ordering by '$orderby' is not supported by this step.");
     }
@@ -136,7 +166,7 @@ class DatasetContext extends RawDKANEntityContext {
       throw new \Exception("Couldn't find $number datasets in the database. Found $count.");
     }
 
-    foreach($results['results'] as $nid => $result) {
+    foreach ($results['results'] as $nid => $result) {
       $dataset = node_load($nid);
       $found_title = array_shift($dataset_list);
       if ($found_title !== $dataset->title) {
@@ -168,7 +198,7 @@ class DatasetContext extends RawDKANEntityContext {
     }
 
     $field_choices = $field->findAll('css', '.chosen-choices .search-choice');
-    foreach($field_choices as $field_choice) {
+    foreach ($field_choices as $field_choice) {
       $remove_button = $field_choice->find('css', '.search-choice-close');
       if ($remove_button) {
         $remove_button->click();
@@ -214,7 +244,7 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Then I should see all published datasets
    */
-  public function iShouldSeeAllPublishedDatasets(){
+  public function iShouldSeeAllPublishedDatasets() {
     $session = $this->getSession();
     $page = $session->getPage();
     $search_region = $page->find('css', '.view-dkan-datasets');
@@ -241,8 +271,7 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Then I should see all the dataset fields in the form
    */
-  public function iShouldSeeAllTheDatasetFieldsInTheForm()
-  {
+  public function iShouldSeeAllTheDatasetFieldsInTheForm() {
     $form_css_selector = '.node-dataset-form';
 
     // We could use field_info_instances() to get the list of fields for the 'dataset' content
@@ -268,7 +297,7 @@ class DatasetContext extends RawDKANEntityContext {
       'field_landing_page' => 'Homepage URL',
       'field_conforms_to' => 'Data Standard',
       'field_language' => 'Language',
-      'og_group_ref' => 'Groups'
+      'og_group_ref' => 'Groups',
     );
 
     $dataset_fieldsets = array(
@@ -301,14 +330,14 @@ class DatasetContext extends RawDKANEntityContext {
       }
     }
 
-    // Check that all form fiels are present
+    // Check that all form fiels are present.
     foreach ($dataset_fields as $key => $field_name) {
       if (!in_array($field_name, $available_form_fields)) {
         throw new \Exception("$field_name was not found in the form with CSS selector '$form_css_selector'");
       }
     }
 
-    // Check that all form fielsets are present
+    // Check that all form fielsets are present.
     foreach ($dataset_fieldsets as $key => $fieldset_name) {
       if (!in_array($fieldset_name, $available_form_fieldsets)) {
         throw new \Exception("$fieldset_name was not found in the form with CSS selector '$form_css_selector'");
@@ -319,8 +348,7 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Given I :operation the :option on DKAN Dataset Forms
    */
-  public function iTheOnDkanDatasetForms($operation, $option)
-  {
+  public function iTheOnDkanDatasetForms($operation, $option) {
     $enabled = 0;
     if ($operation === "enable") {
       $enabled = 1;
@@ -330,9 +358,11 @@ class DatasetContext extends RawDKANEntityContext {
       case 'Strict POD validation':
         variable_set('dkan_dataset_form_pod_validation', $enabled);
         break;
+
       case 'Groups validation':
         variable_set('dkan_dataset_form_group_validation', $enabled);
         break;
+
       default:
         break;
     }
@@ -341,8 +371,7 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Then I should see the :option groups option
    */
-  public function iShouldSeeTheGroupsOption($option)
-  {
+  public function iShouldSeeTheGroupsOption($option) {
     $element = $this->find_select_option('og_group_ref[und][]', $option);
     if (!$element) {
       throw new \Exception(sprintf('The %s option could not be found.', $option));
@@ -352,8 +381,7 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    * @Then I should not see the :option groups option
    */
-  public function iShouldNotSeeTheGroupsOption($option)
-  {
+  public function iShouldNotSeeTheGroupsOption($option) {
     $element = $this->find_select_option('og_group_ref[und][]', $option);
     if ($element) {
       throw new \Exception(sprintf('The %s option was found.', $option));
@@ -368,4 +396,5 @@ class DatasetContext extends RawDKANEntityContext {
     $xpath = "//select[@name='" . $select_name . "']//option[text()='" . $option . "']";
     return $session->getPage()->find('xpath', $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath));
   }
+
 }

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/HarvestSourceContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/HarvestSourceContext.php
@@ -7,6 +7,7 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Behat\Hook\Scope\AfterFeatureScope;
 
@@ -95,25 +96,61 @@ class HarvestSourceContext extends RawDKANEntityContext {
   }
 
   /**
-  * @AfterScenario @harvest_rollback
-  */
-  public function harvestRollback(AfterScenarioScope $event)
-  {
+   * @BeforeScenario @harvest
+   */
+  public function harvestSetup(BeforeScenarioScope $event) {
+    $user = user_load_by_name("sitemanager");
+    $sources = array(
+      "source_one" => "Source one",
+      "source_two" => "Source two",
+    );
+
+    foreach ($sources as $machine_name => $title) {
+      $user = user_load_by_name("sitemanager");
+      $entity = array('type' => 'harvest_source');
+      $entity = entity_create('node', $entity);
+      $wrapper = entity_metadata_wrapper('node', $entity);
+      $wrapper->title = $title;
+      $wrapper->status = 1;
+      $wrapper->field_dkan_harveset_type = 'datajson_v1_1_json';
+      $wrapper->field_dkan_harvest_source_uri = 'http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json';
+      $wrapper->field_dkan_harvest_machine_name = array(
+        'human' => $title,
+        'machine' => $machine_name,
+      );
+      if ($user) {
+        $wrapper->author = $user->uid;
+      }
+      if ($machine_name == 'source_two') {
+        $wrapper->status = 0;
+      }
+      $wrapper->save();
+    }
+  }
+
+  /**
+   * @AfterScenario @harvest
+   */
+  public function harvestTeardown(AfterScenarioScope $event) {
     $migrations = migrate_migrations();
-    $harvest_migrations = array();
+
     foreach ($migrations as $name => $migration) {
-      if(strpos($name , 'dkan_harvest') === 0) {
+      if (strpos($name, 'dkan_harvest') === 0) {
         $migration = \Migration::getInstance($name);
-        $migration->processRollback();
+        if ($migration) {
+          $migration->processRollback();
+        }
       }
     }
+
+    module_load_include('inc', 'devel_generate', 'devel_generate');
+    devel_generate_content_kill(array('node_types' => array('harvest_source')));
   }
 
   /**
    * @Then the content :content_title should be :status
    */
-  public function theContentShouldBe($content_title, $status)
-  {
+  public function theContentShouldBe($content_title, $status) {
     // Get content by title.
     $query = new \EntityFieldQuery();
     $result = $query->entityCondition('entity_type', 'node')
@@ -130,7 +167,8 @@ class HarvestSourceContext extends RawDKANEntityContext {
       $content_id = current($content_ids);
       $content = node_load($content_id, NULL, TRUE);
       $content_wrapper = entity_metadata_wrapper('node', $content);
-    } else {
+    }
+    else {
       if ($status != 'deleted') {
         throw new \Exception("Content with title '$content_title' was not found.");
       }
@@ -144,18 +182,22 @@ class HarvestSourceContext extends RawDKANEntityContext {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       case 'unpublished':
         if ($content_wrapper->status->value() != NODE_NOT_PUBLISHED) {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       case 'orphaned':
         if (!$content_wrapper->field_orphan->value()) {
           throw new \Exception("The status of the content is not '$status'");
         }
         break;
+
       default:
         break;
     }
   }
+
 }

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\DKANExtension\Context;
 
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -6,11 +7,8 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\DKANExtension\ServiceContainer\Page;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use EntityDrupalWrapper;
 use EntityMetadataWrapperException;
-use EntityFieldQuery;
 use Symfony\Component\Config\Definition\Exception\Exception;
-
 
 /**
  * Defines application features from the specific context.
@@ -18,8 +16,9 @@ use Symfony\Component\Config\Definition\Exception\Exception;
 class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingContext {
 
   // Store entities as EntityMetadataWrappers for easy property inspection.
-  //protected $entities = array();
-
+  /**
+   * Protected $entities = array();.
+   */
   protected $entity_type = '';
   protected $bundle = '';
   protected $bundle_key = FALSE;
@@ -36,15 +35,24 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    */
   protected $searchContext;
 
-
+  /**
+   *
+   */
   public function __construct($entity_type, $bundle, $field_map_overrides = array('published' => 'status'), $field_map_custom = array()) {
     $entity_info = entity_get_info($entity_type);
     $this->entity_type = $entity_type;
     $this->field_properties = array();
+    $default_field_map_overrides = array(
+      'published' => 'status',
+    );
 
     if ($field_map_overrides == NULL) {
-      $field_map_overrides = array('published' => 'status');
+      $field_map_overrides = $default_field_map_overrides;
     }
+    else {
+      $field_map_overrides = array_merge($default_field_map_overrides, $field_map_overrides);
+    }
+
     $this->field_map_custom = $field_map_custom;
 
     // Check that the bundle specified actually exists, or if none given,
@@ -65,12 +73,12 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
     // Store the field properties for later.
     $property_info = entity_get_property_info($this->entity_type);
-    // Store the fields for this bundle, but only if the bundle has fields
-    if (isset( $property_info['bundles'][$this->bundle])) {
+    // Store the fields for this bundle, but only if the bundle has fields.
+    if (isset($property_info['bundles'][$this->bundle])) {
       $this->field_properties += $property_info['bundles'][$this->bundle]['properties'];
     }
     // Store the properties shared by all entities of this type.
-    $this->field_properties +=  $property_info['properties'];
+    $this->field_properties += $property_info['properties'];
 
     // Collect the default and overridden field mappings.
     foreach ($this->field_properties as $field => $info) {
@@ -78,7 +86,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       if ($label = array_search($field, $field_map_overrides)) {
         $this->field_map[$label] = $field;
       }
-      // Use the default label from field_properties;
+      // Use the default label from field_properties;.
       else {
         $this->field_map[strtolower($info['label'])] = $field;
       }
@@ -101,17 +109,16 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    */
   public function deleteAll(AfterScenarioScope $scope) {
     $wrappers = $this->entityStore->retrieve($this->entity_type, $this->bundle);
-    if ($wrappers === false) {
+    if ($wrappers === FALSE) {
       return;
     }
     foreach ($wrappers as $wrapper) {
       // The behat user teardown deletes all the content of a user automatically,
       // so we want to get a fresh entity instead of relying on the wrapper
       // (or a bool that confirms it's deleted)
-
       $entities_to_delete = entity_load($this->entity_type, array($wrapper->getIdentifier()));
 
-      if (!empty($entities_to_delete)){
+      if (!empty($entities_to_delete)) {
         foreach ($entities_to_delete as $entity_to_delete) {
           $entity_to_delete = entity_metadata_wrapper($this->entity_type, $entity_to_delete);
           entity_delete($this->entity_type, $entity_to_delete->getIdentifier());
@@ -122,7 +129,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
     // For Scenarios Outlines, EntityContext is not deleted and recreated
     // and thus the entities array is not deleted and houses stale entities
-    // from previous examples, so we clear it here
+    // from previous examples, so we clear it here.
     $this->entityStore->delete($this->entity_type, $this->bundle);
     $this->entityStore->names_flush();
 
@@ -131,9 +138,10 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
   }
 
   /**
-   * Get Entity by name
+   * Get Entity by name.
    *
    * @param $name
+   *
    * @return EntityDrupalWrapper or FALSE
    */
   public function getByName($name) {
@@ -142,20 +150,18 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
   /**
    * Explode a comma separated string in a standard way.
-   *
    */
-  function explode_list($string) {
+  public function explode_list($string) {
     $array = explode(',', $string);
     $array = array_map('trim', $array);
     return is_array($array) ? $array : array();
   }
 
   /**
-   *
    * Helper function to create an entity as an EntityMetadataWrapper.
    *
    * Takes a array of key-mapped values and creates a fresh entity
-   * using the data provided. The array should correspond to the context's field_map
+   * using the data provided. The array should correspond to the context's field_map.
    *
    * @return \stdClass entity, or FALSE if failed
    */
@@ -184,11 +190,11 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * @throws \Exception
    */
   public function apply_fields($wrapper, $fields) {
-    foreach ($fields as $label => $value ) {
+    foreach ($fields as $label => $value) {
       if (in_array($label, $this->field_map_custom)) {
         continue;
       }
-      if(isset($this->field_map[$label]) && $this->field_map[$label] === 'status'){
+      if (isset($this->field_map[$label]) && $this->field_map[$label] === 'status') {
         $value = $this->convertStringToBool($value);
       }
       $this->set_field($wrapper, $label, $value);
@@ -203,7 +209,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * @throws \Exception
    */
   public function set_field($wrapper, $label, $value) {
-    $property = null;
+    $property = NULL;
     try {
       // Make sure there is a mapping to an actual property.
       if (!isset($this->field_map[$label])) {
@@ -221,12 +227,12 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       $field_type = $this->field_properties[$property]['type'];
 
       switch ($field_type) {
-        // Can be NID
+        // Can be NID.
         case 'integer':
-          $wrapper->$property->set((int)$value);
+          $wrapper->$property->set((int) $value);
           break;
 
-        // Do our best to handle 0, false, "false", or "No"
+        // Do our best to handle 0, false, "false", or "No".
         case 'boolean':
           if (gettype($value) == 'string') {
             $value = $this->convertStringToBool($value);
@@ -236,14 +242,19 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
         // Dates - handle strings as best we can. See http://php.net/manual/en/datetime.formats.relative.php
         case 'date':
-          $timestamp = strtotime($value);
+          if (is_numeric($value)) {
+            $timestamp = (int) $value;
+          }
+          else {
+            $timestamp = strtotime($value);
+          }
           if ($timestamp === FALSE) {
             throw new \Exception("Couldn't create a date with '$value'");
           }
           $wrapper->$property->set($timestamp);
           break;
 
-        // User reference
+        // User reference.
         case 'user':
           $user = user_load_by_name($value);
           if ($user === FALSE) {
@@ -254,20 +265,26 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
         // Simple text field.
         case 'text':
+        case "list<text>":
           $wrapper->$property->set($value);
           break;
 
-        // Formatted text like body
+        // Formatted text like body.
         case 'text_formatted':
           // For now just apply the value directly.
-          $wrapper->$property->set(array('value' => $value));
+          if (is_array($value)) {
+            $wrapper->$property->set($value);
+          }
+          else {
+            $wrapper->$property->set(array('value' => $value));
+          }
           break;
 
         case 'taxonomy_term':
           if (!isset($value)) {
             break;
           }
-          if($found_term = $this->tidFromTermName($property, $value)) {
+          if ($found_term = $this->tidFromTermName($property, $value)) {
             $tid = $found_term;
           }
           else {
@@ -275,7 +292,6 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
           }
           $wrapper->$property->set($tid);
           break;
-
 
         case "list<taxonomy_term>":
           // Convert the tags to tids.
@@ -314,19 +330,22 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
             // If the field type is node only one nid is expected.
             // Default to the first element.
             $wrapper->$property->set(reset($nids));
-          } else {
+          }
+          else {
             $wrapper->$property->set($nids);
           }
           break;
+
         // Not sure (something more complex)
         case 'struct':
-          // Images
+          // Images.
         case 'field_item_image':
-          // Links
+          // Links.
         case 'field_item_link':
           $wrapper->$property->set(array("url" => $value));
           break;
-        // Files
+
+        // Files.
         case 'field_item_file':
           $file = (object) array(
             'uri' => $value,
@@ -338,19 +357,21 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
           file_save($file);
           $wrapper->$property->file->set($file);
           break;
+
         case 'token':
-          // References to nodes
+          // References to nodes.
         case 'safeword_field':
           $wrapper->$property->set(array("machine" => $value));
           break;
+
         default:
           // For now, just error out as we can't handle it yet.
           throw new \Exception("Not sure how to handle field '$label' with type '$field_type'");
-          break;
+        break;
       }
     }
-    catch (EntityMetadataWrapperException $e ) {
-      $print_val = print_r($value, true);
+    catch (EntityMetadataWrapperException $e) {
+      $print_val = print_r($value, TRUE);
       throw new \Exception("Error when setting field '$property' with value '$print_val': Error Message => {$e->getMessage()}");
     }
   }
@@ -363,11 +384,13 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * corresponding array. This function will be called by sub-contexts to generate
    * their entities.
    *
-   * @param TableNode $entityTable - provided
+   * @param TableNode $entityTable
+   *   - provided.
+   *
    * @throws \Exception
    */
   public function addMultipleFromTable(TableNode $entityTable) {
-    foreach($this->arrayFromTableNode($entityTable) as $entity) {
+    foreach ($this->arrayFromTableNode($entityTable) as $entity) {
       $this->save($entity);
     }
   }
@@ -376,6 +399,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * Build routine for an entity.
    *
    * @param $fields - the array of key-mapped values
+   *
    * @return EntityDrupalWrapper $wrapper - EntityMetadataWrapper
    */
   public function save($fields) {
@@ -387,12 +411,12 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
     return $wrapper;
   }
 
-   /**
-    * Do further processing after saving.
-    *
-    * @param EntityDrupalWrapper $wrapper
-    * @param $fields
-    */
+  /**
+   * Do further processing after saving.
+   *
+   * @param EntityDrupalWrapper $wrapper
+   * @param $fields
+   */
   public function pre_save($wrapper, $fields) {
     // Update the changed date after the entity has been saved.
     if (isset($fields['date changed'])) {
@@ -406,7 +430,53 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       }
     }
     $this->dispatchDKANHooks('BeforeDKANEntityCreateScope', $wrapper, $fields);
+    $this->applyMissingRequiredFields($fields);
     $this->apply_fields($wrapper, $fields);
+  }
+
+  /**
+   * Uses devel generate to produce default data for required missing fields.
+   *
+   * Works on either field or label tables.
+   *
+   * @param array $data
+   *   Array of maps of label or field_name values.
+   * */
+  public function applyMissingRequiredFields(array &$data) {
+    $wrapper = $this->new_wrapper();
+    $bundle = $wrapper->type->value();
+    if ($bundle == "dataset") {
+      module_load_include('inc', 'devel_generate', 'devel_generate');
+      module_load_include('inc', 'devel_generate', 'devel_generate.fields');
+      $node = new \stdClass();
+      $node->type = $bundle;
+      devel_generate_fields($node, 'node', $bundle);
+      $devel_generate_wrapper = entity_metadata_wrapper('node', $node);
+
+      foreach ($this->field_properties as $key => $field) {
+        if ($key == 'type' || $key == 'author') {
+          continue;
+        }
+
+        if (isset($field['required']) && $field['required']) {
+          $k = array_search($key, $this->field_map);
+          if (!isset($data[$k])) {
+            $data[$k] = $devel_generate_wrapper->$key->value();
+            // TODO: use param passed in from behat config for defaults.
+            $defaults = array(
+              'field_public_access_level' => 'public',
+              'field_hhs_attestation_negative' => 1,
+              'field_license' => 'odc-by',
+            );
+            foreach ($defaults as $default => $value) {
+              if ($key == $default) {
+                $data[$k] = $value;
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -429,7 +499,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
     }
 
     if (isset($fields["dataset"])) {
-      if($fields["dataset"]) {
+      if ($fields["dataset"]) {
         node_save($wrapper->value());
       }
     }
@@ -448,10 +518,12 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * Takes an TableNode and builds a multi-dimensional array,
    *
    * @param TableNode
+   *
    * @throws \Exception
+   *
    * @returns array()
    */
-  function arrayFromTableNode(TableNode $itemsTable) {
+  public function arrayFromTableNode(TableNode $itemsTable) {
     $items = array();
     foreach ($itemsTable as $itemHash) {
       $items[] = $itemHash;
@@ -460,18 +532,21 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
   }
 
   /**
-   * Converts a string value to a boolean value
+   * Converts a string value to a boolean value.
    *
    * @param $value String
    */
-  function convertStringToBool($value){
+  public function convertStringToBool($value) {
     $value = strtolower($value);
     $value = ($value === 'yes') ? TRUE : $value;
     $value = ($value === 'no') ? FALSE : $value;
     return $value;
   }
 
-  function tidFromTermName($field_name, $term) {
+  /**
+   *
+   */
+  public function tidFromTermName($field_name, $term) {
     $info = field_info_field($field_name);
     $vocab_machine_name = $info['settings']['allowed_values'][0]['vocabulary'];
     if ($found_terms = taxonomy_get_term_by_name($term, $vocab_machine_name)) {
@@ -479,7 +554,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       return $found_term->tid;
     }
     else {
-      return false;
+      return FALSE;
     }
   }
 
@@ -490,10 +565,11 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    * Also, there is no guarantee that another action won't cause the updated date to change.
    *
    * @param EntityDrupalWrapper $saved_wrapper
-   * @param String $time_str See time formats supported by strtotime().
+   * @param string $time_str
+   *   See time formats supported by strtotime().
    */
-  function setChangedDate($saved_wrapper, $time_str) {
-    if (! ($saved_wrapper->type() == 'node')) {
+  public function setChangedDate($saved_wrapper, $time_str) {
+    if (!($saved_wrapper->type() == 'node')) {
       throw new Exception("Specifying the 'changed' date is only supported for nodes currently.");
     }
     if (!$nid = $saved_wrapper->getIdentifier()) {
@@ -523,11 +599,16 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
    *
    * @param $scopeType
    * @param \stdClass $entity
+   *
    * @throws
    */
   protected function dispatchDKANHooks($scopeType, \EntityDrupalWrapper $wrapper, &$fields) {
     $fullScopeClass = 'Drupal\\DKANExtension\\Hook\\Scope\\' . $scopeType;
-    $scope = new $fullScopeClass($this->getDrupal()->getEnvironment(), $this, $wrapper, $fields);
+    $drupal = $this->getDrupal();
+    if (!$drupal) {
+      return;
+    }
+    $scope = new $fullScopeClass($drupal->getEnvironment(), $this, $wrapper, $fields);
     $callResults = $this->dispatcher->dispatchScopeHooks($scope);
 
     // The dispatcher suppresses exceptions, throw them here if there are any.
@@ -538,4 +619,5 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       }
     }
   }
+
 }

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\DKANExtension\Context;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
@@ -7,8 +8,7 @@ use Symfony\Component\Config\Definition\Exception\Exception;
 /**
  * Defines application features from the specific context.
  */
-class ServicesContext extends RawDKANContext
-{
+class ServicesContext extends RawDKANContext {
   private $base_url = '';
   private $cookie_session = '';
   private $csrf_token = '';
@@ -16,26 +16,40 @@ class ServicesContext extends RawDKANContext
 
   // Each node field should be formatted properly before the information is sent on a request.
   // This is a map from 'Field name' -> 'Field format'.
+  /**
+   * TODO: Move to configuration passed in to constructor.
+   */
   private $request_fields_map = array(
     'resource' => array(
       'type' => 'type',
       'title' => 'title',
       'body' => 'body[und][0][value]',
-      'status' => 'status'
+      'status' => 'status',
     ),
     'dataset' => array(
       'type' => 'type',
       'title' => 'title',
-      'body' => 'body[und][0][value]',
       'status' => 'status',
-      'resource' => 'field_resources[und][0][target_id]'
-    )
+      'published' => 'status',
+      'body' => 'body[und][0][value]',
+      'resource' => 'field_resources[und][0][target_id]',
+      'access level' => 'field_public_access_level[und]',
+      'contact name' => 'field_contact_name[und][0][value]',
+      'contact email' => 'field_contact_email[und][0][value]',
+      'attest name' => 'field_hhs_attestation_name[und][0][value]',
+      'attest date' => 'field_hhs_attestation_date[und][0][value][date]',
+      'verification status' => 'field_hhs_attestation_negative[und]',
+      'attest privacy' => 'field_hhs_attestation_privacy[und]',
+      'attest quality' => 'field_hhs_attestation_quality[und]',
+      'bureau code' => 'field_odfe_bureau_code[und]',
+      'license' => 'field_license[und][select]',
+    ),
   );
 
   /**
    * @BeforeScenario
    */
-  public function gatherContexts(BeforeScenarioScope $scope){
+  public function gatherContexts(BeforeScenarioScope $scope) {
     parent::gatherContexts($scope);
     $environment = $scope->getEnvironment();
     $this->dkanContext = $environment->getContext('Drupal\DKANExtension\Context\DKANContext');
@@ -52,8 +66,7 @@ class ServicesContext extends RawDKANContext
   /**
    * @Given endpoints:
    */
-  public function endpoints($data)
-  {
+  public function endpoints($data) {
     foreach ($data->getHash() as $endpoint_data) {
       $this->endpoints[$endpoint_data['name']] = $endpoint_data['path'];
     }
@@ -62,9 +75,8 @@ class ServicesContext extends RawDKANContext
   /**
    * @Given I use the :arg1 endpoint to login with user :arg2 and pass :arg3
    */
-  public function iUseTheEndpointToLoginWithUserAndPass($endpoint, $username, $password)
-  {
-    // Build request URL
+  public function iUseTheEndpointToLoginWithUserAndPass($endpoint, $username, $password) {
+    // Build request URL.
     $request_url = $this->base_url . $this->getEndpointPath($endpoint) . '/user/login';
     // Get cookie_session and csrf_token.
     $user_login = $this->services_request_user_login($request_url, $username, $password);
@@ -75,10 +87,9 @@ class ServicesContext extends RawDKANContext
   /**
    * @Given I use the :arg1 endpoint to create the nodes:
    */
-  public function iUseTheEndpointToCreateTheNodes($endpoint, $nodes)
-  {
+  public function iUseTheEndpointToCreateTheNodes($endpoint, $nodes) {
     $request_url = $this->base_url . $this->getEndpointPath($endpoint) . '/node';
-    // Create nodes
+    // Create nodes.
     foreach ($nodes->getHash() as $node_data) {
       // Get node data.
       $processed_data = $this->build_node_data($node_data);
@@ -89,14 +100,13 @@ class ServicesContext extends RawDKANContext
       $wrapper = entity_metadata_wrapper('node', $node);
       $this->dkanContext->entityStore->store('node', $processed_data['type'], $node->nid, $wrapper, $wrapper->label());
     }
-    return true;
+    return TRUE;
   }
 
   /**
    * @Given I use the :arg1 endpoint to attach the file :arg2 to :arg3
    */
-  public function iUseTheEndpointToAttachTheFileTo($endpoint, $file_name, $node_name)
-  {
+  public function iUseTheEndpointToAttachTheFileTo($endpoint, $file_name, $node_name) {
     // Get node.
     $node = $this->dkanContext->entityStore->retrieve_by_name($node_name);
     if ($node) {
@@ -109,59 +119,61 @@ class ServicesContext extends RawDKANContext
       $file_data = array(
         "files[1]" => curl_file_create($file_path),
         "field_name" => "field_upload",
-        "attach" => 0 // 0 -> replace 1 -> append.
+      // 0 -> replace 1 -> append.
+        "attach" => 0,
       );
-      // Build request URL
+      // Build request URL.
       $request_url = $this->base_url . $this->getEndpointPath($endpoint) . '/node/' . $node->getIdentifier() . '/attach_file';
       // Attach file.
       $this->services_request_attach_file($file_data, $this->csrf_token, $this->cookie_session, $request_url);
-    } else {
+    }
+    else {
       throw new Exception(sprintf('The resource could not be found.'));
     }
 
-    return true;
+    return TRUE;
   }
 
   /**
    * @Given I use the :arg1 endpoint to update the node :arg2 with:
    */
-  public function iUseTheEndpointToUpdateTheNodeWith($endpoint, $node_name, $data)
-  {
+  public function iUseTheEndpointToUpdateTheNodeWith($endpoint, $node_name, $data) {
     // Get node.
     $node = $this->dkanContext->entityStore->retrieve_by_name($node_name);
     if ($node) {
-      // Update nodes
+      // Update nodes.
       foreach ($data->getHash() as $node_data) {
         // Get node data.
         $processed_data = $this->build_node_data($node_data, $node);
-        // Build request URL
+        // Build request URL.
         $request_url = $this->base_url . $this->getEndpointPath($endpoint) . '/node/' . $node->getIdentifier();
         // Update node.
         $this->services_request_update_node($processed_data, $this->csrf_token, $this->cookie_session, $request_url);
       }
-    } else {
+    }
+    else {
       throw new Exception(sprintf('The node could not be found.'));
     }
-    return true;
+    return TRUE;
 
   }
 
   /**
    * @Given I use the :arg1 endpoint to delete the node :arg2
    */
-  public function iUseTheEndpointToDeleteTheNode($endpoint, $node_name)
-  {
+  public function iUseTheEndpointToDeleteTheNode($endpoint, $node_name) {
     // Get node.
     $node = $this->dkanContext->entityStore->retrieve_by_name($node_name);
     if ($node) {
-      // Build request URL
+      // Build request URL.
       $request_url = $this->base_url . $this->getEndpointPath($endpoint) . '/node/' . $node->getIdentifier();
       // Delete node.
       $this->services_request_delete_node($this->csrf_token, $this->cookie_session, $request_url);
-    } else {
+    }
+    else {
       throw new Exception(sprintf('The node could not be found.'));
     }
-    return true;
+    return TRUE;
   }
 
   /**
@@ -170,7 +182,8 @@ class ServicesContext extends RawDKANContext
   private function getEndpointPath($endpoint_name) {
     if (isset($this->endpoints[$endpoint_name])) {
       return $this->endpoints[$endpoint_name];
-    } else {
+    }
+    else {
       throw new Exception(sprintf('The %s endpoint could not be found.', $endpoint_name));
     }
   }
@@ -184,7 +197,7 @@ class ServicesContext extends RawDKANContext
     if ($csrf_token) {
       curl_setopt($curl, CURLOPT_HTTPHEADER, array(
         'Accept: application/json',
-        'X-CSRF-Token: ' . $csrf_token
+        'X-CSRF-Token: ' . $csrf_token,
       ));
     }
     else {
@@ -210,11 +223,11 @@ class ServicesContext extends RawDKANContext
     $response['http_code'] = $http_code;
 
     if ($http_code == 200) {
-      $response['success'] = true;
+      $response['success'] = TRUE;
       $response['response'] = json_decode($result);
     }
     else {
-      $response['success'] = false;
+      $response['success'] = FALSE;
       $response['response'] = curl_error($curl);
     }
 
@@ -244,7 +257,8 @@ class ServicesContext extends RawDKANContext
       // Define cookie session.
       $cookie_session = $response['response']->session_name . '=' . $response['response']->sessid;
       return array('cookie_session' => $cookie_session, 'curl' => $curl);
-    } else {
+    }
+    else {
       throw new \Exception(sprintf('Error: %s', $response['response']));
     }
   }
@@ -289,7 +303,8 @@ class ServicesContext extends RawDKANContext
 
     if ($response['success']) {
       return $response['response'];
-    } else {
+    }
+    else {
       throw new \Exception(sprintf('Error: %s', $response['response']));
     }
   }
@@ -313,7 +328,8 @@ class ServicesContext extends RawDKANContext
 
     if ($response['success']) {
       return $response['response'];
-    } else {
+    }
+    else {
       throw new \Exception(sprintf('Error: %s', $response['response']));
     }
   }
@@ -328,7 +344,7 @@ class ServicesContext extends RawDKANContext
     curl_setopt($curl, CURLOPT_HTTPHEADER, array(
       'Content-Type: multipart/form-data',
       'Accept: application/json',
-      'X-CSRF-Token: ' . $csrf_token
+      'X-CSRF-Token: ' . $csrf_token,
     ));
     // Do a regular HTTP POST.
     curl_setopt($curl, CURLOPT_POST, 1);
@@ -341,12 +357,13 @@ class ServicesContext extends RawDKANContext
 
     if ($response['success']) {
       return $response['response'];
-    } else {
+    }
+    else {
       throw new \Exception(sprintf('Error: %s', $response['response']));
     }
   }
 
-  /*
+  /**
    * Delete node.
    */
   private function services_request_delete_node($csrf_token, $cookie_session, $request_url) {
@@ -370,7 +387,7 @@ class ServicesContext extends RawDKANContext
   /**
    * Build node data as needed by endpoint.
    */
-  private function build_node_data($data, $node = null) {
+  private function build_node_data($data, $node = NULL) {
     $node_data = array();
 
     if (!$node && !isset($data['type'])) {
@@ -382,6 +399,12 @@ class ServicesContext extends RawDKANContext
 
     // Get the rest api field map for the content type.
     $rest_api_fields = $this->request_fields_map[$node_type];
+
+    if ($node_type == "dataset") {
+      $rawDkanEntityContext = new DatasetContext();
+      $rawDkanEntityContext->applyMissingRequiredFields($data);
+    }
+
     foreach ($data as $field => $field_value) {
       if (isset($rest_api_fields[$field])) {
         $node_data[$rest_api_fields[$field]] = $this->process_field($field, $field_value);
@@ -401,17 +424,21 @@ class ServicesContext extends RawDKANContext
    */
   private function process_field($field, $field_value) {
     switch ($field) {
-      case 'resource': {
+      case 'resource':
         $resource = $this->dkanContext->entityStore->retrieve_by_name($field_value);
         if ($resource) {
-          return $resource->entityKey('title') . ' (' . $resource->getIdentifier() . ')';
+          $field_value = $resource->entityKey('title') . ' (' . $resource->getIdentifier() . ')';
         }
         break;
-      }
-      default:
-        return $field_value;
+
+      case "attest date":
+        if (is_numeric($field_value)) {
+          $field_value = date('m/d/Y', (int) $field_value);
+        }
+        break;
     }
 
-    return false;
+    return $field_value;
   }
+
 }

--- a/test/features/dkan_harvest.feature
+++ b/test/features/dkan_harvest.feature
@@ -1,6 +1,11 @@
 # time:3m30.05s
 @harvest_rollback @disablecaptcha
 Feature: Dkan Harvest
+  Background:
+    Given pages:
+      | name       | url                        |
+      | Source one | /harvest_source/source-one |
+      | Source two | /harvest_source/source-two |
 
   @api @javascript
   Scenario: As a site manager I should be able to add a harvest source.
@@ -45,15 +50,11 @@ Feature: Dkan Harvest
       | role                    |
       | authenticated user      |
 
-  @api
+  @api @harvest
   Scenario: As a site manager I should see only the published harvest sources listed on the harvest dashboard.
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site manager | Yes       |
-      | Source two | source_two   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site manager | No        |
     And pages:
       | name               | url                            |
       | Harvest Dashboard  | /admin/dkan/harvest/dashboard  |
@@ -62,15 +63,11 @@ Feature: Dkan Harvest
     Then I should see the text "Source one"
     And I should not see the text "Source two"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Delete all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site manager      | admin@fakeemail.com      | 1      | site manager      |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site manager"
     When I am on "admin/content"
@@ -83,17 +80,14 @@ Feature: Dkan Harvest
     And I press "Delete Sources"
     And I wait for the batch job to finish
     Then I should see "Harvest Source Source one has been deleted."
+    And I wait for "3" seconds
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "deleted"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Unpublish and mark as orphan all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site manager      | admin@fakeemail.com      | 1      | site manager     |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site manager"
     When I am on the "Source one" page
@@ -107,15 +101,11 @@ Feature: Dkan Harvest
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "unpublished"
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "orphaned"
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario: Keep published but mark as orphan all associated content when a Source is deleted
     Given users:
       | name              | mail                     | status | roles             |
       | Site Manager      | admin@fakeemail.com      | 1      | site manager      |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
-
     And The "source_one" source is harvested
     And I am logged in as "Site Manager"
     When I am on the "Source one" page
@@ -129,14 +119,11 @@ Feature: Dkan Harvest
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "published"
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "orphaned"
 
-  @api
+  @api @harvest
   Scenario: As a user I should have access to see harvest information into dataset node.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author       | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json | datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -150,14 +137,11 @@ Feature: Dkan Harvest
     And I should see "2016-06-22" in the "Release Date" row
     And I should see "2016-08-02" in the "Modified Date" row
 
-  @api
+  @api @harvest
   Scenario: As a user I should have access to see harvest preview information.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -167,14 +151,11 @@ Feature: Dkan Harvest
     And I should see the text "Harvest now"
     And I should see the text "Florida Bike Lanes Harvest"
 
-  @api
+  @api @harvest
   Scenario: As a user I should be able to refresh the preview on the Harvest Source.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "Site Manager"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -187,14 +168,11 @@ Feature: Dkan Harvest
     And I should see the text "Preview"
 
 
-  @api
+  @api @harvest
   Scenario Outline: As a user I should have access to the Event log tab on the Harvest Source.
     Given users:
       | name            | mail                   | roles           |
       | Site Manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site Manager | Yes       |
     And I am logged in as a "<role>"
     And I am on the "Source one" page
     Given The "source_one" source is harvested
@@ -209,14 +187,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api
+  @api @harvest
   Scenario Outline: As a user I should see a list of imported datasets on the Harvest Source page.
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And The "source_one" source is harvested
     And I am logged in as a "<role>"
     And I am on the "Source one" page
@@ -227,14 +202,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api
+  @api @harvest
   Scenario Outline: As user I should see a list of imported datasets in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -248,14 +220,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by orphan status in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -270,14 +239,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by post date in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -296,14 +262,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to filter harvested datasets by updated date in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |
@@ -325,14 +288,11 @@ Feature: Dkan Harvest
       | role              |
       | site manager      |
 
-  @api @javascript
+  @api @javascript @harvest
   Scenario Outline: As user I want to delete harvested datasets in the harvest administration dashboard
     Given users:
       | name            | mail                   | roles           |
       | Site manager    | admin@fakeemail.com    | site manager    |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Site manager | Yes       |
     And pages:
       | name                       | url                                     |
       | Harvest Dashboard Datasets | /admin/dkan/harvest/dashboard/datasets  |

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -444,15 +444,11 @@ Feature:
     And I click "Edit"
     Then the checkbox "editor" should be checked
 
-  @api @javascript @harvest_rollback
+  @api @javascript @harvest
   Scenario: Check harvested datasets are published by default even when dkan_workflow is enabled.
     Given users:
       | name               | mail                     | status | roles             |
       | Administrator      | admin@fakeemail.com      | 1      | administrator     |
-    And harvest sources:
-      | title      | machine name | source uri                                                                 | type               | author        | published |
-      | Source one | source_one   | http://s3.amazonaws.com/dkan-default-content-files/files/data_harvest.json |  datajson_v1_1_json | Administrator | Yes       |
-
     And The "source_one" source is harvested
     And the content "Gold Prices in London 1950-2008 (Monthly) Harvest" should be "published"
 


### PR DESCRIPTION
Description
====
This PR is a duplicate of #2000 that is required because that PR is not applying cleanly to 1.13.4  and dkan_starter.

These changes are to fix bugs discovered in the latest rounds of site upgrades.

1. Fix dkan_bueditor_markdown_install() uses variable before it is initialized.
2. Fix dkan_update_7016 assumes bueditor id is '5' (not always true).
3. Fix dkan_topics_field_formatter_view() does not check if term exists causing drupal to throw.
4. Fix dkan_default_content_disable() call to processRollback() on null.
5. Fix harvest tests do not clean up.
6. #1963: Allow dkanextension to handle custom fields
7. #1938: Allow skipping of features test via config
8. Do not deregister default content migrations on disable.
9. Fix dkan_migrate_base warning wrong type supplied to foreach.