### PR TITLE
Update scenarios to not use @javascript where possible.

### DIFF
--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -220,7 +220,7 @@ Feature: Dataset Features
     Then I should see "Dataset 09 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @dataset_author_14 @noworkflow
+  @dataset_author_14 @noworkflow @javascript
   Scenario: Add group and resource to a dataset on the same edition
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -137,12 +137,12 @@ Feature: Dataset Features
     When I am on "Group 01" page
     Then I should see "Dataset 03" in the "content" region
 
-  @dataset_author_8 @noworkflow @javascript
+  @dataset_author_8 @noworkflow
   Scenario: Add a resource with no dataset to a dataset with no resource
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -153,12 +153,12 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @dataset_author_9 @noworkflow @javascript
+  @dataset_author_9 @noworkflow
   Scenario: Remove a resource with only one dataset from the dataset
     Given I am logged in as "Katie"
     And I am on "Dataset 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 06 has been updated"
     And I should see "Resource 04" in the "dataset resource list" region
@@ -171,12 +171,12 @@ Feature: Dataset Features
     When I am on "Resource 04" page
     Then I should not see the link "Back to dataset"
 
-  @dataset_author_10 @noworkflow @javascript
+  @dataset_author_10 @noworkflow
   Scenario: Add a resource with no group to a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -184,12 +184,12 @@ Feature: Dataset Features
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
-  @dataset_author_11 @noworkflow @javascript
+  @dataset_author_11 @noworkflow
   Scenario: Remove a resource from a dataset with group
     Given I am logged in as "Katie"
     And I am on "Dataset 07" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 07 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -220,13 +220,13 @@ Feature: Dataset Features
     Then I should see "Dataset 09 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @dataset_author_14 @noworkflow @javascript
+  @dataset_author_14 @noworkflow
   Scenario: Add group and resource to a dataset on the same edition
     Given I am logged in as "Katie"
     And I am on "Dataset 08" page
     When I click "Edit"
     And I fill in the chosen field "edit_og_group_ref_und_chosen" with "Group 02"
-    And I fill in the autocomplete field "edit-field-resources-und-0-target-id" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
     And I press "Finish"
     Then I should see "Dataset 08 has been updated"
     And I should see "Groups were updated on 1 resource(s)"

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -119,24 +119,24 @@ Feature: Resource
     And I press "Delete"
     Then I should see "Resource 02 has been deleted"
 
-  @dkanBug @noworkflow @javascript
+  @dkanBug @noworkflow
   Scenario: Change dataset on resource
     Given I am logged in as "Katie"
     And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 02"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 02"
     And I press "Save"
     Then I should see "Resource 01 has been updated"
     When I click "Back to dataset"
     Then I should see "Dataset 02" in the "dataset title" region
     And I should see "Resource 01" in the "dataset resource list" region
 
-  @noworkflow @javascript
+  @noworkflow
   Scenario: Add a resource with no datasets to a dataset with no resource
     Given I am logged in as "Katie"
     And I am on "Resource 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 03"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 03"
     And I press "Save"
     Then I should see "Resource 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -155,12 +155,12 @@ Feature: Resource
     And I should see "Groups were updated on 1 resource(s)"
     And I should not see the link "Back to dataset"
 
-  @noworkflow @javascript
+  @noworkflow
   Scenario: Add a resource with no group to a dataset with group
     Given I am logged in as "Katie"
     And I am on "Resource 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
     And I press "Save"
     Then I should see "Resource 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
@@ -177,26 +177,26 @@ Feature: Resource
     When I am on "Dataset 05" page
     Then I should not see "Resource 08" in the "dataset resource list" region
 
-  @noworkflow @javascript
+  @noworkflow
   Scenario: Add a resource to multiple datasets with groups
     Given I am logged in as "Katie"
     And I am on "Resource 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
     And I press "Add another item"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-1-target-id" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
     And I press "Save"
     Then I should see "Resource 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @noworkflow @javascript
+  @noworkflow
   Scenario: Remove one dataset with group from resource with multiple datasets
     Given I am logged in as "Katie"
     And I am on "Resource 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
     And I press "Add another item"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-1-target-id" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
     And I press "Save"
     Then I should see "Resource 06 has been updated"
     When I click "Edit"
@@ -205,14 +205,14 @@ Feature: Resource
     Then I should see "Resource 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
-  @noworkflow @javascript
+  @noworkflow
   Scenario: Remove all datasets with groups from resource
     Given I am logged in as "Katie"
     And I am on "Resource 06" page
     When I click "Edit"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-0-target-id" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
     And I press "Add another item"
-    And I fill in the autocomplete field "edit-field-dataset-ref-und-1-target-id" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
     And I press "Save"
     Then I should see "Resource 06 has been updated"
     And I should see "Groups were updated on 1 resource(s)"


### PR DESCRIPTION
REF CIVIC-6649

We added the @javascript tag to some scenarios unnecessarily. This makes tests
slower. This PR undoes that change.