### PR TITLE
Datastore api field exclude alter hook

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.api.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.api.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by DKAN Datastore API module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Allows fields exclusions to be altered for API queries.
+ *
+ * @param array $excludes
+ *   List of fields to exclude.
+ */
+function hook_dkan_datastore_api_field_excluded_alter(&$excludes) {
+  $excludes[] = 'exclude_this_field';
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.api.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.api.php
@@ -16,7 +16,7 @@
  * @param array $excludes
  *   List of fields to exclude.
  */
-function hook_dkan_datastore_api_field_excluded_alter(&$excludes) {
+function hook_dkan_datastore_api_field_excluded_alter(array &$excludes) {
   $excludes[] = 'exclude_this_field';
 }
 

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -98,6 +98,10 @@ function build_qualified_fields($fields, $alias) {
  */
 function dkan_datastore_api_field_excluded($field) {
   $excludes = array('timestamp', 'feeds_entity_id', 'feeds_flatstore_entry_id');
+  foreach (module_implements('dkan_datastore_api_field_excluded_alter') as $module) {
+    $function = $module . '_dkan_datastore_api_field_excluded_alter';
+    $function($excludes);
+  }
   return in_array($field, $excludes);
 }
 


### PR DESCRIPTION
## Description
Adds a hook_datastore_api_field_exclude_alter so that field exclusions can be modified for API queries.

## User story
As an admin, I would like to be able to not exclude some of the internal fields used in the datastore API query so they can be used as a primary key for the data.

## QA Steps
