### PR TITLE
Docker Local Environment Updates (#1955)

### DIFF
--- a/.ahoy/.scripts/config.rb
+++ b/.ahoy/.scripts/config.rb
@@ -1,11 +1,28 @@
 require 'yaml'
 
+# Deep merge only available in ruby >= 3.0
+# TODO: replace defaults with custom deep_merge
+
 begin
   CONFIG = YAML.load_file("config/config.yml")
 rescue Exception => msg
   puts "Loading of Configuration errored out with: #{msg}."
   puts "Using default CONFIG instead."
-  CONFIG = {"circle" => {"skip_features" => []}}
+  CONFIG = {}
 end
 
+if not CONFIG.has_key? "circle"
+  CONFIG["circle"] = {}
+end
 
+if not CONFIG["circle"].has_key? "skip_features"
+  CONFIG["circle"]["skip_features"] = []
+end
+
+if not CONFIG.has_key? "default"
+  CONFIG["default"] = {}
+end
+
+if not CONFIG["default"].has_key? "https_everywhere"
+  CONFIG["default"]["https_everywhere"] = false
+end

--- a/.ahoy/.scripts/dkan-uli.rb
+++ b/.ahoy/.scripts/dkan-uli.rb
@@ -1,0 +1,16 @@
+require "./dkan/.ahoy/.scripts/config.rb"
+
+if CONFIG["default"]["https_everywhere"]
+  url="surl"
+else
+  url="url"
+end
+
+url=`ahoy drush --uri="$(ahoy docker #{url})" uli`
+os =`uname`
+
+if os =~ /Darwin/
+  `open #{url}`
+else
+  puts url
+end

--- a/.ahoy/.scripts/drupal-rebuild.sh
+++ b/.ahoy/.scripts/drupal-rebuild.sh
@@ -12,8 +12,13 @@ fi
 
 drush --root=docroot  make --concurrency=$concurrency --prepare-install dkan/drupal-org-core.make docroot --yes
 
-drush --root=docroot -y --verbose $root si minimal --sites-subdir=default --account-pass='admin' --db-url=$1 install_configure_form.update_status_module='array(false,false)' &&
+drush --root=docroot -y --verbose si minimal --sites-subdir=default --account-pass='admin' --db-url=$1 install_configure_form.update_status_module='array(false,false)' &&
   ln -s ../../dkan docroot/profiles/dkan
 chmod +w docroot/sites/default/settings.php
-printf "// DKAN Datastore Fast Import options.\n\$databases['default']['default']['pdo'] = array(\n  PDO::MYSQL_ATTR_LOCAL_INFILE => 1,\n  PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,\n);" >> docroot/sites/default/settings.php
+
+if [ "$AHOY_CMD_PROXY" = "DOCKER" ]; then
+  printf "// Docker Database Settings\n\$databases['default']['default'] = array(\n  'database' => 'drupal',\n  'username' => 'drupal',\n  'password' => '123',\n  'host' => 'db',\n  'port' => '',\n  'driver' => 'mysql',\n  'prefix' => '',\n);\n" >> docroot/sites/default/settings.php
+fi
+printf "// DKAN Datastore Fast Import options.\n\$databases['default']['default']['pdo'] = array(\n  PDO::MYSQL_ATTR_LOCAL_INFILE => 1,\n  PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,\n);\n" >> docroot/sites/default/settings.php
+
 chmod -w docroot/sites/default/settings.php

--- a/.ahoy/dkan.ahoy.yml
+++ b/.ahoy/dkan.ahoy.yml
@@ -4,10 +4,13 @@ commands:
   drupal-rebuild:
     usage: 'Builds a drupal site in ./docroot. Requires database url.'
     cmd: |
-      if [ "$AHOY_CMD_PROXY" != "DOCKER" ]; then
-        ARGS="{{args}}"
-      else
+      if [ "$AHOY_CMD_PROXY" = "DOCKER" ]; then
         ARGS=`ahoy docker mysql-url`
+      fi
+
+      # If no mysql URL from docker, use passed in args.
+      if [ "$ARGS" = "" ];then
+        ARGS="{{args}}"
       fi
       if [[ "$ARGS" != mysql* ]]; then
           echo "You need to specify the drupal db url to use in the form mysql://root:root@localhost/db as an argument."
@@ -44,9 +47,11 @@ commands:
         mkdir backups
       fi
       if [ -f backups/last_install.sql ] && ahoy confirm "An existing installation backup exists at backups/last_install.sql, do you want to use that instead of reinstalling from scratch?"; then
-        ahoy drush sql-drop -y
-        ahoy drush cc all
-        ahoy drush sql-cli <  backups/last_install.sql
+
+        ahoy drush sql-drop -y && \
+        echo "... Removed tables, restoring DB"
+        ahoy dkan sqlc < backups/last_install.sql
+
         echo "Installed dkan from backup"
       else
         if [ "$AHOY_CMD_PROXY" == "DOCKER" ]; then
@@ -193,15 +198,13 @@ commands:
     import: dkan/.ahoy/theme.ahoy.yml
     hide: true
 
+  # Moved to .ahoy.yml
   uli:
-    usage: log into the
+    usage: Log in via drush
     cmd: |
-      uli=$(ahoy drush uli {{args}} | sed 's/^http.*\/default\/\(.*$\)/\1/g')
-      url="$(ahoy docker url)/$uli"
-      os=$(uname)
+      ruby dkan/.ahoy/.scripts/dkan-uli.rb {{args}}
 
-      if [ "$os" = "Darwin" ]; then
-        open $url
-      else
-        echo $url
-      fi
+  server:
+    usage: Provided as an easy way to setup the php server during testing.
+    cmd:
+      ahoy cmd-proxy bash dkan/.ahoy/.scripts/server.sh

--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -5,8 +5,12 @@
 web:
   hostname: web
   image: nuams/drupal-apache-php:1.0-5.6
+  # Fix for docker for mac container not starting selenium
+  # https://forums.docker.com/t/space-in-new-no-proxy-env-var-breaking-old-containers/14075
+
   environment:
     - VIRTUAL_HOST=dkan.docker
+    - no_proxy=localhost
     #- VIRTUAL_PROTO=https
   ports:
     - "80"
@@ -96,16 +100,21 @@ browser:
     - /dev/shm:/dev/shm
     # Project root folder mapping
     - *project_root
+
   links:
     - web
   ports:
-  #  - "4444:4444"
     - "5900"
+
+  # Fix for docker for mac container not starting selenium
+  # https://forums.docker.com/t/space-in-new-no-proxy-env-var-breaking-old-containers/14075
+  environment:
+    - no_proxy=localhost
 
 solr:
   hostname: solr
   image: devinci/drupal-solr:3.x
-  #ports:
-  #  - "8983:8983"
+  ports:
+    - "8983"
   volumes:
     - "./.docker/etc/solr/3.x:/var/lib/solr/conf"

--- a/.ahoy/docker.ahoy.yml
+++ b/.ahoy/docker.ahoy.yml
@@ -5,39 +5,98 @@ commands:
     cmd: |
       cat << EOF
         # To initialize your environment to use docker.
-        # Run: eval \$(ahoy docker env)
+        # Run: eval "\$(ahoy docker env)"
         #   OR
         # Add the following to your ~/.bashrc
         which docker || (echo "you don't seem to have docker installed. Exiting."; exit 1)
-        which docker-machine || (echo "you don't seem to have docker-machine installed. Exiting."; exit 1)
         which docker-compose || (echo "you don't seem to have docker-compose installed. Exiting."; exit 1)
         echo "Setting up docker environment"
         export AHOY_CMD_PROXY=DOCKER
-        docker-machine start default
-        $(docker-machine env default)
+        which docker-machine || (echo "you don't seem to have docker-machine installed. Exiting."; exit 1)
+        if [ ! -z "$DOCKER_MACHINE_NAME"  ]; then
+          docker-machine start default
+          $(docker-machine env default)
+        fi
+
         ahoy docker up
       EOF
     usage: Outputs the commands needed to setup a docker environment.
+  hostfile:
+    cmd: |
+      ip_address="127.0.0.1"
+      host_name="dkan.docker"
+      # find existing instances in the host file and save the line numbers
+      matches_in_hosts="$(grep -n $host_name /etc/hosts | cut -f1 -d:)"
+      host_entry="${ip_address}    ${host_name}"
+
+      if [ -z "$matches_in_hosts" ];then
+        echo "Adding new hosts entry."
+        echo "$host_entry" | sudo tee -a /etc/hosts > /dev/null
+      fi
   up:
-    cmd: "ahoy docker compose up -d {{args}}"
+    cmd: |
+      if [ -z $AHOY_CMD_PROXY ]; then
+        echo "AHOY_CMD_PROXY is not set. Run 'ahoy docker env' and follow instructions."
+        exit 0
+      fi
+      ahoy docker compose up -d {{args}}
+      ahoy docker proxy-up
+      ahoy docker hostfile
     usage: Start the docker-compose containers.
   proxy-up:
-    cmd: "docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy"
+    cmd: |
+      proxy_image=jwilder/nginx-proxy
+      # Check if the proxy container is running.
+      if [ ! "$(docker ps -f name=dkan_proxy -f ancestor=$proxy_image -q)" ];then
+        # Check if the proxy container stopped.
+        if [ "$(docker ps -f name=dkan_proxy -f ancestor=$proxy_image -qa)" ];then
+          echo "Restarting dkan_proxy container"
+          docker start dkan_proxy
+        else
+          echo "Starting dkan_proxy container"
+          docker run -d --privileged \
+            -p 80:80 -p 443:443 -p 5959:5900 \
+            -v /var/run/docker.sock:/tmp/docker.sock:ro \
+            --name=dkan_proxy jwilder/nginx-proxy
+        fi
+      fi
     usage: Run the nginx-proxy container
   stop:
-    cmd: "ahoy docker compose stop"
+    cmd: |
+      ahoy docker compose stop
+      proxy_image=jwilder/nginx-proxy
+      if [ ! -z "$(docker ps -f name=dkan_proxy -f ancestor=$proxy_image -q)" ];then
+        echo "Stopping dkan_proxy container"
+        docker stop dkan_proxy
+      fi
     usage: Stop the docker-compose containers (non-destructive).
   ps:
     cmd: "ahoy docker compose ps"
     usage: List the running docker-compose containers.
+
+  # Alias for web-ip.
   ip:
-    cmd: "docker-machine ip default"
-    usage: Show the ip address f the default docker machine VM
+    cmd: |
+      if [ -z "$DOCKER_MACHINE_NAME"  ]; then
+        ahoy docker web-ip
+      else
+        docker-machine ip default
+      fi
+
+    usage: Show the ip address of the web container
   reset:
-    cmd: "ahoy docker compose stop && ahoy docker compose rm && ahoy docker compose up -d"
+    cmd: |
+      ahoy docker destroy
+      ahoy docker up
     usage: Destroy and then restart the docker compose containers.
   destroy:
-    cmd: "ahoy docker compose stop && ahoy docker compose rm"
+    cmd: |
+      ahoy docker stop
+      ahoy docker compose rm
+      proxy_image=jwilder/nginx-proxy
+      if [ ! -z "$(docker ps -f name=dkan_proxy -f ancestor=$proxy_image -all -q)" ];then
+        docker rm dkan_proxy
+      fi
     usage: Destroy all the docker compose containers. (use before deleting folder)
   exec:
     cmd: |
@@ -82,18 +141,37 @@ commands:
   compose:
     cmd: docker-compose -f dkan/.ahoy/docker-compose.yml -p "${PWD##*/}" {{args}}
     usage: Abstraction for docker-compose
+  web-host:
+    cmd: |
+      echo `ahoy docker exec web printenv VIRTUAL_HOST | tr -d '\r'`
+  web-ip:
+    usage: Prints the web container IP address
+    cmd: |
+      echo `docker inspect --format '{{ .NetworkSettings.IPAddress }}' $(ahoy docker compose ps -q web)`
   url:
     usage: Prints the project URL
     cmd: |
-      echo "http://`docker-machine ip default`:`ahoy docker compose port web 80|cut -d ':' -f2`"
+      if [ -z "$DOCKER_MACHINE_NAME"  ]; then
+        echo "http://`ahoy docker web-host`"
+      else
+        echo "http://`docker-machine ip default`:`ahoy docker compose port web 80|cut -d ':' -f2`"
+      fi
   surl:
     usage: Prints a secure project URL
     cmd: |
-      echo "https://`docker-machine ip default`:`ahoy docker compose port web 443|cut -d ':' -f2`"
+      if [ -z "$DOCKER_MACHINE_NAME"  ]; then
+        echo "https://`ahoy docker web-host`:`ahoy docker compose port web 443|cut -d ':' -f2`"
+      else
+        echo "https://`docker-machine ip default`:`ahoy docker compose port web 443|cut -d ':' -f2`"
+      fi
   vnc:
     usage: Prints the project VNC URL
     cmd: |
-      echo "`docker-machine ip default`:`ahoy docker compose port browser 5900|cut -d ':' -f2`"
+      if [ -z "$DOCKER_MACHINE_NAME"  ]; then
+        echo "https://`ahoy docker web-host`:`ahoy docker compose port browser 5900|cut -d ':' -f2`"
+      else
+        echo "`docker-machine ip default`:`ahoy docker compose port browser 5900|cut -d ':' -f2`"
+      fi
 
   cleanup:
     usage: Clean ups docker unused images and volumes. See http://blog.yohanliyanage.com/2015/05/docker-clean-up-after-yourself/.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.5
 ----------
+ - #1955 Update ahoy docker tooling for local environment usecase.
  - #2003 Fix dkan_bueditor_markdown_install(), which was using a variable before it was initialized.
  - #2003 Fix to dkan_update_7016, which assumed the bueditor ID was always '5' and failed when it was not.
  - #2003 Fix dkan_topics_field_formatter_view(), which does not check if a term exists before calling it by tid.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,5 @@
 7.x-1.13.5
 ----------
- - #1955 Update ahoy docker tooling for local environment usecase.
  - #2003 Fix dkan_bueditor_markdown_install(), which was using a variable before it was initialized.
  - #2003 Fix to dkan_update_7016, which assumed the bueditor ID was always '5' and failed when it was not.
  - #2003 Fix dkan_topics_field_formatter_view(), which does not check if a term exists before calling it by tid.


### PR DESCRIPTION
Backports #1955 into 1.13.5

REF CIVIC-661

* Docker fix for mysql args

* Changes from docker-machine to docker, fixed uli

* Added 'ahoy docker hostfile' to add to /etc/hosts

* Make backwards compatible with docker-machine.

* Make backwards compatible with docker-machine.

Missed this one.

* Add dkan-uli.rb script.

Will handle function for `ahoy dkan uli`.

* Move uli command back to dkan.ahoy.yml

* Update CHANGELOG.

* Remove .ahoy.yml uli command.