### PR TITLE
Modify test scenarios

### DIFF
--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -48,7 +48,7 @@ Feature: Dataset Features
       | title      | publisher | author  | published        | tags     | description |
       | Dataset 01 | Group 01  | Gabriel | Yes              | price1    |             |
       | Dataset 02 | Group 01  | Gabriel | Yes              | election1 |             |
-      | Dataset 03 |           | Katie   | Yes              | price1    |             |
+      | Dataset 03 | Group 02  | Katie   | Yes              | price1    |             |
       | Dataset 04 | Group 02  | Celeste | No               | election1 |             |
       | Dataset 05 | Group 01  | Katie   | No               | election1 |             |
       | Dataset 06 |           | Katie   | Yes              | election1 |             |
@@ -64,7 +64,7 @@ Feature: Dataset Features
       | Resource 05 |           | Katie  | Yes       | Dataset 08 |             |
       | Resource 06 | Group 02  | Katie  | Yes       | Dataset 09 |             |
 
-  @noworkflow
+  @dataset_author_1 @noworkflow
   Scenario: Create dataset as content creator
     Given I am logged in as "Katie"
     And I am on "Add Dataset" page
@@ -76,12 +76,13 @@ Feature: Dataset Features
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
 
-  @noworkflow
+  @dataset_author_2 @noworkflow
   Scenario: Save using Additional Info
-    Given I am logged in as a user with the "content creator" role
+    Given I am logged in as "Katie"
     And I am on "Add Dataset" page
     When I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "Test description"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     And I fill in "title" with "Test Resource Link File"
     And I press "Next: Additional Info"
@@ -89,7 +90,7 @@ Feature: Dataset Features
     Then I should see "Test Dataset"
     And I should see "Test description"
 
-  @noworkflow
+  @dataset_author_3 @noworkflow
   Scenario: Edit own dataset as a content creator
     Given I am logged in as "Katie"
     And I am on "Dataset 03" page
@@ -100,7 +101,7 @@ Feature: Dataset Features
     When I am on "My Content" page
     Then I should see "Dataset 03 edited"
 
-  @noworkflow
+  @dataset_author_4 @noworkflow
   Scenario: Seeing the License
     Given I am logged in as "Katie"
     And I am on "Dataset 03" page
@@ -112,12 +113,12 @@ Feature: Dataset Features
     And I click "Creative Commons Attribution"
     Then I should see "The Creative Commons Attribution license allows re-distribution and re-use of a licensed work"
 
-  @fixme @noworkflow
-    # TODO: Needs definition. How can a data contributor unpublish content?
+  @dataset_author_5 @fixme @noworkflow
+  # TODO: Needs definition. How can a data contributor unpublish content?
   Scenario: Unpublish own dataset as a content creator
     Given I am on the homepage
 
-  @noworkflow
+  @dataset_author_6 @noworkflow
   Scenario: Delete own dataset as content creator
     Given I am logged in as "Katie"
     And I am on "Dataset 03" page
@@ -126,7 +127,7 @@ Feature: Dataset Features
     And I press "Delete"
     Then I should see "Dataset 03 has been deleted"
 
-  @noworkflow
+  @dataset_author_7 @noworkflow
   Scenario: Add a dataset to group that I am a member of
     Given I am logged in as "Katie"
     And I am on "Dataset 03" page
@@ -137,12 +138,12 @@ Feature: Dataset Features
     When I am on "Group 01" page
     Then I should see "Dataset 03" in the "content" region
 
-  @noworkflow @javascript
+  @dataset_author_8 @noworkflow @javascript
   Scenario: Add a resource with no dataset to a dataset with no resource
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
     When I click "Edit"
-    And I fill in the resources field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -153,12 +154,12 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @noworkflow @javascript
+  @dataset_author_9 @noworkflow @javascript
   Scenario: Remove a resource with only one dataset from the dataset
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
     When I click "Edit"
-    And I fill in the resources field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 06 has been updated"
     And I should see "Resource 04" in the "dataset resource list" region
@@ -171,12 +172,12 @@ Feature: Dataset Features
     When I am on "Resource 04" page
     Then I should not see the link "Back to dataset"
 
-  @noworkflow @javascript
+  @dataset_author_10 @noworkflow @javascript
   Scenario: Add a resource with no group to a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
     When I click "Edit"
-    And I fill in the resources field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -184,12 +185,12 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @noworkflow @javascript
+  @dataset_author_11 @noworkflow @javascript
   Scenario: Remove a resource from a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
     When I click "Edit"
-    And I fill in the resources field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -200,7 +201,7 @@ Feature: Dataset Features
     Then I should see "Dataset 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @noworkflow
+  @dataset_author_12 @noworkflow
   Scenario: Add group to a dataset with resources
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page
@@ -210,7 +211,7 @@ Feature: Dataset Features
     Then I should see "Dataset 08 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @noworkflow
+  @dataset_author_13 @noworkflow
   Scenario: Remove group from dataset with resources
     Given I am logged in as "Katie"
     And I am on "Dataset 09" page
@@ -220,47 +221,47 @@ Feature: Dataset Features
     Then I should see "Dataset 09 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @noworkflow @javascript
+  @dataset_author_14 @noworkflow @javascript
   Scenario: Add group and resource to a dataset on the same edition
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page
     When I click "Edit"
     And I fill in the chosen field "edit_og_group_ref_und_chosen" with "Group 02"
-    And I fill in the resources field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 08 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
     And I should see "Resource 04" in the "dataset resource list" region
 
-  @noworkflow
+  @dataset_author_15 @noworkflow
   Scenario: Site Managers should see groups they are not member of
     Given I am logged in as "John"
     When I visit "node/add/dataset"
     Then I should see the "Group 01" groups option
     And I should see the "Group 02" groups option
 
-  @noworkflow
+  @dataset_author_16 @noworkflow
   Scenario: Content Creators should only see the groups they are member of
     Given I am logged in as "Katie"
     When I visit "node/add/dataset"
     Then I should see the "Group 02" groups option
     And I should not see the "Group 04" groups option
 
-  @noworkflow
+  @dataset_author_17 @noworkflow
   Scenario: Editors should only see the groups they are member of
     Given I am logged in as "Daniel"
     When I visit "node/add/dataset"
     Then I should see the "Group 02" groups option
     And I should not see the "Group 04" groups option
 
-  @noworkflow
+  @dataset_author_18 @noworkflow
   Scenario: Site Managers should see authoring information and publishing options
     Given I am logged in as "John"
     When I visit "node/add/dataset"
     Then I should see "Authoring information"
     And I should see "Publishing options"
 
-  @noworkflow
+  @dataset_author_19 @noworkflow
   Scenario: Content Creators not part of a group should see publishing options
     Given I am logged in as "Keith"
     When I visit "node/add/dataset"
@@ -270,7 +271,7 @@ Feature: Dataset Features
     Then I should not see "Authoring information"
     Then I should see "Publishing options"
 
-  @noworkflow
+  @dataset_author_20 @noworkflow
   Scenario: Content Creators who are part of a group should not see authoring information
     Given I am logged in as "Katie"
     When I visit "node/add/dataset"

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -51,9 +51,9 @@ Feature: Dataset Features
       | Dataset 03 | Group 02  | Katie   | Yes              | price1    |             |
       | Dataset 04 | Group 02  | Celeste | No               | election1 |             |
       | Dataset 05 | Group 01  | Katie   | No               | election1 |             |
-      | Dataset 06 |           | Katie   | Yes              | election1 |             |
+      | Dataset 06 | Group 01  | Katie   | Yes              | election1 |             |
       | Dataset 07 | Group 01  | Katie   | Yes              | election1 |             |
-      | Dataset 08 |           | Katie   | Yes              | election1 |             |
+      | Dataset 08 | Group 01  | Katie   | Yes              | election1 |             |
       | Dataset 09 | Group 02  | Katie   | Yes              | election1 |             |
     And resources:
       | title       | publisher | author | published | dataset    | description |

--- a/test/features/leaflet_draw_widget.feature
+++ b/test/features/leaflet_draw_widget.feature
@@ -5,12 +5,21 @@ Feature: Leaflet Map Widget
   Scenario: Adds "New Table Widget" block to home page using panels ipe editor
 
     Given "Tags" terms:
-      | name     |
+      | name    |
       | New Tag |
+    Given users:
+      | name    | mail                | roles  |
+      | Gabriel | gabriel@example.com | editor |
+    Given groups:
+      | title    | author | published |
+      | Group 01 | Admin  | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | Gabriel | Group 01 | administrator member | Active            |
     And datasets:
-      | title                  | author | published | tags    | description |
-      | This is a test dataset | admin  | Yes       | New Tag | Test        |
-    And I am logged in as a user with the "editor" role
+      | title                  | author | published | tags    | description | publisher |
+      | This is a test dataset | admin  | Yes       | New Tag | Test        | Group 01  |
+    And I am logged in as "Gabriel"
     And I visit the "This is a test dataset" page
     And I click "Edit"
     Then I should see "Spatial / Geographical Coverage Area"

--- a/test/features/markdown_editor.feature
+++ b/test/features/markdown_editor.feature
@@ -1,5 +1,5 @@
 # time:1m32.15s
-@javascript @api @disablecaptcha
+@api @disablecaptcha
 Feature: Markdown Editor
   In order to create content
   As a user with edition permissions
@@ -14,7 +14,15 @@ Feature: Markdown Editor
     | John    | john@example.com    | site manager         |
     | Jaz     | jaz@example.com     | editor               |
     | Gabriel | gabriel@example.com | content creator      |
+    Given groups:
+    | title    | author | published |
+    | Group 01 | Admin  | Yes       |
+    And group memberships:
+    | user    | group    | role on group     | membership status |
+    | Gabriel | Group 01 | member            | Active            |
+    | Jaz     | Group 01 | member            | Active            |
 
+  @javascript
   Scenario: Seeing 'Markdown' text format and toolbar as a Content Creator
     Given I am logged in as "Gabriel"
     When I am on "Add Dataset" page
@@ -43,6 +51,7 @@ Feature: Markdown Editor
     And I should not see the button "Format selected text as code" in the "dataset edit body"
     And I should not see the button "Format selected text as a code block" in the "dataset edit body"
 
+  @javascript
   Scenario: Seeing 'Markdown' text format and toolbar as an Editor
     Given I am logged in as "Jaz"
     When I am on "Add Dataset" page
@@ -54,6 +63,7 @@ Feature: Markdown Editor
     # Buttons that the user should not see on the toolbar
     And I should not see the button "Insert a table" in the "dataset edit body"
 
+  @javascript
   Scenario: Seeing 'Markdown' text format and toolbar as a Site Manager
     Given I am logged in as "John"
     When I am on "Add Dataset" page
@@ -70,6 +80,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "<h2>First subtitle</h2><h3>Second subtitle</h3>"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -81,6 +92,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "*Some text*"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -91,6 +103,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "**Some text**"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -101,6 +114,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "`Some code`"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -111,6 +125,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "> Some quote"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -121,6 +136,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "1. Some item"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -131,6 +147,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "* Some item"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -141,6 +158,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "[Link](http://www.google.com)"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -151,6 +169,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "![alt text]('/the/url' 'Image Title')"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -161,6 +180,7 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "This<br>that"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
@@ -171,11 +191,13 @@ Feature: Markdown Editor
     When I am on "Add Dataset" page
     And I fill in "title" with "Test Dataset"
     And I fill in "body[und][0][value]" with "<iframe src=\"http://www.w3schools.com\"></iframe>"
+    And I select "Group 01" from "og_group_ref[und][]"
     And I press "Next: Add data"
     Then I should see "Test Dataset has been created"
     When I am on "dataset/test-dataset"
     Then I should see the "iframe" element in the "dataset body" region
 
+  @javascript
   Scenario: Don't see markdown toolbar when using 'Plain text' text format
     Given I am logged in as "Jaz"
     When I am on "Add Dataset" page

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -103,7 +103,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"
@@ -123,7 +123,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -88,7 +88,7 @@ Feature: Resource
     And I am on "Resource 02" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     When I click "Manage Datastore"
     And I press "Import"
@@ -103,7 +103,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"
@@ -123,7 +123,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -103,7 +103,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"
@@ -114,7 +114,7 @@ Feature: Resource
     And I wait for "items have been deleted"
     And I am on "Resource 04" page
     When I click "Manage Datastore"
-    Then I should see "No imported items."
+    Then I wait for "No imported items."
 
   @noworkflow @javascript
   Scenario: Drop datastore of any resource
@@ -123,7 +123,7 @@ Feature: Resource
     And I am on "Resource 04" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 04" page
     When I click "Manage Datastore"
@@ -134,7 +134,7 @@ Feature: Resource
     Then I should see "Datastore dropped!"
     And I should see "Your file for this resource is not added to the datastore"
     When I click "Manage Datastore"
-    Then I should see "No imported items."
+    Then I wait for "No imported items."
 
   @noworkflow
   Scenario: Add revision to any resource

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -235,7 +235,7 @@ Feature: Resource
     And I am on "Resource 05" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 05" page
     When I click "Manage Datastore"
@@ -250,7 +250,7 @@ Feature: Resource
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -235,7 +235,7 @@ Feature: Resource
     And I am on "Resource 05" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
     And I press "Save"
     And I am on "Resource 05" page
     When I click "Manage Datastore"
@@ -250,7 +250,7 @@ Feature: Resource
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "hhttps://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -250,7 +250,7 @@ Feature: Resource
     And I am on "Resource 03" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "hhttps://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 03" page

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -98,7 +98,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 01" page
@@ -115,7 +115,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     When I am on "Resource 01" page
@@ -135,7 +135,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_short_version.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 01" page

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -98,7 +98,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 01" page
@@ -115,7 +115,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     When I am on "Resource 01" page
@@ -135,7 +135,7 @@ Feature: Resource
     And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
-    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv"
+    And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_small.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
     And I am on "Resource 01" page

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -26,6 +26,7 @@ Feature: Search
     Given groups:
       | title    | author  | published |
       | Group 01 | Badmin  | Yes       |
+      | Group 02 | Gabriel | Yes       |
     And group memberships:
       | user    | group    | role on group        | membership status |
       | Gabriel | Group 01 | administrator member | Active            |
@@ -39,7 +40,7 @@ Feature: Search
       | dazzling     |
     And datasets:
       | title              | publisher | author  | published | tags         | topics      | description |
-      | ooftaya Dataset 01 |           | Gabriel | Yes       | something01  | edumication | Test 01     |
+      | ooftaya Dataset 01 | Group 02  | Gabriel | Yes       | something01  | edumication | Test 01     |
       | ooftaya Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
 
   Scenario: Searching datasets

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -433,14 +433,11 @@ Feature:
   @workflow_19 @ok
   # https://jira.govdelivery.com/browse/CIVIC-5348
   Scenario: "View draft" should display the draft dataset and not the published revision.
-    Given users:
-      | name                 | roles                                 |
-      | workflow_contributor | Workflow Contributor, content creator |
     And datasets:
-      | title         | author               | published | moderation |
-      | Dataset title | workflow_contributor | Yes       | published  |
+      | title         | author      | published | moderation | publisher |
+      | Dataset title | Contributor | Yes       | published  | Group 01  |
     Given I update the moderation state of "Dataset title" to "Published"
-    Given I am logged in as "workflow_contributor"
+    Given I am logged in as "Contributor"
     And I am on "Dataset title" page
     Then I should see the text "Dataset title"
     When I click "Edit draft"


### PR DESCRIPTION
- Use smaller file for testing datastore
- Update workflow_19 to work when group is required

## Description
Testing the datastore functionality often fails on timing, taking too long to import or delete, so switching to a smaller file.

Reworking workflow_19 to work when datasets require a group
