### PR TITLE
Fix hero image variable setup

### DIFF
--- a/themes/nuboot_radix/includes/panel.inc
+++ b/themes/nuboot_radix/includes/panel.inc
@@ -42,7 +42,7 @@ function nuboot_radix_preprocess(&$variables, $hook) {
   $front_url = drupal_get_normal_path(variable_get('site_frontpage', 'node'));
   $front_nid = NULL;
   $front = explode('/', $front_url);
-  if( $front[0]=='node' && ctype_digit($front[1]) ) {
+  if ($front[0] == 'node' && ctype_digit($front[1])) {
     $front_nid = $front[1];
   }
 
@@ -51,18 +51,18 @@ function nuboot_radix_preprocess(&$variables, $hook) {
     if ($uri = nuboot_radix_hero_file_uri()) :
       $variables['tint'] = 'tint';
       $variables['bg_color'] = 'transparent';
-      $variables['path'] = file_create_url($uri);
+      $variables['path'] = 'url(' . file_create_url($uri) . ')';
     else :
       $background_option = theme_get_setting('background_option');
       if (empty($background_option)) :
         $variables['tint'] = 'no-tint';
         $variables['bg_color'] = '#005e9a';
-        $variables['path'] = '';
+        $variables['path'] = 'none';
       else :
         $uri = '';
         $variables['tint'] = 'no-tint';
         $variables['bg_color'] = '#' . ltrim($background_option, '#');
-        $variables['path'] = '';
+        $variables['path'] = 'none';
       endif;
     endif;
   }

--- a/themes/nuboot_radix/panels/layouts/dkan_front/panels-dkan-front.tpl.php
+++ b/themes/nuboot_radix/panels/layouts/dkan_front/panels-dkan-front.tpl.php
@@ -5,10 +5,13 @@
  * Template for dkan front page.
  */
 ?>
-<div class="panel-display panel-dkan-front clearfix" <?php if (!empty($css_id)) { print "id=\"$css_id\""; } ?>>
+<div class="panel-display panel-dkan-front clearfix"
+  <?php if (!empty($css_id)) {
+    print "id=\"$css_id\"";
+  } ?>>
 
   <?php if($content['hero-first'] || $content['hero-second']): ?>
-    <div class="panel-hero panel-row" <?php print 'style="background-image:url(' . $path . ');background-color:' . $bg_color . '"'; ?>>
+    <div class="panel-hero panel-row" <?php print 'style="background-image:' . $path . ';background-color:' . $bg_color . '"'; ?>>
       <div class="<?php print $tint; ?>"></div>
       <div class="container">
         <div class="panel-col-first">


### PR DESCRIPTION
## Description

When no hero image is defined for the front page we have issues when we add an X-frame-Options-Header.

@kducharm discovered inline style markup on home page that was causing additional loading of the homepage, making a 403 cached version which apparently doesn't respect the X-Frame-Options in Chrome - which is what the security scanner is using. Solution is to remove the broken markup:
```
<div class="panel-top panel-row" style="background-image:url();background-color:#003366">
```
## QA Steps

- [x] Confirm the markup for the front page panel-top panel-row uses `background-image:none;` and not `background-image:url()`
![healthdata_gov](https://user-images.githubusercontent.com/314172/30933820-488a332c-a391-11e7-93b6-42ac709048c1.png)


## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [x] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
