### PR TITLE
Update harvest source messages CIVIC-6644

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.14.x
 ----------
- - #2054 Improve messages displayed when creating a harvest source.
+ - #2055 Improve messages displayed when creating a harvest source.
  - #1970 Adds topics to harvested datasets on migration.
  - #1975 Add landingPage to data.json feed.
  - #1967 Added search title to /search panels.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #2054 Improve messages displayed when creating a harvest source.
  - #1970 Adds topics to harvested datasets on migration.
  - #1975 Add landingPage to data.json feed.
  - #1967 Added search title to /search panels.

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -106,9 +106,8 @@ function dkan_harvest_datajson_set_value(array &$obj, $path, $value, $override =
       $branch = &$branch[$key];
     }
     else {
-      drupal_set_message(t('Key "@path" was automatically generated because doesn\'t exists in the dataset "@title". Make sure you want to modify the key "@path".',
-        array('@path' => $path, '@title' => $obj['title'])),
-      'warning');
+      drupal_set_message(t('A @path of "@value" was added to the <b>@title</b> dataset.',
+        array('@path' => $path, '@value' => $value, '@title' => $obj['title'])), 'warning');
       $branch[$key] = array();
       $branch = &$branch[$key];
     }
@@ -143,9 +142,7 @@ function dkan_harvest_datajson_get_value(array $obj, $path) {
       $value = $value[$key];
     }
     else {
-      drupal_set_message(t('Error trying to access to key "@path". Please make sure "@path" exists in the dataset "@title"',
-        array('@path' => $path, '@title' => $obj['title'])),
-      'error');
+      drupal_set_message(t('Notice not all datasets have a value for @path.', array('@path' => $path, 'title' => $obj['title'])), 'warning', FALSE);
       return;
     }
   }


### PR DESCRIPTION
Issue: CIVIC-6644

## Description
When using the filter or exclude function when creating a harvest source, an error message will display for any dataset that does not have a value for the key being filtered/excluded. For example if you filter by 'theme' any dataset that does not have a value for 'theme' will display this error:
 **Error trying to access to key @theme. Please make sure @theme exists in the dataset**
and if there are 50 datasets without a value for theme, it will display 50 error messages.

## Improvements
**Filter & Exclude**
Message when a dataset does not have a value for the filtered/excluded item:
Current
`Error trying to access to key @path. Please make sure @path exists in the dataset`
New
`Notice a value for @path does not exists in all datasets`
and only a single warning message is displayed, not an error for each instance.

**Default & Override**
Message when a default or override is added:
Current
`Key "@path" was automatically generated because doesn\'t exists in the dataset "@title". Make sure you want to modify the key "@path".`
New
`A @path of "@value" was added to the <b>@title</b> dataset.`

## QA Tests
1. Create a harvest source from a source you know does not have values for theme on all datasets.
2. Filter by theme
3. Add a default keyword
4. Confirm you only see one warning message about theme.
5. Confirm you see a warning message for each dataset a default keyword was added to.


## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
