### PR TITLE
Creation migration after creating harvest source (#1542)

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -897,8 +897,8 @@ function dkan_harvest_node_view($node, $view_mode, $langcode) {
  * Implements hook_node_insert().
  */
 function dkan_harvest_node_insert($node) {
-  if($node->type == 'harvest_source'){
-    // Create the migration
+  if ($node->type == 'harvest_source') {
+    // Create the migration.
     $harvest_source = HarvestSource::getHarvestSourceFromNode($node);
     dkan_harvest_get_migration($harvest_source);
   }

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -894,6 +894,17 @@ function dkan_harvest_node_view($node, $view_mode, $langcode) {
 }
 
 /**
+ * Implements hook_node_insert().
+ */
+function dkan_harvest_node_insert($node) {
+  if($node->type == 'harvest_source'){
+    // Create the migration
+    $harvest_source = HarvestSource::getHarvestSourceFromNode($node);
+    dkan_harvest_get_migration($harvest_source);
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function dkan_harvest_form_alter(&$form, &$form_state, $form_id) {


### PR DESCRIPTION
REF CIVIC-5133
Re-roll of #1542 fixing lint issues.
                                                                    
* Added hook_node_insert for harvest sources in order to create the
migration on the fly
                                                                    
* updated hook