### PR TITLE
Add seckit module to make file

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -316,6 +316,8 @@ projects:
     version: '1.21'
   search_api_db:
     version: '1.6'
+  seckit:
+    version: '1.9'
   select_or_other:
     version: '2.22'
   services:


### PR DESCRIPTION
## Description 
Http Strict Transport Security (HSTS) policy enables web applications to enforce web browsers to restrict communication with the server over an encrypted SSL/TLS connection for a set period. Policy is declared via special Strict Transport Security response header. Encrypted connection protects sensitive user and session data from attackers eavesdropping on network connection. 
A successful MiTM attack can lead to the compromise of sensitive user data as well as grant unauthorized access to user accounts enabling attackers to perform privileged actions on client’s behalf.

## Solution
I've added the seckit module as @acouch proposed to the make file. However, since this module provides more than just the HTST standard I didn't added this to the info file so we can enable this just for the projects that really requires this.

## QA steps
- Enable the module seckit
- Go to /admin/config/system/seckit
- Check HTTP Strict Transport Security under the SSL/TLS section
- Open the chrome developer tools and click in the network tab
- Click on the page request and verify the Strict-Transport-Security header is present in the list of reponse headers


