### PR TITLE
Fix iframe allowed in dataset results summary.

### DIFF
--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -1233,11 +1233,19 @@ function dkan_dataset_entity_info_alter(&$entity_info) {
  */
 function dkan_dataset_preprocess_node(&$vars) {
   if ($vars['view_mode'] == 'search_result') {
-    if (!empty($vars['body'][0]['summary'])) {
-      $body_summary = $vars['body'][0]['summary'];
+    if (isset($vars['body'][0])) {
+      if (!empty($vars['body'][0]['summary'])) {
+        $body_summary = $vars['body'][0]['summary'];
+      }
+      elseif (isset($vars['body'][0]['value'])) {
+        $body_summary = $vars['body'][0]['value'];
+      }
+      else {
+        $body_summary = '';
+      }
     }
     else {
-      $body_summary = $vars['body'][0]['value'];
+      $body_summary = '';
     }
 
     $vars['theme_hook_suggestions'][] = 'node__search_result';

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -1233,8 +1233,29 @@ function dkan_dataset_entity_info_alter(&$entity_info) {
  */
 function dkan_dataset_preprocess_node(&$vars) {
   if ($vars['view_mode'] == 'search_result') {
+    if (!empty($vars['body'][0]['summary'])) {
+      $body_summary = $vars['body'][0]['summary'];
+    }
+    else {
+      $body_summary = $vars['body'][0]['value'];
+    }
+
     $vars['theme_hook_suggestions'][] = 'node__search_result';
+    $vars['body_summary'] = _dkan_dataset_format($body_summary);
   }
+}
+
+/**
+ * Reformat dataset search result descriptions.
+ */
+function _dkan_dataset_format($text) {
+  $text = drupal_html_to_text($text);
+  $summary_options = variable_get('dkan_dataset_summary_options', array(
+    "max_length" => 250,
+    "word_boundary" => TRUE,
+    "ellipsis" => TRUE,
+  ));
+  return views_trim_text($summary_options, $text);
 }
 
 /**

--- a/themes/nuboot_radix/templates/node/node--search-result.tpl.php
+++ b/themes/nuboot_radix/templates/node/node--search-result.tpl.php
@@ -19,7 +19,7 @@
     <?php print render($content['field_topic']); ?>
     <ul class="dataset-list"><?php print $dataset_list ?></ul>
     <?php if(!empty($body)): ?>
-      <div class="node-description"><?php print text_summary($body, 'plain_text', 250) ?></div>
+      <div class="node-description"> <p><?php print $body_summary; ?> </p></div>
     <?php endif; ?>
     <?php print render($content['resources']); ?>
     <?php


### PR DESCRIPTION
REF CIVIC-6504

* If an iframe is the first thing in a description, the iframe will be displayed
on search results page.
* If summary is longer than 250 words summary can get cut off mid word.
* Ellipses at end of summary or not possible.

QA Steps
==
- [x] Add iframe to dataset verify that it does not show up in result summary.
- [x] Add a long body text to a dataset, verify that search results does not get cut off in middle of word by default.
- [x] Verify that by default ellipses are added to end of long auto summaries.