### PR TITLE
Fix dkanextension does not autopopulate as expected.

### DIFF
--- a/test/behat.yml
+++ b/test/behat.yml
@@ -90,6 +90,7 @@ default:
               status: status
               published: status
               body: body[und][0][value]
+              tags: field_tags[und][value_field]
               resource: field_resources[und][0][target_id]
               access level: field_public_access_level[und]
               contact name: field_contact_name[und][0][value]
@@ -103,6 +104,8 @@ default:
               license: field_license[und][select]
               doi: field_doi[und][0][value]
               citation: field_citation[und][0][value]
+              program code: field_odfe_program_code[und][]
+              publisher: og_group_ref[und][]
       - Drupal\DKANExtension\Context\PODContext
       - Drupal\DKANExtension\Context\DatastoreContext
       - Drupal\DKANExtension\Context\TimezoneContext

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -469,7 +469,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
         $defaults = $this->datasetFieldDefaults;
 
         $lang = dkan_dataset_form_field_language($form, $key);
-        $form_field = $form[$key][$lang];
+        $form_field = (isset($form[$key]) ? $form[$key][$lang] : array());
         $field_required = $this->fieldRequired($field, $form_field);
         if ($field_required) {
           $k = array_search($key, $this->field_map);

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -296,6 +296,10 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
         case "list<taxonomy_term>":
           // Convert the tags to tids.
           $tids = array();
+          if (is_array($value)) {
+            $wrapper->$property->set($value);
+            break;
+          }
           foreach ($this->explode_list($value) as $term) {
             if ($found_term = $this->tidFromTermName($property, $term)) {
               $tids[] = $found_term;
@@ -313,6 +317,10 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
         case 'node':
         case 'list<node>':
           $nids = array();
+          if (is_array($value)) {
+            $wrapper->$property->set($value);
+            break;
+          }
           foreach ($this->explode_list($value) as $name) {
             if (empty($name)) {
               continue;
@@ -452,7 +460,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       $node->type = $bundle;
       devel_generate_fields($node, 'node', $bundle);
       $devel_generate_wrapper = entity_metadata_wrapper('node', $node);
-
+      $form = node_add($bundle);
       foreach ($this->field_properties as $key => $field) {
         if ($key == 'type' || $key == 'author') {
           continue;
@@ -460,9 +468,16 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
         $defaults = $this->datasetFieldDefaults;
 
-        if (isset($field['required']) && $field['required']) {
+        $lang = dkan_dataset_form_field_language($form, $key);
+        $form_field = $form[$key][$lang];
+        $field_required = $field['required'] ||
+          $form_field['#required'] ||
+          $form_field[0]['#required'] ||
+          $form_field[0]['value']['#required'];
+
+        if ($field_required) {
           $k = array_search($key, $this->field_map);
-          if (!isset($data[$k])) {
+          if (!isset($data[$k]) || empty($data[$k])) {
             $data[$k] = $devel_generate_wrapper->$key->value();
             $defaults = $this->datasetFieldDefaults;
             foreach ($defaults as $default => $value) {

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -470,11 +470,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
 
         $lang = dkan_dataset_form_field_language($form, $key);
         $form_field = $form[$key][$lang];
-        $field_required = $field['required'] ||
-          $form_field['#required'] ||
-          $form_field[0]['#required'] ||
-          $form_field[0]['value']['#required'];
-
+        $field_required = $this->fieldRequired($field, $form_field);
         if ($field_required) {
           $k = array_search($key, $this->field_map);
           if (!isset($data[$k]) || empty($data[$k])) {
@@ -489,6 +485,16 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
         }
       }
     }
+  }
+
+  /**
+   * Check if field is required.
+   */
+  public function fieldRequired($field, $form_field = array()) {
+    return (isset($field['required']) && $field['required']) ||
+      (isset($form_field['#required']) && $form_field['#required']) ||
+      (isset($form_field[0]['#required']) && $form_field[0]['#required']) ||
+      (isset($form_field[0]['value']) && isset($form_field[0]['value']['#required']) && $form_field[0]['value']['#required']);
   }
 
   /**

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -469,7 +469,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
         $defaults = $this->datasetFieldDefaults;
 
         $lang = dkan_dataset_form_field_language($form, $key);
-        $form_field = (isset($form[$key]) ? $form[$key][$lang] : array());
+        $form_field = (isset($form[$key]) && isset($form[$key][$lang])) ? $form[$key][$lang] : array();
         $field_required = $this->fieldRequired($field, $form_field);
         if ($field_required) {
           $k = array_search($key, $this->field_map);

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -268,7 +268,6 @@ class ServicesContext extends RawDKANContext {
    * Create node.
    */
   private function services_request_create_node($node_data, $csrf_token, $cookie_session, $request_url) {
-
     $node_data = http_build_query($node_data);
 
     $curl = $this->services_request_curl_init($request_url, $csrf_token);
@@ -403,6 +402,24 @@ class ServicesContext extends RawDKANContext {
    */
   private function process_field($field, $field_value) {
     switch ($field) {
+      case 'publisher':
+        if (is_array($field_value)) {
+          $field_value = $field_value[0]->nid;
+        }
+        break;
+
+      case 'tags':
+        if (is_array($field_value)) {
+          $field_value = $field_value[0]->name;
+        }
+        break;
+
+      case 'program code':
+        if (is_array($field_value)) {
+          $field_value = $field_value[0];
+        }
+        break;
+
       case 'resource':
         $resource = $this->dkanContext->entityStore->retrieve_by_name($field_value);
         if ($resource) {


### PR DESCRIPTION
Fix bug where autopopulation fails either because:

(1) The field is made to be required via form_api_alter
(2) The field is set but is empty.
(3) The field label is not properly mapped in behat.yml

REF CIVIC-6552

QA Steps
===
- [ ] Continue to pass.