### PR TITLE
Fixes regression of NuCivic/recline.view.nvd3.js#36

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.x/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/civic-6637-fix-height-regression/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -352,7 +352,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      branch: 7.x-1.x
+      branch: civic-6637-fix-height-regression
     type: module
   workbench:
     version: '1.2'


### PR DESCRIPTION
REF CIVIC-6637
REF NuCivic/recline.view.nvd3.js#36
REF CIVIC-6001

This fix was lost by mistake (typo).  I'm adding it back.  It allows users to configure chart heights.'

## Todo:
- [ ] Merge: https://github.com/NuCivic/recline.view.nvd3.js/pull/45