### PR TITLE
Add BeforeSuite file shiv.

### DIFF
--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -68,6 +68,43 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
   }
 
   /**
+   * @BeforeSuite
+   */
+  public static function moveStageFileProxyFiles(BeforeSuiteScope $scope) {
+    // Only need to run this once.
+    if (variable_get('stage_file_proxy_setup', FALSE)) {
+      return;
+    }
+
+    global $conf;
+    if (!isset($conf['default']['stage_file_proxy_origin']) || $conf['default']['stage_file_proxy_origin'] == 'changeme') {
+      return;
+    }
+
+    // Fix missing font files.
+    $font_files = array('eot', 'svg', 'ttf', 'woff');
+
+    // Add the file usage.
+    foreach ($font_files as $ext) {
+      $filename = 'dkan-topics';
+      $theme_path = drupal_get_path('theme', 'nuboot_radix');
+      $source = $theme_path . '/assets/fonts/' . $filename . '.' . $ext;
+      $destination = 'public://' . $filename . '.' . $ext;
+      copy($source, $destination);
+    }
+
+    if (isset($conf['default']['stage_file_proxy_files'])) {
+      $proxy_files = (array) $conf['default']['stage_file_proxy_files'];
+      foreach ($proxy_files as $file) {
+        $source = $conf['default']['stage_file_proxy_origin'] . '/' . $file;
+        $destination = 'public://' . $file;
+        $copy($source, $destination);
+      }
+    }
+    variable_set('stage_file_proxy_setup', TRUE);
+  }
+
+  /**
    * @AfterSuite
    */
   public static function enableAdminMenuCache(AfterSuiteScope $scope) {


### PR DESCRIPTION
REF CIVIC-6610

When stage file proxy is enabled we need to make sure some required files are present in public://
By adding a BeforeSuite step that copies these files from a site to the local
environment, we fix errors that arise from files not being present in the
testing environment.

QA Steps
==
On a local version of devy with this patch
- [ ] Enable the stage_file_proxy module
- [ ] Verify that config.yml default:stage_file_proxy_origin is set to devy prod or set.
- [ ] Verify that configy.yml default:stage_file_proxy_files points to default_log.png or set it
- [ ] Remove default_log.png from public:// files directory
- [ ] Remove all files like dkan-topic.* from public:// files directory
- [ ] Verify that the following test does not fail: dkan/test/features/theme.admin.feature:16
- [ ] Verify that the following test does not fail: dkan
- [ ] dkan/test/features/topics.feature:48