### PR TITLE
Document terminus deployment

### DIFF
--- a/docs/introduction/get-dkan.md
+++ b/docs/introduction/get-dkan.md
@@ -44,6 +44,16 @@ Choose to make a new site from scratch, and to use the DKAN distribution:
 
 Pantheon will then build your new based site on the latest DKAN release. You will go through a normal Drupal install process, explained in detail in the [installation instructions](../installation.md).
 
+#### Using Terminus
+
+Pantheon provides a command-line tool called [Terminus](https://pantheon.io/docs/terminus/) for interacting with all aspects of site management on their platform. Once you have [installed Terminus](https://pantheon.io/docs/terminus/install/), you can spin up a new instance of DKAN with the command:
+
+```
+$ terminus site:create dkan-example-site "DKAN Example Site" d7370d7e-46fb-4b10-b79f-942b5abf51de
+```
+
+Replace "DKAN Example Site" with the name of your new DKAN site. The last argument, `d7370d7e-46fb-4b10-b79f-942b5abf51de`, is Pantheon's internal ID for the DKAN upstream. After the command completes, you will see your new site on your dashboard.
+
 #### Managing updates
 
 Pantheon uses a modified version of Drupal Pressflow, which is [publicly available on GitHub](https://github.com/pantheon-systems/drops-7). Whenever a new version of the DKAN distribution is released, the changes are merged into a version of DKAN special-built for Pantheon, [also available on GitHub](https://github.com/NuCivic/dkan-drops-7).

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -262,7 +262,7 @@ Feature: Resource
     And I wait for "items have been deleted"
     And I am on "Resource 03" page
     When I click "Manage Datastore"
-    Then I should see "No imported items."
+    Then I wait for "No imported items."
 
   @noworkflow @javascript
   Scenario: Drop datastore of own resource


### PR DESCRIPTION
Terminus is Pantheon's recommended way to deploy distros now. Section added to docs with example Terminus commands.