### PR TITLE
Apply workbench_moderation patch to fix access to revisions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.14
 --------
- - #2161 Fix access to revisions for anonymous users when dkan_workflow is enabled.
+ - #2174 Fix access to revisions for anonymous users when dkan_workflow is enabled.
  - #2075 DKAN Harvest: Modified batch process to split harvest migrations in chunks.
  - #2145 Front page hero image no longer requests empty URL if variable empty.
  - #2124 Add results count and increase results per page on the harvest dashboard view. 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14
 --------
+ - #2161 Fix access to revisions for anonymous users when dkan_workflow is enabled.
  - #2075 DKAN Harvest: Modified batch process to split harvest migrations in chunks.
  - #2145 Front page hero image no longer requests empty URL if variable empty.
  - #2124 Add results count and increase results per page on the harvest dashboard view. 

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -11,3 +11,5 @@ projects:
       1903010: 'https://www.drupal.org/files/issues/drupal-undefinedindex_fileupload-1903010-4.patch'
       # Warning: filesize(): stat failed
       628094: 'https://www.drupal.org/files/issues/file.remote-file_save.628094.22.patch'
+      # Fix PDOException when running user_role_grant_permissions() on module enable.
+      737816: 'https://www.drupal.org/files/drupal-permission-pdoexception-737816-41.patch'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -358,6 +358,7 @@ projects:
     version: '3.0'
     patch:
       2360973: https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch
+      1512442: https://www.drupal.org/files/issues/1512442-20-workbench_moderation-fix_access_check.patch
   drafty:
     version: 1.0-beta4
 libraries:

--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -37,8 +37,8 @@ function dkan_workflow_menu() {
   // Add dummy link so administrators can access My Workbench.
   $items['admin/myworkbench'] = array(
     'menu_name' => 'management',
-    'title' => t('My Workbench'),
-    'description' => t('My Workbench'),
+    'title' => 'My Workbench',
+    'description' => 'My Workbench',
     'page callback' => 'drupal_goto',
     'page arguments' => array('admin/workbench'),
     'access arguments' => array('access workbench'),
@@ -50,8 +50,8 @@ function dkan_workflow_menu() {
     'menu_name' => 'menu-command-center-menu',
     'link_path' => 'admin/workbench/drafts-active',
     'router_path' => 'admin/workbench/drafts-active',
-    'title' => t('My drafts'),
-    'description' => t('My drafts'),
+    'title' => 'My drafts',
+    'description' => 'My drafts',
     'page callback' => 'drupal_goto',
     'access arguments' => array('access workbench'),
     'weight' => 0,
@@ -61,8 +61,8 @@ function dkan_workflow_menu() {
     'menu_name' => 'menu-command-center-menu',
     'link_path' => 'admin/workbench/needs-review-active',
     'router_path' => 'admin/workbench/needs-review-active',
-    'title' => t('Needs review'),
-    'description' => t('Needs review'),
+    'title' => 'Needs review',
+    'description' => 'Needs review',
     'page callback' => 'drupal_goto',
     'access arguments' => array('access workbench'),
     'weight' => 1,
@@ -72,8 +72,8 @@ function dkan_workflow_menu() {
     'menu_name' => 'menu-command-center-menu',
     'link_path' => 'admin/workbench/drafts-stale',
     'router_path' => 'admin/workbench/drafts-stale',
-    'title' => t('Stale drafts'),
-    'description' => t('Stale drafts'),
+    'title' => 'Stale drafts',
+    'description' => 'Stale drafts',
     'page callback' => 'drupal_goto',
     'access arguments' => array('access workbench'),
     'weight' => 2,
@@ -83,8 +83,8 @@ function dkan_workflow_menu() {
     'menu_name' => 'menu-command-center-menu',
     'link_path' => 'admin/workbench/needs-review-stale',
     'router_path' => 'admin/workbench/needs-review-stale',
-    'title' => t('Stale reviews'),
-    'description' => t('Stale reviews'),
+    'title' => 'Stale reviews',
+    'description' => 'Stale reviews',
     'page callback' => 'drupal_goto',
     'access arguments' => array('access workbench'),
     'weight' => 3,
@@ -136,12 +136,29 @@ function dkan_workflow_menu_local_tasks_alter(&$data, $router_item, $root_path) 
         'title' => $stale_drafts,
       ),
     );
-    $stale_reviews  = $data['tabs'][0]['output'][4]['#link']['description'];
+    $stale_reviews = $data['tabs'][0]['output'][4]['#link']['description'];
     $data['tabs'][0]['output'][4]['#link']['localized_options'] = array(
       'attributes' => array(
         'title' => $stale_reviews,
       ),
     );
+  }
+  // Restore 'Revisions' tab for anonymous users when dkan_workflow is enabled.
+  global $user;
+  if (isset($data['tabs'][0]['output'][1]) &&
+    $data['tabs'][0]['output'][1]['#link']['page_callback'] == 'workbench_moderation_node_history_view' &&
+    $user->uid == 0) {
+    // Check if revisions exist.
+    $node = node_load(arg(1));
+    $r = count(node_revision_list($node));
+    if ($r > 1) {
+      // Change moderate button text to 'Revisions' if user is anonymous.
+      $data['tabs'][0]['output'][1]['#link']['title'] = 'Revisions';
+    }
+    else {
+      // Remove local tabs if there are no revisions.
+      unset($data['tabs']);
+    }
   }
 }
 
@@ -330,8 +347,8 @@ function dkan_workflow_views_pre_view(&$view, &$display_id, &$args) {
 
     $item = $view->set_item($display_id, 'filter', 'type', $filter_content_type);
 
-    $role_workflow_contributor  = user_role_load_by_name('Workflow Contributor');
-    $role_workflow_moderator  = user_role_load_by_name('Workflow Moderator');
+    $role_workflow_contributor = user_role_load_by_name('Workflow Contributor');
+    $role_workflow_moderator = user_role_load_by_name('Workflow Moderator');
 
     // On the Needs Review tab, Workflow Moderator can see:
     // - the content submitted to their organic group.

--- a/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
+++ b/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
@@ -17,6 +17,10 @@ function dkan_workflow_permissions_enable() {
   drupal_flush_all_caches();
   features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 
+  // Assign view moderation history perm to anonymous users.
+  $anon = user_role_load_by_name('anonymous user');
+  user_role_grant_permissions($anon->rid, array('view moderation history'));
+
   // Rebuild node access permissions as a batch process.
   node_access_rebuild(TRUE);
 }
@@ -95,6 +99,10 @@ function _dkan_workflow_permissions_setup_admin_menu_source() {
  * Implements hook_disable().
  */
 function dkan_workflow_permissions_disable() {
+  // Remove view moderation history perm from anonymous users.
+  $anon = user_role_load_by_name('anonymous user');
+  user_role_revoke_permissions($anon->rid, array('view moderation history'));
+
   // Rebuild node access permissions as a batch process.
   node_access_rebuild(TRUE);
 }

--- a/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
+++ b/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
@@ -18,6 +18,9 @@ function dkan_workflow_permissions_enable() {
   features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 
   // Assign view moderation history perm to anonymous users.
+  if (!module_exists('workbench_moderation')) {
+    module_enable(array('workbench_moderation'));
+  }
   $anon = user_role_load_by_name('anonymous user');
   user_role_grant_permissions($anon->rid, array('view moderation history'));
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -37,6 +37,7 @@ class WorkflowContext extends RawDKANContext {
       features_revert(array('dkan_feedback'));
     }
     drupal_flush_all_caches();
+    node_access_rebuild(TRUE);
   }
 
   /**
@@ -61,6 +62,7 @@ class WorkflowContext extends RawDKANContext {
     entity_delete_multiple('user', $users_to_delete);
     module_disable(array_values($modules_to_disable));
     drupal_flush_all_caches();
+    node_access_rebuild(TRUE);
   }
 
   /**

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -15,7 +15,6 @@ Feature:
       | My Edits           | /admin/workbench/content/edited      |
       | All Recent Content | /admin/workbench/content/all         |
       | Create User        | /admin/people/create                 |
-      | Datasets           | /search/type/dataset                 |
     Given Users:
       | name        | mail             | status | roles                                 |
       | Contributor | WC@fakeemail.com | 1      | Workflow Contributor, Content Creator |
@@ -32,10 +31,6 @@ Feature:
       | Moderator  | Group 01 | member               | Active            |
       | Contributor| Group 01 | member               | Active            |
       | Moderator  | Group 02 | member               | Active            |
-    And datasets:
-      | title                 | publisher | author    | published   | description |
-      | Dataset Revision Test | Group 01  | Moderator | Yes         | Test        |
-
 
   #Non workbench roles can see the menu item My Workflow. However
   #they can't access to the page.
@@ -503,16 +498,26 @@ Feature:
 
   @workflow_23 @javascript
   Scenario: As an anonymous user I should see a revisions link when dkan_workflow is enabled.
-    Given I am on the "Datasets" page
+    Given pages:
+      | name               | url                                  |
+      | Datasets           | /search/type/dataset                 |
+      | Rebuild perms      | /admin/reports/status/rebuild        |
+    And datasets:
+      | title                 | publisher | author    | published   | description |
+      | Dataset Revision Test | Group 01  | Moderator | Yes         | Test        |
+    When I am on the "Datasets" page
     And I click "Dataset Revision Test"
     Then I should not see "Revisions"
-    Given I am logged in as "Supervisor"
+    Given I am logged in as a user with the "administrator" role
     And I am on the "Dataset Revision Test" page
     When I click "New draft"
     And I fill in "edit-title" with "Dataset Revision Test NEW"
     And I click "Publishing options"
     Then I select "Published" from "edit-workbench-moderation-state-new"
     And I press "Finish"
+    Given I am on the "Rebuild perms" page
+    And I press "Rebuild permissions"
+    And I wait for "Status report"
     And I click "Log out"
     And I am on the "Datasets" page
     And I click "Dataset Revision Test"

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -503,6 +503,9 @@ Feature:
 
   @workflow_23 @javascript
   Scenario: As an anonymous user I should see a revisions link when dkan_workflow is enabled.
+    Given I am on the "Datasets" page
+    And I click "Dataset Revision Test"
+    Then I should not see "Revisions"
     Given I am logged in as "Supervisor"
     And I am on the "Dataset Revision Test" page
     When I click "New draft"

--- a/test/features/workflow.feature
+++ b/test/features/workflow.feature
@@ -15,6 +15,7 @@ Feature:
       | My Edits           | /admin/workbench/content/edited      |
       | All Recent Content | /admin/workbench/content/all         |
       | Create User        | /admin/people/create                 |
+      | Datasets           | /search/type/dataset                 |
     Given Users:
       | name        | mail             | status | roles                                 |
       | Contributor | WC@fakeemail.com | 1      | Workflow Contributor, Content Creator |
@@ -29,8 +30,11 @@ Feature:
       | user       | group    | role on group        | membership status |
       | Supervisor | Group 01 | administrator member | Active            |
       | Moderator  | Group 01 | member               | Active            |
-      | Contributor| Group 01 | member               | Active           |
+      | Contributor| Group 01 | member               | Active            |
       | Moderator  | Group 02 | member               | Active            |
+    And datasets:
+      | title                 | publisher | author    | published   | description |
+      | Dataset Revision Test | Group 01  | Moderator | Yes         | Test        |
 
 
   #Non workbench roles can see the menu item My Workflow. However
@@ -496,3 +500,17 @@ Feature:
     Given I am logged in as "Contributor"
     When I am on the "My Drafts" page
     Then I should see "My Draft Dataset"
+
+  @workflow_23 @javascript
+  Scenario: As an anonymous user I should see a revisions link when dkan_workflow is enabled.
+    Given I am logged in as "Supervisor"
+    And I am on the "Dataset Revision Test" page
+    When I click "New draft"
+    And I fill in "edit-title" with "Dataset Revision Test NEW"
+    And I click "Publishing options"
+    Then I select "Published" from "edit-workbench-moderation-state-new"
+    And I press "Finish"
+    And I click "Log out"
+    And I am on the "Datasets" page
+    And I click "Dataset Revision Test"
+    Then I should see "Revisions"

--- a/themes/nuboot_radix/includes/menu.inc
+++ b/themes/nuboot_radix/includes/menu.inc
@@ -86,6 +86,7 @@ function nuboot_radix_menu_local_task($variables) {
         break;
 
       case 'node/%/revisions':
+      case 'node/%/moderation':
         $icon_type = 'folder-open-o';
         break;
 


### PR DESCRIPTION
Connects #2147 

## QA Steps
- [x] Enable dkan_workflow & dkan_workflow_permissions
- [x] As anonymous user, visit a dataset with no revisions, confirm you do not see 'View published' or 'Revisions' tabs
- [x] Log in as admin or sitemanager, create a new revision of the dataset and publish. Log out.
- [x] Visit the dataset again and confirm you see 'View published' and 'Revisions' tabs

## Reminders
- [x] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.