### PR TITLE
Update open_data_schema_map_dkan to use language field token rather t…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.x
 ----------
+ - #2109 Fix ODSM language token to solve validation errors.
  - #2019 DKAN Workflow: Fix 'My Drafts' view to restore content to original user after rejection.
  - #1970 Adds topics to harvested datasets on migration.
  - #1975 Add landingPage to data.json feed.

--- a/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
+++ b/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
@@ -1350,7 +1350,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'language' => array(
-        'value' => 'en',
+        'value' => '[node:field_language]',
         'type' => 'array',
       ),
       'license' => array(


### PR DESCRIPTION
Issue: hhs-997

## Description

POD validation errors for the language field. It looks like {{false}} is being added as a value to the data.json when there is no defined language. Language is optional for POD.

## How to reproduce

1. create a harvest source from `http://datafiles.samhsa.gov/data.json`
2. view `admin/config/services/odsm/validate/pod`
3. confirm you see errors on lanugage

## QA Steps
1. create a harvest source from `http://datafiles.samhsa.gov/data.json`
2. view `admin/config/services/odsm/validate/pod`
3. confirm there are no errors

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
