### PR TITLE
Adjust harvest functions to pick up multiple override or default values

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -106,11 +106,11 @@ function dkan_harvest_datajson_set_value(array &$obj, $path, $value, $override =
       $branch = &$branch[$key];
     }
     else {
-      drupal_set_message(t('The @path field was set to "@value" on all harvested datasets.',
-        array('@path' => $path, '@value' => $value, '@title' => $obj['title'])), 'warning', FALSE);
       $branch[$key] = array();
       $branch = &$branch[$key];
     }
+    drupal_set_message(t('The @path field was set to "@value" on all harvested datasets.',
+      array('@path' => $path, '@value' => $value, '@title' => $obj['title'])), 'warning', FALSE);
   }
 
   // Update the obj if $override is set or the branch is empty.
@@ -147,11 +147,11 @@ function dkan_harvest_datajson_set_default_value(array &$obj, $path, $value, $ov
       $branch = &$branch[$key];
     }
     else {
-      drupal_set_message(t('A @path value of "@value" was added to datasets where the @path field was empty.',
-        array('@path' => $path, '@value' => $value, '@title' => $obj['title'])), 'warning', FALSE);
       $branch[$key] = array();
       $branch = &$branch[$key];
     }
+    drupal_set_message(t('A @path value of "@value" was added to datasets where the @path field was empty.',
+      array('@path' => $path, '@value' => $value, '@title' => $obj['title'])), 'warning', FALSE);
   }
 
   // Update the obj if $override is set or the branch is empty.
@@ -319,11 +319,12 @@ function dkan_harvest_datajson_cache_pod_v1_1_json(array $data, HarvestSource $s
 
     foreach ($overrides as $path => $override_values) {
       $override_values = array_map('trim', $override_values);
-      $overridden = $overridden || dkan_harvest_datajson_set_value($dataset, $path, $override_values[0], TRUE);
-    }
-
-    if ($overridden) {
-      $harvest_cache->setCacheEntryOverridden($identifier, $dataset['title']);
+      if (!empty($path) && !empty($override_values)) {
+        $overridden = dkan_harvest_datajson_set_value($dataset, $path, $override_values[0], TRUE);
+      }
+      if ($overridden) {
+        $harvest_cache->setCacheEntryOverridden($identifier, $dataset['title']);
+      }
     }
 
     return $dataset;
@@ -339,10 +340,9 @@ function dkan_harvest_datajson_cache_pod_v1_1_json(array $data, HarvestSource $s
     foreach ($defaults as $path => $default_values) {
       $defaults_values = array_map('trim', $default_values);
       $defaulted = $defaulted || dkan_harvest_datajson_set_default_value($dataset, $path, $default_values[0]);
-    }
-
-    if ($defaulted) {
-      $harvest_cache->setCacheEntryDefaulted($identifier, $dataset['title']);
+      if ($defaulted) {
+        $harvest_cache->setCacheEntryDefaulted($identifier, $dataset['title']);
+      }
     }
 
     return $dataset;

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -342,6 +342,7 @@ function dkan_harvest_datajson_cache_pod_v1_1_json(array $data, HarvestSource $s
       $defaulted = $defaulted || dkan_harvest_datajson_set_default_value($dataset, $path, $default_values[0]);
       if ($defaulted) {
         $harvest_cache->setCacheEntryDefaulted($identifier, $dataset['title']);
+        $defaulted = FALSE;
       }
     }
 


### PR DESCRIPTION
Connects #2153 

## Description
When creating a harvest source, only the first override or default value is used, multiple value configurations are ignored.

## QA steps
- [x] Create a harvest source from the demo site http://demo.getdkan.com/.
- [x] Add two overrides: theme = something, publisher.name = Harvy
- [x] Add two defaults: author = test, describedBy: http://whatevs.com
- [x] Confirm you see a message for both override values.
- [x] Confirm you see a message for both default values.
- [x] Harvest and confirm the values are as expected.

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
