### PR TITLE
Add configurable arguments via Behat Contexts.

### DIFF
--- a/.ahoy/tests/behat-parse-params.rb
+++ b/.ahoy/tests/behat-parse-params.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "./.scripts/behat-parse-params.rb"
+require "./dkan/.ahoy/.scripts/behat-parse-params.rb"
 
 class TestBehatParseParams < MiniTest::Unit::TestCase
 

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -79,58 +79,29 @@ default:
           - Drupal\DKANExtension\Context\ServicesContext:
             - request_fields_map:
                 resource:
-                  fields:
-                    type: type
-                    title: title
-                    body: body[und][0][value]
-                    status: status
+                  type: type
+                  title: title
+                  body: body[und][0][value]
+                  status: status
                 dataset:
-                  fields:
-                    title: title
-                    description: body
-                    published: status
-                    resource: field_resources
-                    access level: field_public_access_level
-                    contact name: field_contact_name
-                    contact email: field_contact_email
-                    attest name: field_hhs_attestation_name
-                    attest date: field_hhs_attestation_date
-                    verification status: field_hhs_attestation_negative
-                    attest privacy: field_hhs_attestation_privacy
-                    attest quality: field_hhs_attestation_quality
-                    bureau code: field_odfe_bureau_code
-                    license: field_license
-                    doi: field_doi
-                    citation: field_citation
-                  labels:
-                    title: Title
-                    body: Description
-                    field_tags: Tags
-                    field_topics: Topics
-                    field_license: License
-                    field_author: Author
-                    field_spatial_geographical_cover: Spatial / Geographical Coverage Location
-                    field_frequency: Frequency
-                    field_granularity: Granularity
-                    field_data_dictionary_type: Data Dictionary Type
-                    field_data_dictionary: Data Dictionary
-                    field_contact_name: Contact Name
-                    field_contact_email: Contact Email
-                    field_public_access_level: Public Access Level
-                    field_additional_info: Additional Info
-                    field_resources: Resources
-                    field_related_content: Related Content
-                    field_landing_page: Homepage URL
-                    field_conforms_to: Data Standard
-                    field_language: Language
-                    og_group_ref: Groups
-                  sets:
-                    field_spatial: Spatial / Geographical Coverage Area
-                    field_temporal_coverage: Temporal Coverage
-                  defaults:
-                    field_public_access_level: public
-                    field_hhs_attestation_negative: 1
-                    field_license: odc-by
+                  type: type
+                  title: title
+                  status: status
+                  published: status
+                  body: body[und][0][value]
+                  resource: field_resources[und][0][target_id]
+                  access level: field_public_access_level[und]
+                  contact name: field_contact_name[und][0][value]
+                  contact email: field_contact_email[und][0][value]
+                  attest name: field_hhs_attestation_name[und][0][value]
+                  attest date: field_hhs_attestation_date[und][0][value][date]
+                  verification status: field_hhs_attestation_negative[und]
+                  attest privacy: field_hhs_attestation_privacy[und]
+                  attest quality: field_hhs_attestation_quality[und]
+                  bureau code: field_odfe_bureau_code[und]
+                  license: field_license[und][select]
+                  doi: field_doi[und][0][value]
+                  citation: field_citation[und][0][value]
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\DatastoreContext
           - Drupal\DKANExtension\Context\TimezoneContext

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -14,7 +14,54 @@ default:
           - Drupal\DKANExtension\Context\GroupContext
           - Drupal\DKANExtension\Context\HarvestSourceContext
           - Drupal\DKANExtension\Context\WorkflowContext
-          - Drupal\DKANExtension\Context\DatasetContext
+          - Drupal\DKANExtension\Context\DatasetContext:
+            - fields:
+                title: title
+                description: body
+                published: status
+                resource: field_resources
+                access level: field_public_access_level
+                contact name: field_contact_name
+                contact email: field_contact_email
+                attest name: field_hhs_attestation_name
+                attest date: field_hhs_attestation_date
+                verification status: field_hhs_attestation_negative
+                attest privacy: field_hhs_attestation_privacy
+                attest quality: field_hhs_attestation_quality
+                bureau code: field_odfe_bureau_code
+                license: field_license
+                doi: field_doi
+                citation: field_citation
+                corn: stop
+            - labels:
+                title: Title
+                body: Description
+                field_tags: Tags
+                field_topics: Topics
+                field_license: License
+                field_author: Author
+                field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+                field_frequency: Frequency
+                field_granularity: Granularity
+                field_data_dictionary_type: Data Dictionary Type
+                field_data_dictionary: Data Dictionary
+                field_contact_name: Contact Name
+                field_contact_email: Contact Email
+                field_public_access_level: Public Access Level
+                field_additional_info: Additional Info
+                field_resources: Resources
+                field_related_content: Related Content
+                field_landing_page: Homepage URL
+                field_conforms_to: Data Standard
+                field_language: Language
+                og_group_ref: Groups
+            - sets:
+                field_spatial: Spatial / Geographical Coverage Area
+                field_temporal_coverage: Temporal Coverage
+            - defaults:
+                field_public_access_level: public
+                field_hhs_attestation_negative: 1
+                field_license: odc-by
           - Drupal\DKANExtension\Context\DataDashboardContext
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\FastImportContext
@@ -30,7 +77,32 @@ default:
                   results_css: '.view-dkan-harvest-source-search'
                   result_item_css: '.views-row'
           - Drupal\DKANExtension\Context\ResourceContext
-          - Drupal\DKANExtension\Context\ServicesContext
+          - Drupal\DKANExtension\Context\ServicesContext:
+            - request_fields_map:
+                resource:
+                  type: type
+                  title: title
+                  body: body[und][0][value]
+                  status: status
+                dataset':
+                  type: type
+                  title: title
+                  status: status
+                  published: status
+                  body: body[und][0][value]
+                  resource: field_resources[und][0][target_id]
+                  access level: field_public_access_level[und]
+                  contact name: field_contact_name[und][0][value]
+                  contact email: field_contact_email[und][0][value]
+                  attest name: field_hhs_attestation_name[und][0][value]
+                  attest date: field_hhs_attestation_date[und][0][value][date]
+                  verification status: field_hhs_attestation_negative[und]
+                  attest privacy: field_hhs_attestation_privacy[und]
+                  attest quality: field_hhs_attestation_quality[und]
+                  bureau code: field_odfe_bureau_code[und]
+                  license: field_license[und][select]
+                  doi: field_doi[und][0][value]
+                  citation: field_citation[und][0][value]
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\DatastoreContext
           - Drupal\DKANExtension\Context\TimezoneContext

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -1,193 +1,195 @@
-default:
-  suites:
-     dkan:
-        contexts:
-          - FeatureContext #Temporary overrides only!
-          - Drupal\DrupalExtension\Context\MinkContext
-          - Drupal\DrupalExtension\Context\DrupalContext
-          - Drupal\DrupalExtension\Context\MessageContext
-          - Drupal\DrupalExtension\Context\MarkupContext
-          - Drupal\DrupalExtension\Context\BatchContext
-          - Drupal\DKANExtension\Context\DKANContext
-          - Drupal\DKANExtension\Context\MailContext
-          - Drupal\DKANExtension\Context\PageContext
-          - Drupal\DKANExtension\Context\GroupContext
-          - Drupal\DKANExtension\Context\HarvestSourceContext
-          - Drupal\DKANExtension\Context\WorkflowContext
-          - Drupal\DKANExtension\Context\DatasetContext:
-            - fields:
-                title: title
-                description: body
-                published: status
-                resource: field_resources
-                access level: field_public_access_level
-                contact name: field_contact_name
-                contact email: field_contact_email
-                attest name: field_hhs_attestation_name
-                attest date: field_hhs_attestation_date
-                verification status: field_hhs_attestation_negative
-                attest privacy: field_hhs_attestation_privacy
-                attest quality: field_hhs_attestation_quality
-                bureau code: field_odfe_bureau_code
-                license: field_license
-                doi: field_doi
-                citation: field_citation
-            - labels:
-                title: Title
-                body: Description
-                field_tags: Tags
-                field_topics: Topics
-                field_license: License
-                field_author: Author
-                field_spatial_geographical_cover: Spatial / Geographical Coverage Location
-                field_frequency: Frequency
-                field_granularity: Granularity
-                field_data_dictionary_type: Data Dictionary Type
-                field_data_dictionary: Data Dictionary
-                field_contact_name: Contact Name
-                field_contact_email: Contact Email
-                field_public_access_level: Public Access Level
-                field_additional_info: Additional Info
-                field_resources: Resources
-                field_related_content: Related Content
-                field_landing_page: Homepage URL
-                field_conforms_to: Data Standard
-                field_language: Language
-                og_group_ref: Groups
-            - sets:
-                field_spatial: Spatial / Geographical Coverage Area
-                field_temporal_coverage: Temporal Coverage
-            - defaults:
-                field_public_access_level: public
-                field_hhs_attestation_negative: 1
-                field_license: odc-by
-          - Drupal\DKANExtension\Context\DataDashboardContext
-          - Drupal\DKANExtension\Context\PODContext
-          - Drupal\DKANExtension\Context\FastImportContext
-          - Drupal\DKANExtension\Context\SearchAPIContext:
-              search_forms:
-                default:
-                  form_css: '#dkan-sitewide-dataset-search-form'
-                  form_field: 'edit-search'
-                  form_button: 'edit-submit'
-                  results_css: '.view-dkan-datasets'
-                  result_item_css: '.views-row'
-                harvest_source:
-                  results_css: '.view-dkan-harvest-source-search'
-                  result_item_css: '.views-row'
-          - Drupal\DKANExtension\Context\ResourceContext
-          - Drupal\DKANExtension\Context\ServicesContext:
-            - request_fields_map:
-                resource:
-                  type: type
-                  title: title
-                  body: body[und][0][value]
-                  status: status
-                dataset:
-                  type: type
-                  title: title
-                  status: status
-                  published: status
-                  body: body[und][0][value]
-                  resource: field_resources[und][0][target_id]
-                  access level: field_public_access_level[und]
-                  contact name: field_contact_name[und][0][value]
-                  contact email: field_contact_email[und][0][value]
-                  attest name: field_hhs_attestation_name[und][0][value]
-                  attest date: field_hhs_attestation_date[und][0][value][date]
-                  verification status: field_hhs_attestation_negative[und]
-                  attest privacy: field_hhs_attestation_privacy[und]
-                  attest quality: field_hhs_attestation_quality[und]
-                  bureau code: field_odfe_bureau_code[und]
-                  license: field_license[und][select]
-                  doi: field_doi[und][0][value]
-                  citation: field_citation[und][0][value]
-          - Drupal\DKANExtension\Context\PODContext
-          - Drupal\DKANExtension\Context\DatastoreContext
-          - Drupal\DKANExtension\Context\TimezoneContext
-          - Drupal\DrupalExtension\Context\DrushContext
-          - Devinci\DevinciExtension\Context\DebugContext:
-              asset_dump_path: '%paths.base%/assets'
-          - Devinci\DevinciExtension\Context\JavascriptContext:
-              maximum_wait: 30
-  formatters:
-    pretty:
-      output_styles:
-        comment:    [default, default , [conceal]]
-  gherkin:
-    filters:
+--- 
+default: 
+  suites: 
+    dkan: 
+      contexts: 
+      - FeatureContext
+      - Drupal\DrupalExtension\Context\MinkContext
+      - Drupal\DrupalExtension\Context\DrupalContext
+      - Drupal\DrupalExtension\Context\MessageContext
+      - Drupal\DrupalExtension\Context\MarkupContext
+      - Drupal\DrupalExtension\Context\BatchContext
+      - Drupal\DKANExtension\Context\DKANContext
+      - Drupal\DKANExtension\Context\MailContext
+      - Drupal\DKANExtension\Context\PageContext
+      - Drupal\DKANExtension\Context\GroupContext
+      - Drupal\DKANExtension\Context\HarvestSourceContext
+      - Drupal\DKANExtension\Context\WorkflowContext
+      - Drupal\DKANExtension\Context\DatasetContext: 
+        - fields: 
+            title: title
+            description: body
+            published: status
+            resource: field_resources
+            access level: field_public_access_level
+            contact name: field_contact_name
+            contact email: field_contact_email
+            attest name: field_hhs_attestation_name
+            attest date: field_hhs_attestation_date
+            verification status: field_hhs_attestation_negative
+            attest privacy: field_hhs_attestation_privacy
+            attest quality: field_hhs_attestation_quality
+            bureau code: field_odfe_bureau_code
+            license: field_license
+            doi: field_doi
+            citation: field_citation
+        - labels: 
+            title: Title
+            body: Description
+            field_tags: Tags
+            field_topics: Topics
+            field_license: License
+            field_author: Author
+            field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+            field_frequency: Frequency
+            field_granularity: Granularity
+            field_data_dictionary_type: Data Dictionary Type
+            field_data_dictionary: Data Dictionary
+            field_contact_name: Contact Name
+            field_contact_email: Contact Email
+            field_public_access_level: Public Access Level
+            field_additional_info: Additional Info
+            field_resources: Resources
+            field_related_content: Related Content
+            field_landing_page: Homepage URL
+            field_conforms_to: Data Standard
+            field_language: Language
+            og_group_ref: Groups
+        - sets: 
+            field_spatial: Spatial / Geographical Coverage Area
+            field_temporal_coverage: Temporal Coverage
+        - defaults: 
+            field_public_access_level: public
+            field_hhs_attestation_negative: 1
+            field_license: odc-by
+      - Drupal\DKANExtension\Context\DataDashboardContext
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\FastImportContext
+      - Drupal\DKANExtension\Context\SearchAPIContext: 
+          search_forms: 
+            default: 
+              form_css: "#dkan-sitewide-dataset-search-form"
+              form_field: edit-search
+              form_button: edit-submit
+              results_css: .view-dkan-datasets
+              result_item_css: .views-row
+            harvest_source: 
+              results_css: .view-dkan-harvest-source-search
+              result_item_css: .views-row
+      - Drupal\DKANExtension\Context\ResourceContext
+      - Drupal\DKANExtension\Context\ServicesContext: 
+        - request_fields_map: 
+            resource: 
+              type: type
+              title: title
+              body: body[und][0][value]
+              status: status
+            dataset: 
+              type: type
+              title: title
+              status: status
+              published: status
+              body: body[und][0][value]
+              resource: field_resources[und][0][target_id]
+              access level: field_public_access_level[und]
+              contact name: field_contact_name[und][0][value]
+              contact email: field_contact_email[und][0][value]
+              attest name: field_hhs_attestation_name[und][0][value]
+              attest date: field_hhs_attestation_date[und][0][value][date]
+              verification status: field_hhs_attestation_negative[und]
+              attest privacy: field_hhs_attestation_privacy[und]
+              attest quality: field_hhs_attestation_quality[und]
+              bureau code: field_odfe_bureau_code[und]
+              license: field_license[und][select]
+              doi: field_doi[und][0][value]
+              citation: field_citation[und][0][value]
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\DatastoreContext
+      - Drupal\DKANExtension\Context\TimezoneContext
+      - Drupal\DrupalExtension\Context\DrushContext
+      - Devinci\DevinciExtension\Context\DebugContext: 
+          asset_dump_path: "%paths.base%/assets"
+      - Devinci\DevinciExtension\Context\JavascriptContext: 
+          maximum_wait: 30
+  formatters: 
+    pretty: 
+      output_styles: 
+        comment: 
+        - default
+        - default
+        - [conceal]
+  gherkin: 
+    filters: 
       tags: ~@fixme
-  extensions:
-    Behat\MinkExtension:
-      goutte: ~
-      selenium2: ~
-      default_session: 'goutte'
-      javascript_session: 'selenium2'
+  extensions: 
+    Behat\MinkExtension: 
+      goutte: []
+
+      selenium2: []
+
+      default_session: goutte
+      javascript_session: selenium2
       browser_name: chrome
-      files_path: '%paths.base%/files'
-    Drupal\DrupalExtension:
-      blackbox: ~
-      drupal:
-        #TODO Abstract this out.
-        drupal_root: '%paths.base%/../../docroot'
-      api_driver: 'drupal'
-      # @todo fixup these regions for use with new theme. Updated navigation only
-      region_map:
-        content: ".region-content"
-        toolbar: ".tabs--primary"
+      files_path: "%paths.base%/files"
+    Drupal\DrupalExtension: 
+      blackbox: 
+      drupal: 
+        drupal_root: "%paths.base%/../../docroot"
+      api_driver: drupal
+      region_map: 
+        admin menu: "#admin-menu"
+        breadcrumb: .breadcrumb
+        comment: .comment-main
+        content search: .form-item-query
+        content: .region-content
+        dashboards: .view-data-dashboards table tbody
+        dataset body: .field-name-body
+        dataset edit body: "#edit-body"
+        dataset resource list: "#data-and-resources"
+        dataset spatial: "#edit-field-spatial"
+        dataset title: .pane-node .pane-title
+        datasets: .view-dkan-datasets
+        dropdown_links: .comment-main .links.inline.dropdown-menu
+        facet container: .radix-layouts-sidebar
+        filter by author: .facetapi-facet-author
+        filter by date changed: .facetapi-facet-changed
+        filter by resource format: .facetapi-facet-field-resourcesfield-format
+        filter by tag: .facetapi-facet-field-tags
+        filter by topics: .facetapi-facet-field-topic
         footer: "#footer"
+        group block: .pane-views-group-block-block
+        group members: .view-id-dkan_og_extras_group_members
+        group subscribe: .group-subscribe-message
+        groups: .view-content
+        harvest datasets: .view-dkan-harvest-datasets
         header: "#header"
-        modal: "#modalContent"
         left header: "#header-left"
+        left_sidebar: .panel-col-first
+        modal: "#modalContent"
+        navigation: .navigation-wrapper
+        other access: .pane-dkan-sitewide-dkan-sitewide-other-access
+        primary tabs: .tabs--primary
+        resource groups: "#edit-groups"
+        resource title: .pane-node .pane-title
+        results: .view-header
         right header: "#header-right"
         right sidebar: "#column-right"
-        dashboards: ".view-data-dashboards table tbody"
-        navigation: '.navigation-wrapper'
-        breadcrumb: '.breadcrumb'
-        left_sidebar: '.panel-col-first'
-        dataset title: '.pane-node .pane-title'
-        dataset resource list: '#data-and-resources'
-        dataset body: '.field-name-body'
-        dataset edit body: '#edit-body'
-        dataset spatial: '#edit-field-spatial'
-        resource title: '.pane-node .pane-title'
-        resource groups: '#edit-groups'
-        search_area: '.panel-col-last'
-        dropdown_links: '.comment-main .links.inline.dropdown-menu'
-        comment: '.comment-main'
-        navigation: '.navigation-wrapper'
-        primary tabs: '.tabs--primary'
-        group subscribe: '.group-subscribe-message'
-        group block: '.pane-views-group-block-block'
-        group members: '.view-id-dkan_og_extras_group_members'
-        facet container: '.radix-layouts-sidebar'
-        filter by resource format: '.facetapi-facet-field-resourcesfield-format'
-        filter by author: '.facetapi-facet-author'
-        filter by topics: '.facetapi-facet-field-topic'
-        filter by tag: '.facetapi-facet-field-tags'
-        filter by date changed: '.facetapi-facet-changed'
-        social: '.pane-dkan-sitewide-dkan-sitewide-social'
-        other access: '.pane-dkan-sitewide-dkan-sitewide-other-access'
-        datasets: '.view-dkan-datasets'
-        user profile: '.pane-dkan-sitewide-panels-dkan-user-summary'
-        results: '.view-header'
-        user page: '.main'
-        user command center: '.pane-dkan-sitewide-profile-page-dkan-user-summary'
-        tabs: '.field-group-htabs-wrapper'
-        content: '.view-content'
-        groups: '.view-content'
-        search content results: '.content'
-        user content: '.view-user-profile-search'
-        content search: '.form-item-query'
-        user block: '.pane-views-user-profile-fields-block'
-        admin menu: '#admin-menu'
-        harvest datasets: '.view-dkan-harvest-datasets'
-      text:
-        log_out: "Log out"
-        log_in: "Log in"
-      selectors:
-        message_selector: '.alert'
-        error_message_selector: '.alert.alert-error'
-        success_message_selector: '.alert.alert-success'
-    Drupal\DKANExtension:
+        search content results: .content
+        search_area: .panel-col-last
+        social: .pane-dkan-sitewide-dkan-sitewide-social
+        tabs: .field-group-htabs-wrapper
+        toolbar: .tabs--primary
+        user block: .pane-views-user-profile-fields-block
+        user command center: .pane-dkan-sitewide-profile-page-dkan-user-summary
+        user content: .view-user-profile-search
+        user page: .main
+        user profile: .pane-dkan-sitewide-panels-dkan-user-summary
+      text: 
+        log_out: Log out
+        log_in: Log in
+      selectors: 
+        message_selector: .alert
+        error_message_selector: .alert.alert-error
+        success_message_selector: .alert.alert-success
+    Drupal\DKANExtension: 
       some_param: test

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -108,7 +108,7 @@ default:
           - Drupal\DKANExtension\Context\TimezoneContext
           - Drupal\DrupalExtension\Context\DrushContext
           - Devinci\DevinciExtension\Context\DebugContext:
-              asset_dump_path: %paths.base%/assets
+              asset_dump_path: '%paths.base%/assets'
           - Devinci\DevinciExtension\Context\JavascriptContext:
               maximum_wait: 30
   formatters:
@@ -125,12 +125,12 @@ default:
       default_session: 'goutte'
       javascript_session: 'selenium2'
       browser_name: chrome
-      files_path: %paths.base%/files
+      files_path: '%paths.base%/files'
     Drupal\DrupalExtension:
       blackbox: ~
       drupal:
         #TODO Abstract this out.
-        drupal_root: %paths.base%/../../docroot
+        drupal_root: '%paths.base%/../../docroot'
       api_driver: 'drupal'
       # @todo fixup these regions for use with new theme. Updated navigation only
       region_map:

--- a/test/behat.yml
+++ b/test/behat.yml
@@ -32,7 +32,6 @@ default:
                 license: field_license
                 doi: field_doi
                 citation: field_citation
-                corn: stop
             - labels:
                 title: Title
                 body: Description
@@ -80,29 +79,58 @@ default:
           - Drupal\DKANExtension\Context\ServicesContext:
             - request_fields_map:
                 resource:
-                  type: type
-                  title: title
-                  body: body[und][0][value]
-                  status: status
-                dataset':
-                  type: type
-                  title: title
-                  status: status
-                  published: status
-                  body: body[und][0][value]
-                  resource: field_resources[und][0][target_id]
-                  access level: field_public_access_level[und]
-                  contact name: field_contact_name[und][0][value]
-                  contact email: field_contact_email[und][0][value]
-                  attest name: field_hhs_attestation_name[und][0][value]
-                  attest date: field_hhs_attestation_date[und][0][value][date]
-                  verification status: field_hhs_attestation_negative[und]
-                  attest privacy: field_hhs_attestation_privacy[und]
-                  attest quality: field_hhs_attestation_quality[und]
-                  bureau code: field_odfe_bureau_code[und]
-                  license: field_license[und][select]
-                  doi: field_doi[und][0][value]
-                  citation: field_citation[und][0][value]
+                  fields:
+                    type: type
+                    title: title
+                    body: body[und][0][value]
+                    status: status
+                dataset:
+                  fields:
+                    title: title
+                    description: body
+                    published: status
+                    resource: field_resources
+                    access level: field_public_access_level
+                    contact name: field_contact_name
+                    contact email: field_contact_email
+                    attest name: field_hhs_attestation_name
+                    attest date: field_hhs_attestation_date
+                    verification status: field_hhs_attestation_negative
+                    attest privacy: field_hhs_attestation_privacy
+                    attest quality: field_hhs_attestation_quality
+                    bureau code: field_odfe_bureau_code
+                    license: field_license
+                    doi: field_doi
+                    citation: field_citation
+                  labels:
+                    title: Title
+                    body: Description
+                    field_tags: Tags
+                    field_topics: Topics
+                    field_license: License
+                    field_author: Author
+                    field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+                    field_frequency: Frequency
+                    field_granularity: Granularity
+                    field_data_dictionary_type: Data Dictionary Type
+                    field_data_dictionary: Data Dictionary
+                    field_contact_name: Contact Name
+                    field_contact_email: Contact Email
+                    field_public_access_level: Public Access Level
+                    field_additional_info: Additional Info
+                    field_resources: Resources
+                    field_related_content: Related Content
+                    field_landing_page: Homepage URL
+                    field_conforms_to: Data Standard
+                    field_language: Language
+                    og_group_ref: Groups
+                  sets:
+                    field_spatial: Spatial / Geographical Coverage Area
+                    field_temporal_coverage: Temporal Coverage
+                  defaults:
+                    field_public_access_level: public
+                    field_hhs_attestation_negative: 1
+                    field_license: odc-by
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\DatastoreContext
           - Drupal\DKANExtension\Context\TimezoneContext

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
@@ -16,29 +16,15 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    *
    */
-  public function __construct() {
+  public function __construct($fields, $labels = array(), $sets = array(), $defaults = array()) {
+    $this->datasetFieldLabels = $labels['labels'];
+    $this->datasetFieldSets = $sets['sets'];
+    $this->datasetFieldDefaults = $defaults['defaults'];
+
     parent::__construct(
       'node',
       'dataset',
-      // ToDo: load this from custom context.https://github.com/NuCivic/dkan_starter/issues/332.
-      array(
-        'title' => 'title',
-        'description' => 'body',
-        'published' => 'status',
-        'resource' => 'field_resources',
-        'access level' => 'field_public_access_level',
-        'contact name' => 'field_contact_name',
-        'contact email' => 'field_contact_email',
-        'attest name' => 'field_hhs_attestation_name',
-        'attest date' => 'field_hhs_attestation_date',
-        'verification status' => 'field_hhs_attestation_negative',
-        'attest privacy' => 'field_hhs_attestation_privacy',
-        'attest quality' => 'field_hhs_attestation_quality',
-        'bureau code' => 'field_odfe_bureau_code',
-        'license' => 'field_license',
-        'doi' => 'field_doi',
-        'citation' => 'field_citation',
-      ),
+      $fields['fields'],
       array(
         'moderation',
         'moderation_date',
@@ -278,35 +264,8 @@ class DatasetContext extends RawDKANEntityContext {
 
     // We could use field_info_instances() to get the list of fields for the 'dataset' content
     // type but that would not cover the case where a field is removed accidentally.
-    $dataset_fields = array(
-      'title' => 'Title',
-      'body' => 'Description',
-      'field_tags' => 'Tags',
-      'field_topics' => 'Topics',
-      'field_license' => 'License',
-      'field_author' => 'Author',
-      'field_spatial_geographical_cover' => 'Spatial / Geographical Coverage Location',
-      'field_frequency' => 'Frequency',
-      'field_granularity' => 'Granularity',
-      'field_data_dictionary_type' => 'Data Dictionary Type',
-      'field_data_dictionary' => 'Data Dictionary',
-      'field_contact_name' => 'Contact Name',
-      'field_contact_email' => 'Contact Email',
-      'field_public_access_level' => 'Public Access Level',
-      'field_additional_info' => 'Additional Info',
-      'field_resources' => 'Resources',
-      'field_related_content' => 'Related Content',
-      'field_landing_page' => 'Homepage URL',
-      'field_conforms_to' => 'Data Standard',
-      'field_language' => 'Language',
-      'og_group_ref' => 'Groups',
-    );
-
-    $dataset_fieldsets = array(
-      'field_spatial' => 'Spatial / Geographical Coverage Area',
-      'field_temporal_coverage' => 'Temporal Coverage',
-    );
-
+    $dataset_fields = $this->datasetFieldLabels;
+    $dataset_fieldsets = $this->datasetFieldSets;
     // Get all available form fields.
     // Searching by the Label as a text on the page is not enough since a text like 'Resources'
     // could appear because other reasons.

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
@@ -36,7 +36,7 @@ class PODContext extends RawDKANContext {
   {
     $data_json = open_data_schema_map_api_load('data_json_1_1');
     // Get base URL.
-    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1::8888";
+    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1:8888";
 
     // Validate POD.
     $results = open_data_schema_pod_process_validate($url . '/data.json', TRUE);

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -98,7 +98,7 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
       foreach ($proxy_files as $file) {
         $source = $conf['default']['stage_file_proxy_origin'] . '/' . $file;
         $destination = 'public://' . $file;
-        $copy($source, $destination);
+        copy($source, $destination);
       }
     }
     variable_set('stage_file_proxy_setup', TRUE);

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -458,16 +458,13 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
           continue;
         }
 
+        $defaults = $this->datasetFieldDefaults;
+
         if (isset($field['required']) && $field['required']) {
           $k = array_search($key, $this->field_map);
           if (!isset($data[$k])) {
             $data[$k] = $devel_generate_wrapper->$key->value();
-            // TODO: use param passed in from behat config for defaults.
-            $defaults = array(
-              'field_public_access_level' => 'public',
-              'field_hhs_attestation_negative' => 1,
-              'field_license' => 'odc-by',
-            );
+            $defaults = $this->datasetFieldDefaults;
             foreach ($defaults as $default => $value) {
               if ($key == $default) {
                 $data[$k] = $value;

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -380,13 +380,8 @@ class ServicesContext extends RawDKANContext {
     $rest_api_fields = $this->request_fields_map[$node_type]['fields'];
 
     if ($node_type == "dataset") {
-      print_r($this->request_fields_map[$node_type]);
-      $rawDkanEntityContext = new DatasetContext(
-        $this->request_fields_map[$node_type],
-        $this->request_fields_map[$node_type],
-        $this->request_fields_map[$node_type],
-        $this->request_fields_map[$node_type]
-      );
+      $environment = $scope->getEnvironment();
+      $rawDkanEntityContext = $environment->getContext('DatasetContext');
       $rawDkanEntityContext->applyMissingRequiredFields($data);
     }
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -377,10 +377,16 @@ class ServicesContext extends RawDKANContext {
     $node_type = ($node) ? $node->getBundle() : $data['type'];
 
     // Get the rest api field map for the content type.
-    $rest_api_fields = $this->request_fields_map[$node_type];
+    $rest_api_fields = $this->request_fields_map[$node_type]['fields'];
 
     if ($node_type == "dataset") {
-      $rawDkanEntityContext = new DatasetContext();
+      print_r($this->request_fields_map[$node_type]);
+      $rawDkanEntityContext = new DatasetContext(
+        $this->request_fields_map[$node_type],
+        $this->request_fields_map[$node_type],
+        $this->request_fields_map[$node_type],
+        $this->request_fields_map[$node_type]
+      );
       $rawDkanEntityContext->applyMissingRequiredFields($data);
     }
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -32,6 +32,7 @@ class ServicesContext extends RawDKANContext {
     parent::gatherContexts($scope);
     $environment = $scope->getEnvironment();
     $this->dkanContext = $environment->getContext('Drupal\DKANExtension\Context\DKANContext');
+    $this->datasetContext = $environment->getContext('Drupal\DKANExtension\Context\DatasetContext');
   }
 
   /**
@@ -377,12 +378,10 @@ class ServicesContext extends RawDKANContext {
     $node_type = ($node) ? $node->getBundle() : $data['type'];
 
     // Get the rest api field map for the content type.
-    $rest_api_fields = $this->request_fields_map[$node_type]['fields'];
+    $rest_api_fields = $this->request_fields_map[$node_type];
 
     if ($node_type == "dataset") {
-      $environment = $scope->getEnvironment();
-      $rawDkanEntityContext = $environment->getContext('DatasetContext');
-      $rawDkanEntityContext->applyMissingRequiredFields($data);
+      $this->datasetContext->applyMissingRequiredFields($data);
     }
 
     foreach ($data as $field => $field_value) {

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -19,34 +19,11 @@ class ServicesContext extends RawDKANContext {
   /**
    * TODO: Move to configuration passed in to constructor.
    */
-  private $request_fields_map = array(
-    'resource' => array(
-      'type' => 'type',
-      'title' => 'title',
-      'body' => 'body[und][0][value]',
-      'status' => 'status',
-    ),
-    'dataset' => array(
-      'type' => 'type',
-      'title' => 'title',
-      'status' => 'status',
-      'published' => 'status',
-      'body' => 'body[und][0][value]',
-      'resource' => 'field_resources[und][0][target_id]',
-      'access level' => 'field_public_access_level[und]',
-      'contact name' => 'field_contact_name[und][0][value]',
-      'contact email' => 'field_contact_email[und][0][value]',
-      'attest name' => 'field_hhs_attestation_name[und][0][value]',
-      'attest date' => 'field_hhs_attestation_date[und][0][value][date]',
-      'verification status' => 'field_hhs_attestation_negative[und]',
-      'attest privacy' => 'field_hhs_attestation_privacy[und]',
-      'attest quality' => 'field_hhs_attestation_quality[und]',
-      'bureau code' => 'field_odfe_bureau_code[und]',
-      'license' => 'field_license[und][select]',
-      'doi' => 'field_doi[und][0][value]',
-      'citation' => 'field_citation[und][0][value]',
-    ),
-  );
+  private $request_fields_map;
+
+  public function __construct($request_fields_map = array()) {
+    $this->request_fields_map = $request_fields_map['request_fields_map'];
+  }
 
   /**
    * @BeforeScenario


### PR DESCRIPTION
REF CIVIC-6614 nucivic/dkan_starter#332

By passing Context Attributes via configuration we have the option of overriding
them for custom settings and test environments.

See NuCivic/dkan_starter#392 for dkan_starter version of this and more details.