### PR TITLE
Include language selectors on 'chosen_jquery_selector' config

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.13.6
 ----------
- - #2034 Added upgrade hook to include language selectors on 'chosen_jquery_selector' configuration.
+ - #2034 Added language selectors on 'chosen_jquery_selector' configuration.
  - #2018 Additional test/devops improvements needed for deployment. See #2012, #2014, #2015 and #2016 for specifics.
 
 7.x-1.13.5

--- a/dkan.install
+++ b/dkan.install
@@ -378,3 +378,12 @@ function dkan_update_7021() {
     ->condition('eid', $eid)
     ->execute();
 }
+
+/**
+ * Update chosen_jquery_selector to include language selectors.
+ */
+function dkan_update_7022() {
+  // REF #1936, #1890.
+  variable_set('chosen_jquery_selector',
+    '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"], [id*="lang-dropdown-select-language"])');
+}

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -15,7 +15,7 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_jquery_selector';
-  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"])';
+  $strongarm->value = '.page-node select:not([class*="delta-order"], [name*="workbench_moderation"], [class*="filter-list"], [id*="delimiter"],[name*="sort_by"],[name*="sort_order"], [id*="lines-terminated-by"], [id*="lang-dropdown-select-language"])';
   $export['chosen_jquery_selector'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Issue: None

## Description

This PR adds language selectors to the 'chosen_jquery_selector' configuration. This is needed in order for language selectors to display properly when used (ex: GOSA).

## QA Steps

- [ ] Tests should pass.

## Reminders
- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
