### PR TITLE
Add update hook for admin_views variable set

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -406,3 +406,10 @@ function dkan_update_7023() {
       ->execute();
   }
 }
+
+/**
+ * Update default variables.
+ */
+function dkan_update_7024(&$context) {
+  dkan_misc_variables_set($context);
+}


### PR DESCRIPTION
REF NuCivic/dkan#1807

Some required variables are being set in installation that are not being set
when upgrading from a previous setting.  This is causing some access issues and
multiple test failures.

AC
==
- [x] This change is required for devy to green, verify here: https://github.com/NuCivic/devy/pull/22