### PR TITLE
Make accessLevel: private translate to "non-public" 

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,7 +2,7 @@ api: '2'
 core: 7.x
 includes:
   - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
+  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/accesslevel-nonpublic/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
 projects:
@@ -249,7 +249,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/open_data_schema_map.git
-      branch: 7.x-1.x
+      branch: accesslevel-nonpublic
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION
CIVIC-6603
ref: NuCivic/open_data_schema_map#93

## Description

The value "Private" in dataset access level needs to be translated to "non-public" in data.json as per the Project Open Data 1.1 Schema. 

1.  Create a dataset and set "Public Access Level" to "private".
2. Check the /data.json
3. `accessLevel` will be set to `"private"`

## QA Steps

1.  Create a dataset and set "Public Access Level" to "private".
2. Check the /data.json
3. `accessLevel` should be set to `"non-public"`

## Merge process

- [x] NuCivic/open_data_schema_map#93
- Close/delete this PR

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
